### PR TITLE
fix: allow point-in-time no-score signals without movement

### DIFF
--- a/skills/decision-first-dashboard/schemas/decision-state.schema.json
+++ b/skills/decision-first-dashboard/schemas/decision-state.schema.json
@@ -54,7 +54,7 @@
     "signal": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["metric", "label", "value", "delta", "direction", "provenance"],
+      "required": ["metric", "label", "value", "provenance"],
       "properties": {
         "metric": { "type": "string", "pattern": "^[a-z0-9_]{1,40}$" },
         "label": { "type": "string", "minLength": 1, "maxLength": 24 },

--- a/tests/compiler/schema.test.js
+++ b/tests/compiler/schema.test.js
@@ -111,3 +111,18 @@ test('allows source plan names without product-specific enums', () => {
   good.exceptions[0].plan = 'Enterprise Plus';
   assert.equal(validateDecisionState(good).valid, true);
 });
+
+test('accepts point-in-time source signals when the source exposes no delta or direction', () => {
+  const good = structuredClone(base);
+  good.signals = [
+    { metric: 'arr', label: 'ARR', value: '$4.98M', provenance: 'source' },
+    { metric: 'ndr', label: 'NDR', value: '80.7%', provenance: 'source' },
+    { metric: 'gross_margin', label: 'Gross margin', value: '88.9%', provenance: 'source' },
+    { metric: 'cac_payback', label: 'CAC payback', value: '9.4 mo', provenance: 'source' },
+    { metric: 'burn_multiple', label: 'Burn multiple', value: '1.5x', provenance: 'source' }
+  ];
+  delete good.exceptions;
+  delete good.events;
+
+  assert.equal(validateDecisionState(good).valid, true);
+});


### PR DESCRIPTION
## Real-world reproduction

A SaaSGrid executive dashboard exposes point-in-time KPI values such as ARR, NDR, gross margin, CAC payback, and burn multiple without a per-metric delta or direction on the KPI cards.

The current `no_score` signal contract requires both `delta` and `direction`, which forces callers to insert placeholders such as `—` / `unknown` just to validate. That conflicts with the compiler's facts-only anti-hallucination rule.

## TDD step

This PR starts with a regression test only. The test requires a valid `no_score` payload whose source-backed signals contain `metric`, `label`, `value`, and `provenance`, but omit `delta` and `direction` when the source does not expose movement.

Expected initial CI result: RED because the current schema still requires those two fields.