### PR TITLE
feat: add strict composite dashboard compiler mode

### DIFF
--- a/.github/workflows/compiler-tests.yml
+++ b/.github/workflows/compiler-tests.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - feature/dashboard-compiler-mvp
+      - feature/composite-mode-compiler
   pull_request:
     paths:
       - 'skills/decision-first-dashboard/**'

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ verified facts
       ↓
 decision-state JSON
       ↓
-schema validation
+schema + semantic validation
       ↓
 deterministic renderer
       ↓
@@ -34,20 +34,28 @@ Table
 
 The user still has to scan everything and construct the conclusion mentally.
 
-Decision-First Dashboard changes the information hierarchy first. For executive no-score cases, the rendered structure is deliberately constrained:
+Decision-First Dashboard changes the information hierarchy first. The LLM extracts evidence; the compiler validates the evidence mode and owns the layout.
+
+## Two strict evidence modes
+
+The compiler supports two mutually exclusive modes.
+
+### 1. `no_score`
+
+Use this when the source does not provide a defensible composite model.
+
+For executive no-score cases, the rendered structure is deliberately constrained:
 
 ```text
 WHY / CONTEXT  →  DOMINANT SYNTHESIS  ←  WHO / EVENTS
 ```
 
-The LLM extracts evidence. The renderer controls the layout.
-
-## Before → deterministic no-score output
+The output does **not** invent a Health Score. Overall direction is derived deterministically from source-supported signal directions.
 
 <table>
   <tr>
     <th width="50%">Before</th>
-    <th width="50%">Compiler output</th>
+    <th width="50%">Deterministic no-score output</th>
   </tr>
   <tr>
     <td width="50%"><img src="examples/saas/before.png" width="100%"></td>
@@ -55,15 +63,27 @@ The LLM extracts evidence. The renderer controls the layout.
   </tr>
 </table>
 
-The no-score output does **not** invent a Health Score. Its overall direction is derived deterministically from the source-supported signal directions.
+### 2. `composite`
 
-## Composite reference
+Use this only when the source already provides a complete, defensible score model.
 
-When a real score model exists, a dominant composite can be appropriate. The repository also includes a composite visual reference:
+Composite v1 requires all of the following:
+
+- an overall score and score scale;
+- source-provided normalized component scores;
+- source-provided component weights;
+- a weighted-average aggregation rule;
+- complete source-provided score bands / thresholds.
+
+The validator checks that weights sum to 1, the displayed score matches the weighted average, component scores stay inside the declared scale, score bands are contiguous and cover the full scale, and the displayed band matches the score.
+
+If any required model fact is missing, the correct fallback is `no_score` — not an inferred formula, guessed weight, or fabricated threshold.
+
+The existing `examples/saas/after.png` remains a visual reference for a dominant score composition. It is **not** treated as proof that the canonical SaaS source fixture contains a real composite model.
 
 <img src="examples/saas/after.png" width="760">
 
-A composite is valid only when normalization, weights, thresholds, and status rules are defensible. The current compiler MVP implements the deterministic **no-score executive** branch; it will not fabricate a score just to imitate the composite reference.
+The repository's composite JSON fixture lives under `tests/compiler/fixtures/` and is synthetic contract data used only for automated validation and rendering tests.
 
 ## Install
 
@@ -82,10 +102,11 @@ Give the agent a dashboard screenshot, Figma frame, existing dashboard code, or 
 The intended execution path is:
 
 1. Extract verified facts only.
-2. Build `decision-state.json` matching the bundled schema.
-3. Validate it.
-4. Render SVG and HTML from the same JSON.
-5. Inspect the output for evidence and visual integrity.
+2. Decide whether the evidence supports `no_score` or strict `composite` mode.
+3. Build `decision-state.json` matching the bundled closed schema.
+4. Validate schema and mode-specific semantics.
+5. Render SVG and HTML from the same JSON.
+6. Inspect the output for evidence and visual integrity.
 
 From the skill directory:
 
@@ -94,52 +115,84 @@ node scripts/validate.js path/to/decision-state.json
 node scripts/render.js path/to/decision-state.json path/to/output-directory
 ```
 
+The renderer writes mode-specific filenames:
+
+```text
+no_score   → output.no-score.svg / output.no-score.html
+composite  → output.composite.svg / output.composite.html
+```
+
 ## Anti-hallucination contract
 
-The no-score schema intentionally makes common dashboard hallucinations structurally invalid.
+The schema is closed with mutually exclusive `no_score` and `composite` states.
 
-It rejects unsupported fields such as:
+### No-score safeguards
+
+The no-score branch rejects unsupported fields such as:
 
 - invented `score` / health score;
 - caller-supplied overall direction;
 - invented target or goal fields;
 - renewal/workflow/action/assignee fields;
-- derived account exceptions or events presented as source facts.
+- derived account exceptions or events presented as source facts;
+- composite model fields.
 
 Numeric trend series are optional. If exact source-supported points are unavailable, the renderer says `Trend data unavailable` instead of drawing a plausible-looking line.
 
-## Overall direction is derived
+### Composite safeguards
 
-The agent does not provide `IMPROVING`, `MIXED`, or `DETERIORATING` as a top-level verdict.
+The composite branch accepts only source-supported score-model facts. It rejects, among other cases:
 
-The renderer derives it from the validated signal directions:
+- missing component weights;
+- weights that do not sum to 1;
+- a score that does not equal the weighted average;
+- component scores outside the declared score scale;
+- score-band gaps or overlaps;
+- a displayed status that does not match the source thresholds;
+- unsupported normalization or aggregation methods.
+
+Composite validation failure is never repaired by inventing the missing model.
+
+## Direction is not health
+
+In `no_score`, the agent does not provide `IMPROVING`, `MIXED`, or `DETERIORATING` as a top-level verdict. The renderer derives it from validated signal directions:
 
 ```text
-all improving          → IMPROVING
+all improving             → IMPROVING
 improving + deteriorating → MIXED
-all deteriorating      → DETERIORATING
-flat only              → FLAT
-no known direction     → UNKNOWN
+all deteriorating         → DETERIORATING
+flat only                 → FLAT
+no known direction        → UNKNOWN
 ```
-
-This keeps directional synthesis separate from health status.
 
 > `Improving` does not mean `Healthy`.
 
-If targets or healthy ranges are unknown, the UI says `Target unknown` rather than inventing adequacy.
+If targets or healthy ranges are unknown, the no-score UI says `Target unknown` rather than inventing adequacy.
 
 ## Deterministic visual contract
 
-The bundled no-score renderers enforce:
+Both rendering branches use fixed templates and the same shared visual system.
 
-- one dominant center synthesis area;
+### No-score composition
+
+- one dominant center directional synthesis area;
 - 3–6 signals converging on the center;
 - compact left business context;
-- compact right account exceptions and events;
+- compact right account exceptions and events.
+
+### Composite composition
+
+- one dominant center source-supported score and band;
+- 3–6 weighted score components converging on the center;
+- compact left score trend and score composition;
+- compact right account exceptions and events.
+
+### Shared constraints
+
 - no four-equal-KPI top row;
-- no full-width customer table;
+- no dominant full-width customer table;
 - no invented action buttons;
-- no framework labels in the UI;
+- no compiler/framework labels in visible UI;
 - restrained SaaS visual styling.
 
 SVG is the compatibility baseline. HTML/CSS is the higher-fidelity output. Both consume the same validated JSON.
@@ -170,15 +223,23 @@ decision-first-dashboard/
 │       ├── templates/
 │       │   ├── no-score.svg
 │       │   ├── no-score.html
+│       │   ├── composite.svg
+│       │   ├── composite.html
 │       │   └── dashboard.css
 │       └── references/
 │           ├── visual-pattern.md
 │           └── after-reference.png
 └── tests/
     ├── compiler/
+    │   ├── fixtures/
+    │   │   └── composite.valid.json
     │   ├── schema.test.js
+    │   ├── composite-schema.test.js
     │   ├── render-svg.test.js
-    │   └── render-html.test.js
+    │   ├── render-html.test.js
+    │   ├── render-composite-svg.test.js
+    │   ├── render-composite-html.test.js
+    │   └── render-cli.test.js
     ├── saas.md
     ├── saas-no-score.md
     ├── visual-output.md
@@ -195,7 +256,7 @@ npm run validate:saas
 npm run render:saas
 ```
 
-GitHub Actions runs the compiler tests, validates the canonical SaaS fixture, renders both outputs, and uploads the generated artifacts for visual QA.
+GitHub Actions runs the complete compiler test suite, validates the canonical SaaS no-score fixture, renders its SVG/HTML outputs, and uploads those generated artifacts for visual QA.
 
 ## What this is not
 
@@ -203,8 +264,8 @@ This is not a generic chart library and not a prompt that asks the model to free
 
 The project separates two responsibilities:
 
-- **Agent:** evidence extraction and decision classification.
-- **Compiler:** validation, synthesis, and visual composition.
+- **Agent:** evidence extraction and mode classification.
+- **Compiler:** contract validation, deterministic synthesis, and visual composition.
 
 That separation is what makes the output repeatable across agents.
 

--- a/docs/superpowers/plans/2026-09-03-composite-mode-compiler.md
+++ b/docs/superpowers/plans/2026-09-03-composite-mode-compiler.md
@@ -1,0 +1,111 @@
+# Composite Mode Compiler Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a strict, deterministic composite-score branch to the existing Decision-First Dashboard compiler while preserving all no-score anti-hallucination guarantees.
+
+**Architecture:** Extend the closed decision-state schema to two mutually exclusive modes, teach the lightweight validator `oneOf` plus composite semantic checks, and dispatch the existing renderer API to fixed composite SVG/HTML templates. Composite v1 accepts only source-provided normalized component scores, source weights, weighted-average aggregation, and complete score-band thresholds.
+
+**Tech Stack:** Node.js 22 in CI, vanilla JavaScript, JSON Schema Draft-07 subset, Node built-in `node:test`, deterministic SVG, vanilla HTML/CSS.
+
+**Spec:** `docs/superpowers/specs/2026-09-03-composite-mode-design.md`
+
+## Global Constraints
+
+- Never infer or invent normalization, weights, thresholds, bands, score values, account states, events, actions, or causal claims.
+- Composite v1 supports only `normalization: "source_provided"` and `aggregation: "weighted_average"`.
+- Existing no-score payloads must remain valid and must continue to physically reject `score` / `model` fields.
+- Existing `renderSvg(data)` and `renderHtml(data)` public APIs remain unchanged.
+- No-score rendering behavior must remain unchanged.
+- No compiler/framework methodology labels may appear in rendered UI.
+
+---
+
+### Task 1: Establish RED composite contract tests and CI coverage
+
+**Files:**
+- Create: `tests/compiler/composite-schema.test.js`
+- Create: `tests/compiler/fixtures/composite.valid.json`
+- Modify: `.github/workflows/compiler-tests.yml`
+
+**Interfaces:**
+- Fixture provides the canonical synthetic contract input used only by automated tests.
+- Tests consume `validateDecisionState(data)`.
+
+- [ ] **Step 1: Add `feature/composite-mode-compiler` to the workflow push branches.**
+- [ ] **Step 2: Add a valid composite fixture with score 68/100, three components whose weighted average is 68, and contiguous bands 0–70 / 70–85 / 85–100.**
+- [ ] **Step 3: Add failing tests asserting a valid composite payload is accepted and malformed composite payloads are rejected: missing weight, weights != 1, weighted-score mismatch, band mismatch, band gap, component outside score scale.**
+- [ ] **Step 4: Push and confirm GitHub Actions fails for the expected reason: the current schema accepts only `mode: "no_score"`.**
+
+---
+
+### Task 2: Implement the composite schema and semantic validator
+
+**Files:**
+- Modify: `skills/decision-first-dashboard/schemas/decision-state.schema.json`
+- Modify: `skills/decision-first-dashboard/scripts/validate.js`
+- Test: `tests/compiler/schema.test.js`
+- Test: `tests/compiler/composite-schema.test.js`
+
+**Interfaces:**
+- Root schema becomes `oneOf` between `noScoreState` and `compositeState`.
+- `validateDecisionState(data)` retains `{ valid, errors }`.
+
+- [ ] **Step 1: Extend the lightweight schema walker to evaluate `oneOf` branches without leaking branch-local errors when exactly one branch validates.**
+- [ ] **Step 2: Refactor the existing no-score object into `definitions.noScoreState` without loosening any current property constraints.**
+- [ ] **Step 3: Add `definitions.compositeState`, `score`, `scoreModel`, `scoreComponent`, `scoreBand`, and `scoreContext` definitions. All objects use `additionalProperties: false`.**
+- [ ] **Step 4: Add semantic validation after schema validation for composite mode: score scale, component ranges, positive weights, weight sum tolerance `1e-6`, weighted-score tolerance `0.01`, contiguous bands, band selection, and band-label match.**
+- [ ] **Step 5: Run the full compiler suite and confirm schema/composite tests pass while all existing no-score tests remain green.**
+
+---
+
+### Task 3: Establish RED composite renderer tests
+
+**Files:**
+- Create: `tests/compiler/render-composite-svg.test.js`
+- Create: `tests/compiler/render-composite-html.test.js`
+
+**Interfaces:**
+- Tests consume existing `renderSvg(data)` / `renderHtml(data)` APIs.
+
+- [ ] **Step 1: Add SVG tests requiring score label/value/band, all component labels/scores/weights, score trend, exceptions/events, no unresolved template tokens, and no methodology labels.**
+- [ ] **Step 2: Add equivalent HTML tests plus a structural assertion that the output uses the dominant center composition rather than KPI cards.**
+- [ ] **Step 3: Push and confirm tests fail because the renderer still loads no-score templates for composite data.**
+
+---
+
+### Task 4: Implement fixed composite templates and mode dispatch
+
+**Files:**
+- Create: `skills/decision-first-dashboard/templates/composite.svg`
+- Create: `skills/decision-first-dashboard/templates/composite.html`
+- Modify: `skills/decision-first-dashboard/templates/dashboard.css`
+- Modify: `skills/decision-first-dashboard/scripts/render.js`
+
+**Interfaces:**
+- `renderSvg(data)` dispatches by validated `data.mode`.
+- `renderHtml(data)` dispatches by validated `data.mode`.
+
+- [ ] **Step 1: Add deterministic composite SVG geometry: compact left score context, dominant center score, compact right exceptions/events.**
+- [ ] **Step 2: Add deterministic composite HTML shell with equivalent hierarchy and reuse shared CSS tokens.**
+- [ ] **Step 3: Add renderer helpers for score-series path, weighted component cluster placement for 3–6 components, composition rows, and score display.**
+- [ ] **Step 4: Keep no-score helper paths untouched where possible; dispatch to composite templates only for `mode === "composite"`.**
+- [ ] **Step 5: Run the full test suite and confirm both composite renderer suites and all existing no-score suites pass.**
+
+---
+
+### Task 5: CLI naming, skill instructions, and final verification
+
+**Files:**
+- Modify: `skills/decision-first-dashboard/scripts/render.js`
+- Modify: `skills/decision-first-dashboard/SKILL.md`
+- Modify: `README.md`
+
+**Interfaces:**
+- CLI writes `output.composite.svg` / `output.composite.html` for composite input and preserves `output.no-score.*` for no-score input.
+
+- [ ] **Step 1: Add a regression test for mode-specific CLI output basenames if needed by renderer tests.**
+- [ ] **Step 2: Update `SKILL.md` with exact composite eligibility rules and the fallback-to-no-score rule.**
+- [ ] **Step 3: Update README compiler documentation without presenting synthetic test values as real product data.**
+- [ ] **Step 4: Run GitHub Actions on the feature branch. Verify `npm test`, `npm run validate:saas`, and `npm run render:saas` all succeed.**
+- [ ] **Step 5: Compare the feature branch with `main`, review changed files against the spec, and leave the feature branch ready for merge.**

--- a/docs/superpowers/specs/2026-09-03-composite-mode-design.md
+++ b/docs/superpowers/specs/2026-09-03-composite-mode-design.md
@@ -1,0 +1,205 @@
+# Decision-First Dashboard Composite Mode Design
+
+## Purpose
+
+Add the deferred composite branch to the existing deterministic dashboard compiler without weakening the no-score anti-hallucination guarantees.
+
+## Scope
+
+Composite v1 is intentionally narrow. It is valid only when the source explicitly provides:
+
+- an overall composite score and scale;
+- source-provided normalized component scores;
+- source-provided component weights;
+- a weighted-average aggregation rule;
+- complete source-provided score bands / thresholds.
+
+If any of these are unavailable, the agent must use `no_score` instead.
+
+Composite v1 does not derive normalization rules from raw metrics, does not infer weights, and does not invent score bands.
+
+## Contract
+
+A composite decision state has this shape:
+
+```json
+{
+  "mode": "composite",
+  "score": {
+    "label": "Subscription health",
+    "value": 68,
+    "min": 0,
+    "max": 100,
+    "band": "At risk",
+    "provenance": "source"
+  },
+  "model": {
+    "normalization": "source_provided",
+    "aggregation": "weighted_average",
+    "provenance": "source",
+    "components": [
+      {
+        "metric": "retention",
+        "label": "Retention",
+        "value": "96.8%",
+        "normalizedScore": 60,
+        "weight": 0.4,
+        "provenance": "source"
+      },
+      {
+        "metric": "growth",
+        "label": "Growth",
+        "value": "+12.4%",
+        "normalizedScore": 80,
+        "weight": 0.3,
+        "provenance": "source"
+      },
+      {
+        "metric": "conversion",
+        "label": "Conversion",
+        "value": "31.7%",
+        "normalizedScore": 66.6667,
+        "weight": 0.3,
+        "provenance": "source"
+      }
+    ],
+    "bands": [
+      { "label": "At risk", "min": 0, "max": 70, "provenance": "source" },
+      { "label": "Watch", "min": 70, "max": 85, "provenance": "source" },
+      { "label": "Healthy", "min": 85, "max": 100, "provenance": "source" }
+    ]
+  },
+  "context": {
+    "scoreSeries": [61, 63, 64, 66, 67, 68],
+    "provenance": "source"
+  },
+  "exceptions": [],
+  "events": []
+}
+```
+
+The existing source-only exception/event structures remain reusable.
+
+## Schema rules
+
+The root schema becomes a closed `oneOf` contract with two mutually exclusive states:
+
+- `noScoreState` — existing behavior, physically rejects `score` and `model`;
+- `compositeState` — requires `score` and `model` and does not accept no-score-only synthesis fields.
+
+Composite v1 requires 3–6 model components and 2–8 score bands.
+
+All source-visible or model-defining facts carry `provenance: "source"` in composite v1. Derived normalization is deferred.
+
+## Semantic validation
+
+Schema validation remains closed with `additionalProperties: false`. Composite mode adds semantic checks that JSON Schema alone does not express cleanly in the current lightweight validator:
+
+1. `score.min < score.max` and `score.value` lies within the scale.
+2. Every component `normalizedScore` lies within the same scale.
+3. Every weight is greater than 0 and no greater than 1.
+4. Component weights sum to 1 within `1e-6`.
+5. `score.value` equals the weighted average of component normalized scores within `0.01`.
+6. Bands are ordered by `min`, contiguous, gap-free, non-overlapping, cover the full score scale, and each has `min < max`.
+7. Score-band selection is half-open `[min,max)` except the final band, which includes `max`.
+8. `score.band` must equal the band selected by the score value.
+9. Composite v1 rejects non-weighted aggregation and non-source-provided normalization.
+
+Validation failure never triggers automatic score-model repair. The caller must provide source-supported model facts or use `no_score`.
+
+## Rendering
+
+The renderer continues to own page layout. Composite mode uses fixed `composite.svg` and `composite.html` templates plus the shared visual tokens in `dashboard.css`.
+
+Executive composition:
+
+```text
+compact score context | dominant composite score | compact exceptions/events
+```
+
+### Center
+
+- source score label;
+- dominant score value and scale;
+- source band;
+- 3–6 weighted component nodes converging on the score;
+- each component shows normalized score and weight;
+- no compiler/framework labels.
+
+### Left
+
+- `Score trend` when a source-supported `scoreSeries` is present;
+- compact `Score composition` list showing component label, normalized score, and weight.
+
+### Right
+
+- source-supported `Accounts to watch`;
+- source-supported `Recent events`.
+
+The center remains the first focal point. The composite renderer must not expose controls that permit KPI-card strips, dominant tables, arbitrary charts, or arbitrary layout changes.
+
+## Product-native copy
+
+Allowed renderer-owned labels include:
+
+- Score trend
+- Score composition
+- Accounts to watch
+- Recent events
+
+Forbidden rendered labels include:
+
+- Composite mode
+- Weighted average
+- Aggregation
+- Normalization
+- Decision
+- Driver
+- Diagnostic
+- Framework
+- Compiler
+
+## Rendering API
+
+The existing public functions remain unchanged:
+
+```js
+export function renderSvg(data) { return string; }
+export function renderHtml(data) { return string; }
+```
+
+They dispatch by validated `data.mode`.
+
+## Compatibility
+
+Existing no-score fixtures and outputs must remain byte-for-byte stable unless a change is explicitly required by a regression fix.
+
+Existing CLI behavior remains:
+
+```bash
+node scripts/validate.js <decision-state.json>
+node scripts/render.js <decision-state.json> <output-dir>
+```
+
+The renderer writes filenames by mode:
+
+- `output.no-score.svg` / `output.no-score.html`;
+- `output.composite.svg` / `output.composite.html`.
+
+## Testing
+
+Add regression tests for:
+
+- valid composite payload;
+- missing weights or thresholds;
+- weights not summing to 1;
+- weighted score mismatch;
+- band mismatch, gaps, and overlaps;
+- component scores outside the scale;
+- no-score payload still rejecting score/model fields;
+- deterministic SVG composite rendering;
+- deterministic HTML composite rendering;
+- absence of methodology/compiler labels in both renderers;
+- unchanged no-score tests.
+
+GitHub Actions must run the full compiler suite on `main`, `feature/dashboard-compiler-mvp`, and `feature/composite-mode-compiler`.

--- a/skills/decision-first-dashboard/SKILL.md
+++ b/skills/decision-first-dashboard/SKILL.md
@@ -23,23 +23,55 @@ Never invent scores, targets, thresholds, customer states, events, workflows, ac
 
 ### 2. Choose the evidence mode
 
-Use a composite only when normalization, weights, thresholds, and status rules are already defensible from the source.
+The compiler supports two mutually exclusive modes.
 
-Otherwise use `no_score`. For no-score executive dashboards, do not create `Healthy`, `Marginal`, `At risk`, or a 0–100 score. The compiler derives overall direction from the individual signal directions.
+Use `composite` only when the source already provides **all** of the following:
+
+- an overall score and score scale;
+- normalized component scores;
+- component weights;
+- a weighted-average aggregation rule;
+- complete score bands / thresholds that determine the displayed status.
+
+Composite v1 accepts only:
+
+- `normalization: "source_provided"`;
+- `aggregation: "weighted_average"`;
+- source-provided score, component, weight, band, exception, event, and trend facts.
+
+Do not infer normalization formulas, weights, thresholds, or bands. If any required composite-model fact is missing or cannot be defended from the source, use `no_score` instead.
+
+For `no_score` executive dashboards, do not create `Healthy`, `Marginal`, `At risk`, or a 0–100 score. The compiler derives overall direction from the individual signal directions.
 
 ### 3. Build the contract, not the layout
 
-For `no_score`, create JSON that matches:
+Create JSON that matches:
 
 `schemas/decision-state.schema.json`
 
-Important constraints:
+The root contract is closed and accepts exactly one of `no_score` or `composite`.
+
+For `no_score`:
 
 - do not supply an overall `direction` field;
 - 3–6 signals carry value, delta, direction, and provenance;
 - numeric context series are optional and require `provenance: "source"`;
 - visible account exceptions and events require source provenance;
+- score/model fields are structurally invalid;
 - unsupported keys fail validation.
+
+For `composite`:
+
+- `score` must include source label, value, min, max, band, and provenance;
+- `model.components` contains 3–6 source-provided normalized scores and weights;
+- component weights must sum to 1;
+- the score must equal the weighted average of normalized component scores within compiler tolerance;
+- source-provided bands must be contiguous, non-overlapping, and cover the full score scale;
+- the displayed band must match the band selected by the score value;
+- optional score trend data requires source provenance;
+- unsupported normalization or aggregation methods fail validation.
+
+Validation failure is never repaired by inventing missing score-model facts. Fall back to `no_score` or request the missing source evidence.
 
 ### 4. Validate before rendering
 
@@ -53,42 +85,62 @@ Do not render invalid JSON. Fix the evidence payload instead of weakening the sc
 
 ### 5. Render deterministically
 
-For the supported no-score executive mode:
+For either supported mode:
 
 ```bash
 node scripts/render.js <decision-state.json> <output-dir>
 ```
 
-This produces deterministic SVG and HTML/CSS from the same JSON. Do not rewrite the templates, add KPI grids, tables, banners, buttons, or extra business copy unless the user explicitly asks to change the design system itself.
+The CLI writes mode-specific outputs:
+
+- `no_score` → `output.no-score.svg` and `output.no-score.html`;
+- `composite` → `output.composite.svg` and `output.composite.html`.
+
+Both SVG and HTML/CSS consume the same validated JSON. Do not rewrite the templates, add KPI grids, tables, banners, buttons, or extra business copy unless the user explicitly asks to change the design system itself.
 
 If execution is unavailable, preserve the same contract: populate the schema and use the supplied template structure literally. Do not fall back to free-form image generation. If the template cannot be rendered, return the validated/self-checked JSON rather than inventing a different dashboard.
 
 ## Visual contract
 
-The no-score renderer owns the layout:
+The renderer owns the layout.
 
-- dominant center synthesis;
+For `no_score`:
+
+- dominant center directional synthesis;
 - 3–6 signals converging on the center;
 - compact left business context;
-- compact right exceptions/events;
+- compact right exceptions/events.
+
+For `composite`:
+
+- dominant center source-supported score and band;
+- 3–6 weighted score components converging on the center;
+- compact left score trend and score composition;
+- compact right exceptions/events.
+
+For both modes:
+
 - no four-card KPI strip;
 - no dominant full-width customer table;
+- no invented action controls;
 - product-native labels only;
+- no compiler/framework methodology labels in visible UI;
 - restrained color and generous whitespace.
 
 See `references/visual-pattern.md`.
 
 ## Hard stops
 
-Safety, compliance, security, regulatory, contractual, or outage conditions override ordinary synthesis. Never average them into a reassuring status. Do not force a hard-stop case through the current SaaS no-score renderer.
+Safety, compliance, security, regulatory, contractual, or outage conditions override ordinary synthesis. Never average them into a reassuring status. Do not force a hard-stop case through the current SaaS renderers.
 
 ## Final gate
 
 Before delivery, verify:
 
 - every displayed fact traces to source data or a deterministic derivation allowed by the contract;
-- overall direction matches the signal directions;
+- `no_score` overall direction matches the signal directions;
+- `composite` weights, weighted score, score scale, and score band pass semantic validation;
 - no unsupported score/status/target/action appears;
-- no framework labels leak into the UI;
+- no framework or compiler labels leak into visible UI;
 - the center is the first focal point;
 - outputs contain no unresolved template tokens.

--- a/skills/decision-first-dashboard/schemas/decision-state.schema.json
+++ b/skills/decision-first-dashboard/schemas/decision-state.schema.json
@@ -1,29 +1,56 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "type": "object",
-  "additionalProperties": false,
-  "required": ["mode", "signals"],
-  "properties": {
-    "mode": { "const": "no_score" },
-    "signals": {
-      "type": "array",
-      "minItems": 3,
-      "maxItems": 6,
-      "items": { "$ref": "#/definitions/signal" }
-    },
-    "context": { "$ref": "#/definitions/context" },
-    "exceptions": {
-      "type": "array",
-      "maxItems": 5,
-      "items": { "$ref": "#/definitions/exception" }
-    },
-    "events": {
-      "type": "array",
-      "maxItems": 5,
-      "items": { "$ref": "#/definitions/event" }
-    }
-  },
+  "oneOf": [
+    { "$ref": "#/definitions/noScoreState" },
+    { "$ref": "#/definitions/compositeState" }
+  ],
   "definitions": {
+    "noScoreState": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["mode", "signals"],
+      "properties": {
+        "mode": { "const": "no_score" },
+        "signals": {
+          "type": "array",
+          "minItems": 3,
+          "maxItems": 6,
+          "items": { "$ref": "#/definitions/signal" }
+        },
+        "context": { "$ref": "#/definitions/noScoreContext" },
+        "exceptions": {
+          "type": "array",
+          "maxItems": 5,
+          "items": { "$ref": "#/definitions/exception" }
+        },
+        "events": {
+          "type": "array",
+          "maxItems": 5,
+          "items": { "$ref": "#/definitions/event" }
+        }
+      }
+    },
+    "compositeState": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["mode", "score", "model"],
+      "properties": {
+        "mode": { "const": "composite" },
+        "score": { "$ref": "#/definitions/score" },
+        "model": { "$ref": "#/definitions/scoreModel" },
+        "context": { "$ref": "#/definitions/scoreContext" },
+        "exceptions": {
+          "type": "array",
+          "maxItems": 5,
+          "items": { "$ref": "#/definitions/exception" }
+        },
+        "events": {
+          "type": "array",
+          "maxItems": 5,
+          "items": { "$ref": "#/definitions/event" }
+        }
+      }
+    },
     "signal": {
       "type": "object",
       "additionalProperties": false,
@@ -37,7 +64,7 @@
         "provenance": { "enum": ["source", "derived"] }
       }
     },
-    "context": {
+    "noScoreContext": {
       "type": "object",
       "additionalProperties": false,
       "required": ["revenueSeries", "provenance"],
@@ -47,6 +74,79 @@
           "minItems": 2,
           "maxItems": 24,
           "items": { "type": "number", "minimum": 0 }
+        },
+        "provenance": { "const": "source" }
+      }
+    },
+    "score": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["label", "value", "min", "max", "band", "provenance"],
+      "properties": {
+        "label": { "type": "string", "minLength": 1, "maxLength": 40 },
+        "value": { "type": "number" },
+        "min": { "type": "number" },
+        "max": { "type": "number" },
+        "band": { "type": "string", "minLength": 1, "maxLength": 32 },
+        "provenance": { "const": "source" }
+      }
+    },
+    "scoreModel": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["normalization", "aggregation", "provenance", "components", "bands"],
+      "properties": {
+        "normalization": { "const": "source_provided" },
+        "aggregation": { "const": "weighted_average" },
+        "provenance": { "const": "source" },
+        "components": {
+          "type": "array",
+          "minItems": 3,
+          "maxItems": 6,
+          "items": { "$ref": "#/definitions/scoreComponent" }
+        },
+        "bands": {
+          "type": "array",
+          "minItems": 2,
+          "maxItems": 8,
+          "items": { "$ref": "#/definitions/scoreBand" }
+        }
+      }
+    },
+    "scoreComponent": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["metric", "label", "value", "normalizedScore", "weight", "provenance"],
+      "properties": {
+        "metric": { "type": "string", "pattern": "^[a-z0-9_]{1,40}$" },
+        "label": { "type": "string", "minLength": 1, "maxLength": 24 },
+        "value": { "type": "string", "minLength": 1, "maxLength": 24 },
+        "normalizedScore": { "type": "number" },
+        "weight": { "type": "number", "minimum": 0, "maximum": 1 },
+        "provenance": { "const": "source" }
+      }
+    },
+    "scoreBand": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["label", "min", "max", "provenance"],
+      "properties": {
+        "label": { "type": "string", "minLength": 1, "maxLength": 32 },
+        "min": { "type": "number" },
+        "max": { "type": "number" },
+        "provenance": { "const": "source" }
+      }
+    },
+    "scoreContext": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["scoreSeries", "provenance"],
+      "properties": {
+        "scoreSeries": {
+          "type": "array",
+          "minItems": 2,
+          "maxItems": 24,
+          "items": { "type": "number" }
         },
         "provenance": { "const": "source" }
       }

--- a/skills/decision-first-dashboard/scripts/render.js
+++ b/skills/decision-first-dashboard/scripts/render.js
@@ -5,8 +5,10 @@ import { validateDecisionState } from './validate.js';
 
 const currentFile = fileURLToPath(import.meta.url);
 const currentDir = path.dirname(currentFile);
-const svgTemplatePath = path.resolve(currentDir, '../templates/no-score.svg');
-const htmlTemplatePath = path.resolve(currentDir, '../templates/no-score.html');
+const noScoreSvgTemplatePath = path.resolve(currentDir, '../templates/no-score.svg');
+const noScoreHtmlTemplatePath = path.resolve(currentDir, '../templates/no-score.html');
+const compositeSvgTemplatePath = path.resolve(currentDir, '../templates/composite.svg');
+const compositeHtmlTemplatePath = path.resolve(currentDir, '../templates/composite.html');
 const cssTemplatePath = path.resolve(currentDir, '../templates/dashboard.css');
 
 function assertValid(data) {
@@ -90,6 +92,22 @@ function htmlRevenueVisual(series) {
   return `<svg class="sparkline" viewBox="0 0 234 86" aria-label="Revenue trend"><path d="${path}"></path></svg>`;
 }
 
+function svgScoreVisual(series) {
+  if (!series?.length) {
+    return '<text x="98" y="330" class="muted" font-size="12">Trend data unavailable</text>';
+  }
+  const path = pathForSeries(series, { left: 98, right: 332, top: 286, bottom: 360 });
+  return `<path d="${path}" fill="none" stroke="url(#accentLine)" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>`;
+}
+
+function htmlScoreVisual(series) {
+  if (!series?.length) {
+    return '<div class="trend-unavailable">Trend data unavailable</div>';
+  }
+  const path = pathForSeries(series, { left: 0, right: 234, top: 6, bottom: 80 });
+  return `<svg class="sparkline" viewBox="0 0 234 86" aria-label="Score trend"><path d="${path}"></path></svg>`;
+}
+
 function splitSignalRows(signals) {
   const topCount = Math.ceil(signals.length / 2);
   return {
@@ -165,6 +183,84 @@ function htmlSignalCluster(signals) {
   </div>`).join('\n');
 
   return { paths, nodes };
+}
+
+function formatScore(value) {
+  if (Number.isInteger(value)) return String(value);
+  return String(Number(value.toFixed(1)));
+}
+
+function formatWeight(weight) {
+  return `${Number((weight * 100).toFixed(1))}%`;
+}
+
+function svgComponentCluster(components) {
+  const { top, bottom } = splitSignalRows(components);
+  const placed = [];
+
+  for (const [rowName, row, y] of [['top', top, 330], ['bottom', bottom, 590]]) {
+    const xs = svgRowXs(row.length);
+    row.forEach((component, index) => placed.push({ component, x: xs[index], y, rowName }));
+  }
+
+  const paths = placed.map(({ x, y }) => `M698 464 L${x} ${y}`).join(' ');
+  const nodes = placed.map(({ component, x, y, rowName }) => {
+    const topRow = rowName === 'top';
+    const scoreY = topRow ? y - 62 : y + 66;
+    const labelY = topRow ? y - 37 : y + 91;
+    const detailY = topRow ? y - 18 : y + 110;
+    const detail = `${formatWeight(component.weight)} · ${component.value}`;
+    return `<g class="score-component-node">
+      <circle cx="${x}" cy="${y}" r="9" fill="#ffffff" stroke="#8d7fda" stroke-width="3"/>
+      <text x="${x}" y="${scoreY}" class="accent" font-size="24" font-weight="740" text-anchor="middle">${escapeMarkup(formatScore(component.normalizedScore))}</text>
+      <text x="${x}" y="${labelY}" class="ink" font-size="13" font-weight="650" text-anchor="middle">${escapeMarkup(component.label)}</text>
+      <text x="${x}" y="${detailY}" class="muted" font-size="11" text-anchor="middle">${escapeMarkup(detail)}</text>
+    </g>`;
+  }).join('\n');
+
+  return { paths, nodes };
+}
+
+function htmlComponentCluster(components) {
+  const { top, bottom } = splitSignalRows(components);
+  const placed = [];
+
+  for (const [row, y] of [[top, 28], [bottom, 72]]) {
+    const xs = htmlRowXs(row.length);
+    row.forEach((component, index) => placed.push({ component, x: xs[index], y }));
+  }
+
+  const paths = placed.map(({ x, y }) => {
+    const px = (620 * x / 100).toFixed(1);
+    const py = (520 * y / 100).toFixed(1);
+    return `M310 260 L${px} ${py}`;
+  }).join(' ');
+
+  const nodes = placed.map(({ component, x, y }) => `<div class="signal score-component" style="left:${x}%;top:${y}%">
+    <strong>${escapeMarkup(formatScore(component.normalizedScore))}</strong>
+    <span>${escapeMarkup(component.label)}</span>
+    <small>${escapeMarkup(`${formatWeight(component.weight)} · ${component.value}`)}</small>
+  </div>`).join('\n');
+
+  return { paths, nodes };
+}
+
+function svgCompositionRows(components) {
+  return components.map((component, index) => {
+    const y = 552 + index * 34;
+    const detail = `${formatScore(component.normalizedScore)} · ${formatWeight(component.weight)}`;
+    return `<g>
+      <text x="98" y="${y}" class="ink" font-size="12" font-weight="650">${escapeMarkup(component.label)}</text>
+      <text x="332" y="${y}" class="muted" font-size="11" text-anchor="end">${escapeMarkup(detail)}</text>
+    </g>`;
+  }).join('\n');
+}
+
+function htmlCompositionRows(components) {
+  return components.map((component) => `<div class="composition-row">
+    <span>${escapeMarkup(component.label)}</span>
+    <small>${escapeMarkup(`${formatScore(component.normalizedScore)} · ${formatWeight(component.weight)}`)}</small>
+  </div>`).join('\n');
 }
 
 function movementSignals(signals) {
@@ -285,7 +381,7 @@ function fillTemplate(template, replacements) {
   return output;
 }
 
-function viewModel(data) {
+function noScoreViewModel(data) {
   const mrr = data.signals.find((signal) => signal.metric === 'mrr');
   const synthesis = synthesisCopy(data.signals);
   const revenueSeries = data.context?.provenance === 'source' ? data.context.revenueSeries : null;
@@ -293,10 +389,9 @@ function viewModel(data) {
   return { mrr, synthesis, revenueSeries, movement };
 }
 
-export function renderSvg(data) {
-  assertValid(data);
-  const template = fs.readFileSync(svgTemplatePath, 'utf8');
-  const { mrr, synthesis, revenueSeries, movement } = viewModel(data);
+function renderNoScoreSvg(data) {
+  const template = fs.readFileSync(noScoreSvgTemplatePath, 'utf8');
+  const { mrr, synthesis, revenueSeries, movement } = noScoreViewModel(data);
   const signalCluster = svgSignalCluster(data.signals);
 
   return fillTemplate(template, {
@@ -313,11 +408,10 @@ export function renderSvg(data) {
   });
 }
 
-export function renderHtml(data) {
-  assertValid(data);
-  const template = fs.readFileSync(htmlTemplatePath, 'utf8');
+function renderNoScoreHtml(data) {
+  const template = fs.readFileSync(noScoreHtmlTemplatePath, 'utf8');
   const css = fs.readFileSync(cssTemplatePath, 'utf8');
-  const { mrr, synthesis, revenueSeries, movement } = viewModel(data);
+  const { mrr, synthesis, revenueSeries, movement } = noScoreViewModel(data);
   const signalCluster = htmlSignalCluster(data.signals);
 
   return fillTemplate(template, {
@@ -333,6 +427,56 @@ export function renderHtml(data) {
     HTML_EXCEPTION_ROWS: htmlExceptionRows(data.exceptions),
     HTML_EVENT_ROWS: htmlEventRows(data.events)
   });
+}
+
+function renderCompositeSvg(data) {
+  const template = fs.readFileSync(compositeSvgTemplatePath, 'utf8');
+  const scoreSeries = data.context?.provenance === 'source' ? data.context.scoreSeries : null;
+  const cluster = svgComponentCluster(data.model.components);
+
+  return fillTemplate(template, {
+    SCORE_LABEL: escapeMarkup(data.score.label),
+    SCORE_VALUE: escapeMarkup(formatScore(data.score.value)),
+    SCORE_MAX: escapeMarkup(formatScore(data.score.max)),
+    SCORE_BAND: escapeMarkup(data.score.band),
+    SVG_SCORE_TREND: svgScoreVisual(scoreSeries),
+    SVG_COMPOSITION_ROWS: svgCompositionRows(data.model.components),
+    SVG_COMPONENT_PATHS: cluster.paths,
+    SVG_COMPONENT_NODES: cluster.nodes,
+    EXCEPTION_ROWS: svgExceptionRows(data.exceptions),
+    EVENT_ROWS: svgEventRows(data.events)
+  });
+}
+
+function renderCompositeHtml(data) {
+  const template = fs.readFileSync(compositeHtmlTemplatePath, 'utf8');
+  const css = fs.readFileSync(cssTemplatePath, 'utf8');
+  const scoreSeries = data.context?.provenance === 'source' ? data.context.scoreSeries : null;
+  const cluster = htmlComponentCluster(data.model.components);
+
+  return fillTemplate(template, {
+    CSS: css,
+    SCORE_LABEL: escapeMarkup(data.score.label),
+    SCORE_VALUE: escapeMarkup(formatScore(data.score.value)),
+    SCORE_MAX: escapeMarkup(formatScore(data.score.max)),
+    SCORE_BAND: escapeMarkup(data.score.band),
+    HTML_SCORE_TREND: htmlScoreVisual(scoreSeries),
+    HTML_COMPOSITION_ROWS: htmlCompositionRows(data.model.components),
+    HTML_COMPONENT_PATHS: cluster.paths,
+    HTML_COMPONENT_NODES: cluster.nodes,
+    HTML_EXCEPTION_ROWS: htmlExceptionRows(data.exceptions),
+    HTML_EVENT_ROWS: htmlEventRows(data.events)
+  });
+}
+
+export function renderSvg(data) {
+  assertValid(data);
+  return data.mode === 'composite' ? renderCompositeSvg(data) : renderNoScoreSvg(data);
+}
+
+export function renderHtml(data) {
+  assertValid(data);
+  return data.mode === 'composite' ? renderCompositeHtml(data) : renderNoScoreHtml(data);
 }
 
 if (process.argv[1] === currentFile) {

--- a/skills/decision-first-dashboard/scripts/render.js
+++ b/skills/decision-first-dashboard/scripts/render.js
@@ -493,8 +493,9 @@ if (process.argv[1] === currentFile) {
   const html = renderHtml(data);
   fs.mkdirSync(outputDir, { recursive: true });
 
-  const svgOutput = path.join(outputDir, 'output.no-score.svg');
-  const htmlOutput = path.join(outputDir, 'output.no-score.html');
+  const outputMode = data.mode === 'composite' ? 'composite' : 'no-score';
+  const svgOutput = path.join(outputDir, `output.${outputMode}.svg`);
+  const htmlOutput = path.join(outputDir, `output.${outputMode}.html`);
   fs.writeFileSync(svgOutput, svg);
   fs.writeFileSync(htmlOutput, html);
   console.log(svgOutput);

--- a/skills/decision-first-dashboard/scripts/validate.js
+++ b/skills/decision-first-dashboard/scripts/validate.js
@@ -28,6 +28,19 @@ function validateNode(value, nodeSchema, instancePath, errors, rootSchema) {
     return;
   }
 
+  if (nodeSchema.oneOf) {
+    let matches = 0;
+    for (const branch of nodeSchema.oneOf) {
+      const branchErrors = [];
+      validateNode(value, branch, instancePath, branchErrors, rootSchema);
+      if (branchErrors.length === 0) matches += 1;
+    }
+    if (matches !== 1) {
+      pushError(errors, instancePath, 'oneOf', 'must match exactly one decision-state mode');
+    }
+    return;
+  }
+
   if (Object.hasOwn(nodeSchema, 'const') && value !== nodeSchema.const) {
     pushError(errors, instancePath, 'const', `must be equal to constant ${JSON.stringify(nodeSchema.const)}`);
     return;
@@ -115,9 +128,84 @@ function validateNode(value, nodeSchema, instancePath, errors, rootSchema) {
   }
 }
 
+function nearlyEqual(a, b, tolerance) {
+  return Math.abs(a - b) <= tolerance;
+}
+
+function validateCompositeSemantics(data, errors) {
+  const { score, model } = data;
+
+  if (!(score.min < score.max)) {
+    pushError(errors, '/score', 'scoreScale', 'score min must be less than score max');
+    return;
+  }
+
+  if (score.value < score.min || score.value > score.max) {
+    pushError(errors, '/score/value', 'scoreScale', 'score value must lie within the declared score scale');
+  }
+
+  let weightSum = 0;
+  let weightedScore = 0;
+  for (const [index, component] of model.components.entries()) {
+    if (!(component.weight > 0 && component.weight <= 1)) {
+      pushError(errors, `/model/components/${index}/weight`, 'weight', 'component weight must be greater than 0 and no greater than 1');
+    }
+    if (component.normalizedScore < score.min || component.normalizedScore > score.max) {
+      pushError(errors, `/model/components/${index}/normalizedScore`, 'scoreScale', 'normalized score must lie within the composite score scale');
+    }
+    weightSum += component.weight;
+    weightedScore += component.normalizedScore * component.weight;
+  }
+
+  if (!nearlyEqual(weightSum, 1, 1e-6)) {
+    pushError(errors, '/model/components', 'weightSum', 'component weights must sum to 1');
+  }
+
+  if (!nearlyEqual(weightedScore, score.value, 0.01)) {
+    pushError(errors, '/score/value', 'weightedAverage', 'score value must equal the weighted average of normalized component scores');
+  }
+
+  const bands = model.bands;
+  if (!nearlyEqual(bands[0].min, score.min, 1e-9)) {
+    pushError(errors, '/model/bands/0/min', 'bandCoverage', 'first band must begin at the score minimum');
+  }
+
+  for (const [index, band] of bands.entries()) {
+    if (!(band.min < band.max)) {
+      pushError(errors, `/model/bands/${index}`, 'bandRange', 'band min must be less than band max');
+    }
+    if (band.min < score.min || band.max > score.max) {
+      pushError(errors, `/model/bands/${index}`, 'bandCoverage', 'band must remain within the score scale');
+    }
+    if (index > 0 && !nearlyEqual(bands[index - 1].max, band.min, 1e-9)) {
+      pushError(errors, `/model/bands/${index}/min`, 'bandContinuity', 'score bands must be contiguous and non-overlapping');
+    }
+  }
+
+  if (!nearlyEqual(bands[bands.length - 1].max, score.max, 1e-9)) {
+    pushError(errors, `/model/bands/${bands.length - 1}/max`, 'bandCoverage', 'last band must end at the score maximum');
+  }
+
+  const selectedBand = bands.find((band, index) => {
+    const isLast = index === bands.length - 1;
+    return score.value >= band.min && (isLast ? score.value <= band.max : score.value < band.max);
+  });
+
+  if (!selectedBand) {
+    pushError(errors, '/score/band', 'bandSelection', 'score value must map to exactly one declared band');
+  } else if (selectedBand.label !== score.band) {
+    pushError(errors, '/score/band', 'bandSelection', 'score band must match the threshold band selected by the score value');
+  }
+}
+
 export function validateDecisionState(data) {
   const errors = [];
   validateNode(data, schema, '', errors, schema);
+
+  if (errors.length === 0 && data.mode === 'composite') {
+    validateCompositeSemantics(data, errors);
+  }
+
   return { valid: errors.length === 0, errors };
 }
 

--- a/skills/decision-first-dashboard/templates/composite.html
+++ b/skills/decision-first-dashboard/templates/composite.html
@@ -1,0 +1,71 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{{SCORE_LABEL}}</title>
+  <style>{{CSS}}</style>
+</head>
+<body>
+  <main class="dashboard-shell">
+    <header class="page-header">
+      <div>
+        <h1>{{SCORE_LABEL}}</h1>
+        <p>Score movement, composition, exceptions, and recent events</p>
+      </div>
+    </header>
+
+    <section class="decision-layout">
+      <aside class="support-column support-column--left">
+        <article class="card score-card">
+          <div class="eyebrow">Score trend</div>
+          <div class="score-value-line">
+            <strong>{{SCORE_VALUE}}</strong>
+            <span>/ {{SCORE_MAX}}</span>
+          </div>
+          <div class="score-band">{{SCORE_BAND}}</div>
+          {{HTML_SCORE_TREND}}
+          <div class="card-divider"></div>
+          <div class="context-row"><span>Current score</span><strong>{{SCORE_VALUE}} / {{SCORE_MAX}}</strong></div>
+        </article>
+
+        <article class="card composition-card">
+          <div class="eyebrow">Score composition</div>
+          <div class="composition-list">{{HTML_COMPOSITION_ROWS}}</div>
+        </article>
+      </aside>
+
+      <section class="card synthesis-card score-center" aria-label="{{SCORE_LABEL}} score">
+        <div class="eyebrow synthesis-eyebrow">Current score</div>
+        <div class="orbit" aria-hidden="true">
+          <div class="orbit-ring orbit-ring--outer"></div>
+          <div class="orbit-ring orbit-ring--inner"></div>
+          <svg viewBox="0 0 620 520" preserveAspectRatio="none">
+            <path d="{{HTML_COMPONENT_PATHS}}"></path>
+          </svg>
+        </div>
+
+        {{HTML_COMPONENT_NODES}}
+
+        <div class="synthesis-core">
+          <strong>{{SCORE_VALUE}}</strong>
+          <span>/ {{SCORE_MAX}}</span>
+          <em>{{SCORE_BAND}}</em>
+        </div>
+      </section>
+
+      <aside class="support-column support-column--right">
+        <article class="card compact-card">
+          <div class="eyebrow">Accounts to watch</div>
+          <div class="exception-list">{{HTML_EXCEPTION_ROWS}}</div>
+        </article>
+
+        <article class="card compact-card events-card">
+          <div class="eyebrow">Recent events</div>
+          <div class="event-list">{{HTML_EVENT_ROWS}}</div>
+        </article>
+      </aside>
+    </section>
+  </main>
+</body>
+</html>

--- a/skills/decision-first-dashboard/templates/composite.svg
+++ b/skills/decision-first-dashboard/templates/composite.svg
@@ -1,0 +1,85 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1440 900" role="img" aria-labelledby="title desc">
+  <title id="title">{{SCORE_LABEL}}</title>
+  <desc id="desc">Score movement, score composition, account exceptions, and recent events.</desc>
+  <defs>
+    <linearGradient id="pageBg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#f8f7ff"/>
+      <stop offset="1" stop-color="#f2f4fb"/>
+    </linearGradient>
+    <radialGradient id="centerGlow" cx="50%" cy="45%" r="58%">
+      <stop offset="0" stop-color="#eee9ff" stop-opacity="0.92"/>
+      <stop offset="1" stop-color="#f9f8ff" stop-opacity="0.16"/>
+    </radialGradient>
+    <linearGradient id="accentLine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#8172d8"/>
+      <stop offset="1" stop-color="#a99ce9"/>
+    </linearGradient>
+    <filter id="cardShadow" x="-20%" y="-20%" width="140%" height="160%">
+      <feDropShadow dx="0" dy="14" stdDeviation="20" flood-color="#554d86" flood-opacity="0.08"/>
+    </filter>
+    <style>
+      .sans { font-family: Inter, ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+      .ink { fill: #242338; }
+      .muted { fill: #858398; }
+      .soft { fill: #aaa7ba; }
+      .accent { fill: #7264ca; }
+      .danger { fill: #b95e69; }
+      .card { fill: #ffffff; stroke: #ebe9f5; stroke-width: 1; }
+    </style>
+  </defs>
+
+  <rect width="1440" height="900" fill="url(#pageBg)"/>
+
+  <g class="sans">
+    <text x="72" y="76" class="ink" font-size="28" font-weight="700">{{SCORE_LABEL}}</text>
+    <text x="72" y="106" class="muted" font-size="14">Score movement, composition, exceptions, and recent events</text>
+
+    <g filter="url(#cardShadow)">
+      <rect x="72" y="150" width="286" height="302" rx="26" class="card"/>
+    </g>
+    <text x="98" y="190" class="ink" font-size="15" font-weight="650">Score trend</text>
+    <text x="98" y="230" class="ink" font-size="31" font-weight="740">{{SCORE_VALUE}}</text>
+    <text x="140" y="230" class="muted" font-size="14">/ {{SCORE_MAX}}</text>
+    <text x="98" y="255" class="danger" font-size="13" font-weight="650">{{SCORE_BAND}}</text>
+    {{SVG_SCORE_TREND}}
+    <line x1="98" y1="392" x2="332" y2="392" stroke="#efedf6"/>
+    <text x="98" y="421" class="muted" font-size="12">Current score</text>
+    <text x="332" y="421" class="ink" font-size="13" font-weight="650" text-anchor="end">{{SCORE_VALUE}} / {{SCORE_MAX}}</text>
+
+    <g filter="url(#cardShadow)">
+      <rect x="72" y="476" width="286" height="284" rx="26" class="card"/>
+    </g>
+    <text x="98" y="516" class="ink" font-size="15" font-weight="650">Score composition</text>
+    {{SVG_COMPOSITION_ROWS}}
+
+    <g filter="url(#cardShadow)">
+      <rect x="382" y="150" width="632" height="610" rx="34" class="card"/>
+    </g>
+    <rect x="406" y="174" width="584" height="562" rx="30" fill="url(#centerGlow)"/>
+    <text x="414" y="204" class="muted" font-size="12" font-weight="650" letter-spacing="1.5">CURRENT SCORE</text>
+
+    <circle cx="698" cy="464" r="188" fill="none" stroke="#e3dff5" stroke-width="1.5" stroke-dasharray="5 8"/>
+    <circle cx="698" cy="464" r="132" fill="none" stroke="#ece9f7" stroke-width="1"/>
+    <path d="{{SVG_COMPONENT_PATHS}}" fill="none" stroke="#d6d0ef" stroke-width="1.6"/>
+
+    <circle cx="698" cy="464" r="98" fill="#ffffff" stroke="#d7d0ef" stroke-width="2"/>
+    <circle cx="698" cy="464" r="86" fill="#f7f4ff"/>
+    <text x="698" y="454" class="accent" font-size="48" font-weight="780" text-anchor="middle">{{SCORE_VALUE}}</text>
+    <text x="698" y="481" class="muted" font-size="14" text-anchor="middle">/ {{SCORE_MAX}}</text>
+    <text x="698" y="511" class="danger" font-size="14" font-weight="700" text-anchor="middle">{{SCORE_BAND}}</text>
+
+    {{SVG_COMPONENT_NODES}}
+
+    <g filter="url(#cardShadow)">
+      <rect x="1038" y="150" width="330" height="278" rx="26" class="card"/>
+    </g>
+    <text x="1064" y="190" class="ink" font-size="15" font-weight="650">Accounts to watch</text>
+    {{EXCEPTION_ROWS}}
+
+    <g filter="url(#cardShadow)">
+      <rect x="1038" y="452" width="330" height="308" rx="26" class="card"/>
+    </g>
+    <text x="1064" y="492" class="ink" font-size="15" font-weight="650">Recent events</text>
+    {{EVENT_ROWS}}
+  </g>
+</svg>

--- a/skills/decision-first-dashboard/templates/dashboard.css
+++ b/skills/decision-first-dashboard/templates/dashboard.css
@@ -195,6 +195,49 @@ body {
 .signal span { display: block; margin-top: 9px; font-weight: 700; font-size: 13px; }
 .signal small { display: block; margin-top: 5px; color: var(--muted); font-size: 11px; }
 
+.score-card { padding: 26px; min-height: 302px; }
+.score-value-line {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  margin-top: 26px;
+}
+.score-value-line strong {
+  font-size: 34px;
+  font-weight: 780;
+  letter-spacing: -0.035em;
+}
+.score-value-line span { color: var(--muted); font-size: 14px; }
+.score-band { margin-top: 7px; color: var(--danger); font-size: 13px; font-weight: 700; }
+.composition-card { padding: 26px; min-height: 284px; }
+.composition-list { margin-top: 14px; }
+.composition-row {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 12px;
+  align-items: center;
+  padding: 12px 0;
+  border-bottom: 1px solid #efedf6;
+}
+.composition-row:last-child { border-bottom: 0; }
+.composition-row span { font-size: 12px; font-weight: 650; }
+.composition-row small { color: var(--muted); font-size: 11px; }
+.score-center .synthesis-core { width: 194px; height: 194px; }
+.score-center .synthesis-core strong {
+  font-size: 48px;
+  line-height: 1;
+  letter-spacing: -0.035em;
+}
+.score-center .synthesis-core span { margin-top: 5px; }
+.score-center .synthesis-core em {
+  margin-top: 10px;
+  color: var(--danger);
+  font-size: 13px;
+  font-style: normal;
+  font-weight: 700;
+}
+.score-component strong { font-size: 24px; }
+
 .compact-card { padding: 26px; min-height: 278px; }
 .events-card { min-height: 308px; }
 .exception-list, .event-list { margin-top: 22px; }

--- a/tests/compiler/composite-schema.test.js
+++ b/tests/compiler/composite-schema.test.js
@@ -1,0 +1,80 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import { validateDecisionState } from '../../skills/decision-first-dashboard/scripts/validate.js';
+
+const fixtureUrl = new URL('./fixtures/composite.valid.json', import.meta.url);
+const base = JSON.parse(fs.readFileSync(fixtureUrl, 'utf8'));
+
+function valid(data) {
+  return validateDecisionState(data).valid;
+}
+
+test('accepts a source-supported composite weighted-average payload', () => {
+  assert.equal(valid(base), true);
+});
+
+test('rejects a composite component without a source weight', () => {
+  const bad = structuredClone(base);
+  delete bad.model.components[0].weight;
+  assert.equal(valid(bad), false);
+});
+
+test('rejects composite weights that do not sum to one', () => {
+  const bad = structuredClone(base);
+  bad.model.components[0].weight = 0.5;
+  assert.equal(valid(bad), false);
+});
+
+test('rejects a composite score that does not match the weighted average', () => {
+  const bad = structuredClone(base);
+  bad.score.value = 72;
+  assert.equal(valid(bad), false);
+});
+
+test('rejects a score band label that does not match the score', () => {
+  const bad = structuredClone(base);
+  bad.score.band = 'Watch';
+  assert.equal(valid(bad), false);
+});
+
+test('rejects gaps in source-provided score bands', () => {
+  const bad = structuredClone(base);
+  bad.model.bands[1].min = 71;
+  assert.equal(valid(bad), false);
+});
+
+test('rejects overlaps in source-provided score bands', () => {
+  const bad = structuredClone(base);
+  bad.model.bands[1].min = 69;
+  assert.equal(valid(bad), false);
+});
+
+test('rejects normalized component scores outside the composite scale', () => {
+  const bad = structuredClone(base);
+  bad.model.components[0].normalizedScore = 120;
+  assert.equal(valid(bad), false);
+});
+
+test('rejects invented or unsupported composite methods', () => {
+  const inferred = structuredClone(base);
+  inferred.model.normalization = 'agent_inferred';
+  assert.equal(valid(inferred), false);
+
+  const median = structuredClone(base);
+  median.model.aggregation = 'median';
+  assert.equal(valid(median), false);
+});
+
+test('keeps no-score mode physically closed to composite fields', () => {
+  const noScore = {
+    mode: 'no_score',
+    signals: [
+      { metric: 'mrr', label: 'MRR', value: '$184,320', delta: '+12.4%', direction: 'improving', provenance: 'source' },
+      { metric: 'active_customers', label: 'Customers', value: '8,942', delta: '+8.1%', direction: 'improving', provenance: 'source' },
+      { metric: 'churn_rate', label: 'Churn', value: '2.84%', delta: '-0.6pp', direction: 'improving', provenance: 'source' }
+    ]
+  };
+  noScore.model = structuredClone(base.model);
+  assert.equal(valid(noScore), false);
+});

--- a/tests/compiler/fixtures/composite.valid.json
+++ b/tests/compiler/fixtures/composite.valid.json
@@ -1,0 +1,68 @@
+{
+  "mode": "composite",
+  "score": {
+    "label": "Subscription health",
+    "value": 68,
+    "min": 0,
+    "max": 100,
+    "band": "At risk",
+    "provenance": "source"
+  },
+  "model": {
+    "normalization": "source_provided",
+    "aggregation": "weighted_average",
+    "provenance": "source",
+    "components": [
+      {
+        "metric": "retention",
+        "label": "Retention",
+        "value": "96.8%",
+        "normalizedScore": 60,
+        "weight": 0.4,
+        "provenance": "source"
+      },
+      {
+        "metric": "growth",
+        "label": "Growth",
+        "value": "+12.4%",
+        "normalizedScore": 80,
+        "weight": 0.3,
+        "provenance": "source"
+      },
+      {
+        "metric": "conversion",
+        "label": "Conversion",
+        "value": "31.7%",
+        "normalizedScore": 66.6667,
+        "weight": 0.3,
+        "provenance": "source"
+      }
+    ],
+    "bands": [
+      { "label": "At risk", "min": 0, "max": 70, "provenance": "source" },
+      { "label": "Watch", "min": 70, "max": 85, "provenance": "source" },
+      { "label": "Healthy", "min": 85, "max": 100, "provenance": "source" }
+    ]
+  },
+  "context": {
+    "scoreSeries": [61, 63, 64, 66, 67, 68],
+    "provenance": "source"
+  },
+  "exceptions": [
+    {
+      "name": "Northstar",
+      "plan": "Enterprise",
+      "mrr": "$7,200",
+      "status": "At risk",
+      "provenance": "source"
+    }
+  ],
+  "events": [
+    {
+      "subject": "Northstar",
+      "event": "Plan downgrade requested",
+      "time": "2 hr ago",
+      "provenance": "source"
+    }
+  ]
+}

--- a/tests/compiler/render-cli.test.js
+++ b/tests/compiler/render-cli.test.js
@@ -1,0 +1,37 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const renderer = path.join(repoRoot, 'skills/decision-first-dashboard/scripts/render.js');
+const compositeFixture = path.join(repoRoot, 'tests/compiler/fixtures/composite.valid.json');
+const noScoreFixture = path.join(repoRoot, 'examples/saas/input.no-score.json');
+
+function runRenderer(inputPath) {
+  const outputDir = fs.mkdtempSync(path.join(os.tmpdir(), 'decision-first-render-'));
+  const result = spawnSync(process.execPath, [renderer, inputPath, outputDir], {
+    cwd: repoRoot,
+    encoding: 'utf8'
+  });
+  return { outputDir, result };
+}
+
+test('CLI writes composite mode to output.composite.svg and output.composite.html', () => {
+  const { outputDir, result } = runRenderer(compositeFixture);
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(fs.existsSync(path.join(outputDir, 'output.composite.svg')), true);
+  assert.equal(fs.existsSync(path.join(outputDir, 'output.composite.html')), true);
+  assert.equal(fs.existsSync(path.join(outputDir, 'output.no-score.svg')), false);
+  assert.equal(fs.existsSync(path.join(outputDir, 'output.no-score.html')), false);
+});
+
+test('CLI preserves no-score output basenames', () => {
+  const { outputDir, result } = runRenderer(noScoreFixture);
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(fs.existsSync(path.join(outputDir, 'output.no-score.svg')), true);
+  assert.equal(fs.existsSync(path.join(outputDir, 'output.no-score.html')), true);
+});

--- a/tests/compiler/render-composite-html.test.js
+++ b/tests/compiler/render-composite-html.test.js
@@ -35,9 +35,12 @@ test('keeps exceptions and events compact without KPI grids or tables', () => {
   assert.doesNotMatch(html, /kpi-grid|grid-cols-4/i);
 });
 
-test('does not leak composite methodology labels into HTML', () => {
+test('does not leak composite methodology labels into visible HTML copy', () => {
   const html = renderHtml(fixture);
-  assert.doesNotMatch(html, /Composite mode|Weighted average|Aggregation|Normalization|Decision|Driver|Diagnostic|Framework|Compiler/i);
+  assert.doesNotMatch(
+    html,
+    />\s*(Composite mode|Weighted average|Aggregation|Normalization|Decision|Driver|Diagnostic|Framework|Compiler)\s*</i
+  );
 });
 
 test('composite HTML is deterministic and fully resolved', () => {

--- a/tests/compiler/render-composite-html.test.js
+++ b/tests/compiler/render-composite-html.test.js
@@ -1,0 +1,48 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import { renderHtml } from '../../skills/decision-first-dashboard/scripts/render.js';
+
+const fixture = JSON.parse(
+  fs.readFileSync(new URL('./fixtures/composite.valid.json', import.meta.url), 'utf8')
+);
+
+test('renders a dominant composite score in fixed HTML composition', () => {
+  const html = renderHtml(fixture);
+  assert.match(html, /Subscription health/);
+  assert.match(html, />68</);
+  assert.match(html, /\/ 100/);
+  assert.match(html, /At risk/);
+  assert.match(html, /score-center/);
+});
+
+test('renders every weighted score component and source score trend', () => {
+  const html = renderHtml(fixture);
+  for (const label of ['Retention', 'Growth', 'Conversion']) {
+    assert.match(html, new RegExp(`>${label}<`));
+  }
+  assert.match(html, /40%/);
+  assert.match(html, /30%/);
+  assert.match(html, /aria-label="Score trend"/);
+});
+
+test('keeps exceptions and events compact without KPI grids or tables', () => {
+  const html = renderHtml(fixture);
+  assert.match(html, /Northstar/);
+  assert.match(html, /Plan downgrade requested/);
+  assert.doesNotMatch(html, /<table\b/i);
+  assert.doesNotMatch(html, /<button\b/i);
+  assert.doesNotMatch(html, /kpi-grid|grid-cols-4/i);
+});
+
+test('does not leak composite methodology labels into HTML', () => {
+  const html = renderHtml(fixture);
+  assert.doesNotMatch(html, /Composite mode|Weighted average|Aggregation|Normalization|Decision|Driver|Diagnostic|Framework|Compiler/i);
+});
+
+test('composite HTML is deterministic and fully resolved', () => {
+  const first = renderHtml(fixture);
+  const second = renderHtml(structuredClone(fixture));
+  assert.equal(first, second);
+  assert.doesNotMatch(first, /{{[^}]+}}/);
+});

--- a/tests/compiler/render-composite-svg.test.js
+++ b/tests/compiler/render-composite-svg.test.js
@@ -1,0 +1,48 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import { renderSvg } from '../../skills/decision-first-dashboard/scripts/render.js';
+
+const fixture = JSON.parse(
+  fs.readFileSync(new URL('./fixtures/composite.valid.json', import.meta.url), 'utf8')
+);
+
+test('renders a dominant composite score with its source-supported band', () => {
+  const svg = renderSvg(fixture);
+  assert.match(svg, /Subscription health/);
+  assert.match(svg, />68</);
+  assert.match(svg, /\/ 100/);
+  assert.match(svg, /At risk/);
+});
+
+test('renders all weighted score components around the composite score', () => {
+  const svg = renderSvg(fixture);
+  for (const label of ['Retention', 'Growth', 'Conversion']) {
+    assert.match(svg, new RegExp(`>${label}<`));
+  }
+  for (const score of ['60', '80', '66.7']) {
+    assert.match(svg, new RegExp(score.replace('.', '\\.')));
+  }
+  for (const weight of ['40%', '30%']) {
+    assert.match(svg, new RegExp(weight));
+  }
+});
+
+test('renders source score trend plus compact exceptions and events', () => {
+  const svg = renderSvg(fixture);
+  assert.match(svg, /Score trend/);
+  assert.match(svg, /Northstar/);
+  assert.match(svg, /Plan downgrade requested/);
+});
+
+test('does not leak composite methodology labels into SVG', () => {
+  const svg = renderSvg(fixture);
+  assert.doesNotMatch(svg, /Composite mode|Weighted average|Aggregation|Normalization|Decision|Driver|Diagnostic|Framework|Compiler/i);
+});
+
+test('composite SVG is deterministic and fully resolved', () => {
+  const first = renderSvg(fixture);
+  const second = renderSvg(structuredClone(fixture));
+  assert.equal(first, second);
+  assert.doesNotMatch(first, /{{[^}]+}}/);
+});


### PR DESCRIPTION
## Summary

Adds the second deterministic compiler branch: strict `composite` mode, while preserving the existing `no_score` behavior.

## Composite eligibility

Composite is accepted only when the source provides all of the following:

- an overall score and scale;
- source-provided normalized component scores;
- source-provided component weights;
- a weighted-average aggregation rule;
- complete source-provided score bands / thresholds.

If any of those are missing, the contract requires `no_score` instead.

## What changed

- extends `decision-state.schema.json` to mutually exclusive `no_score` and `composite` branches;
- validates component provenance, weight totals, weighted score calculation, score scale, band continuity, and band/score consistency;
- adds deterministic composite SVG and HTML templates;
- renders 3–6 weighted components around the dominant score;
- supports source-provided score trend, exceptions, and events;
- dispatches renderer by `mode`;
- writes `output.composite.svg/html` for composite while preserving `output.no-score.svg/html`;
- updates README and skill guidance;
- adds composite schema, renderer, CLI, regression, and anti-methodology-leak tests.

## Anti-hallucination guarantees

- no invented normalization formulas;
- no invented weights or thresholds;
- no arbitrary aggregation methods;
- no composite fields allowed in `no_score`;
- source-supported exceptions/events only;
- methodology labels remain internal and do not render into product UI.

## Verification

Latest feature-branch GitHub Actions run passed:

- `npm test`
- `npm run validate:saas`
- `npm run render:saas`
- artifact upload

Recommended integration: **Squash and merge** with commit title `feat: add strict composite dashboard compiler mode`.

Note: the composite fixture uses explicit test-contract data to exercise the compiler. It is not presented as source truth for the canonical SaaS screenshot example.