### PR TITLE
fix: make no-score revenue context source-driven

### DIFF
--- a/skills/decision-first-dashboard/scripts/render.js
+++ b/skills/decision-first-dashboard/scripts/render.js
@@ -71,6 +71,30 @@ function signalDisplay(signal) {
   };
 }
 
+function selectRevenueSignal(signals) {
+  return signals.find((signal) => signal.metric === 'mrr')
+    ?? signals.find((signal) => signal.metric === 'arr')
+    ?? null;
+}
+
+function revenueTitle(signal) {
+  return signal ? `${signal.label} context` : 'Revenue context';
+}
+
+function currentRevenueLabel(signal) {
+  return signal ? `Current ${signal.label}` : 'Revenue metric unavailable';
+}
+
+function svgRevenueDeltaBlock(signal) {
+  if (!signal?.delta) return '';
+  return `<text x="98" y="252" class="${directionClass(signal.direction)}" font-size="14" font-weight="650">${escapeMarkup(signal.delta)}</text>`;
+}
+
+function htmlRevenueDeltaBlock(signal) {
+  if (!signal?.delta) return '';
+  return `<div class="metric-delta ${directionClass(signal.direction)}">${escapeMarkup(signal.delta)}</div>`;
+}
+
 function pathForSeries(series, { left, right, top, bottom }) {
   const min = Math.min(...series);
   const max = Math.max(...series);
@@ -280,7 +304,7 @@ function htmlCompositionRows(components) {
   </div>`).join('\n');
 }
 
-function movementSignals(signals) {
+function movementSignals(signals, revenueMetric = null) {
   const eligible = signals.filter((signal) => signal.delta);
   const preferred = ['churn_rate', 'trial_conversion'];
   const selected = [];
@@ -292,7 +316,7 @@ function movementSignals(signals) {
 
   for (const signal of eligible) {
     if (selected.length >= 2) break;
-    if (signal.metric !== 'mrr' && !selected.includes(signal)) selected.push(signal);
+    if (signal.metric !== revenueMetric && !selected.includes(signal)) selected.push(signal);
   }
 
   return selected.slice(0, 2);
@@ -400,22 +424,23 @@ function fillTemplate(template, replacements) {
 }
 
 function noScoreViewModel(data) {
-  const mrr = data.signals.find((signal) => signal.metric === 'mrr');
+  const revenue = selectRevenueSignal(data.signals);
   const synthesis = synthesisCopy(data.signals);
   const revenueSeries = data.context?.provenance === 'source' ? data.context.revenueSeries : null;
-  const movement = movementSignals(data.signals);
-  return { mrr, synthesis, revenueSeries, movement };
+  const movement = movementSignals(data.signals, revenue?.metric ?? null);
+  return { revenue, synthesis, revenueSeries, movement };
 }
 
 function renderNoScoreSvg(data) {
   const template = fs.readFileSync(noScoreSvgTemplatePath, 'utf8');
-  const { mrr, synthesis, revenueSeries, movement } = noScoreViewModel(data);
+  const { revenue, synthesis, revenueSeries, movement } = noScoreViewModel(data);
   const signalCluster = svgSignalCluster(data.signals);
 
   return fillTemplate(template, {
-    MRR_VALUE: escapeMarkup(mrr?.value ?? '—'),
-    MRR_DELTA: escapeMarkup(mrr?.delta ?? '—'),
-    MRR_DIRECTION_CLASS: directionClass(mrr?.direction),
+    REVENUE_TITLE: escapeMarkup(revenueTitle(revenue)),
+    REVENUE_VALUE: escapeMarkup(revenue?.value ?? '—'),
+    REVENUE_DELTA_BLOCK: svgRevenueDeltaBlock(revenue),
+    CURRENT_REVENUE_LABEL: escapeMarkup(currentRevenueLabel(revenue)),
     REVENUE_VISUAL: svgRevenueVisual(revenueSeries),
     MOVEMENT_ROWS: svgMovementRows(movement),
     SYNTHESIS: synthesis.direction,
@@ -429,14 +454,15 @@ function renderNoScoreSvg(data) {
 function renderNoScoreHtml(data) {
   const template = fs.readFileSync(noScoreHtmlTemplatePath, 'utf8');
   const css = fs.readFileSync(cssTemplatePath, 'utf8');
-  const { mrr, synthesis, revenueSeries, movement } = noScoreViewModel(data);
+  const { revenue, synthesis, revenueSeries, movement } = noScoreViewModel(data);
   const signalCluster = htmlSignalCluster(data.signals);
 
   return fillTemplate(template, {
     CSS: css,
-    MRR_VALUE: escapeMarkup(mrr?.value ?? '—'),
-    MRR_DELTA: escapeMarkup(mrr?.delta ?? '—'),
-    MRR_DIRECTION_CLASS: directionClass(mrr?.direction),
+    REVENUE_TITLE: escapeMarkup(revenueTitle(revenue)),
+    REVENUE_VALUE: escapeMarkup(revenue?.value ?? '—'),
+    HTML_REVENUE_DELTA_BLOCK: htmlRevenueDeltaBlock(revenue),
+    CURRENT_REVENUE_LABEL: escapeMarkup(currentRevenueLabel(revenue)),
     HTML_REVENUE_VISUAL: htmlRevenueVisual(revenueSeries),
     HTML_MOVEMENT_ROWS: htmlMovementRows(movement),
     SYNTHESIS: synthesis.direction,

--- a/skills/decision-first-dashboard/templates/no-score.html
+++ b/skills/decision-first-dashboard/templates/no-score.html
@@ -18,12 +18,12 @@
     <section class="decision-layout">
       <aside class="support-column support-column--left">
         <article class="card revenue-card">
-          <div class="eyebrow">Revenue growth</div>
-          <div class="metric-value">{{MRR_VALUE}}</div>
-          <div class="metric-delta {{MRR_DIRECTION_CLASS}}">{{MRR_DELTA}} <span>vs last month</span></div>
+          <div class="eyebrow">{{REVENUE_TITLE}}</div>
+          <div class="metric-value">{{REVENUE_VALUE}}</div>
+          {{HTML_REVENUE_DELTA_BLOCK}}
           {{HTML_REVENUE_VISUAL}}
           <div class="card-divider"></div>
-          <div class="context-row"><span>Current MRR</span><strong>{{MRR_VALUE}}</strong></div>
+          <div class="context-row"><span>{{CURRENT_REVENUE_LABEL}}</span><strong>{{REVENUE_VALUE}}</strong></div>
         </article>
 
         <article class="card context-card">

--- a/skills/decision-first-dashboard/templates/no-score.svg
+++ b/skills/decision-first-dashboard/templates/no-score.svg
@@ -38,14 +38,13 @@
     <g filter="url(#cardShadow)">
       <rect x="72" y="150" width="286" height="302" rx="26" class="card"/>
     </g>
-    <text x="98" y="190" class="ink" font-size="15" font-weight="650">Revenue growth</text>
-    <text x="98" y="228" class="ink" font-size="30" font-weight="720">{{MRR_VALUE}}</text>
-    <text x="98" y="252" class="{{MRR_DIRECTION_CLASS}}" font-size="14" font-weight="650">{{MRR_DELTA}}</text>
-    <text x="156" y="252" class="muted" font-size="13">vs last month</text>
+    <text x="98" y="190" class="ink" font-size="15" font-weight="650">{{REVENUE_TITLE}}</text>
+    <text x="98" y="228" class="ink" font-size="30" font-weight="720">{{REVENUE_VALUE}}</text>
+    {{REVENUE_DELTA_BLOCK}}
     {{REVENUE_VISUAL}}
     <line x1="98" y1="392" x2="332" y2="392" stroke="#efedf6"/>
-    <text x="98" y="421" class="muted" font-size="12">Current MRR</text>
-    <text x="332" y="421" class="ink" font-size="13" font-weight="650" text-anchor="end">{{MRR_VALUE}}</text>
+    <text x="98" y="421" class="muted" font-size="12">{{CURRENT_REVENUE_LABEL}}</text>
+    <text x="332" y="421" class="ink" font-size="13" font-weight="650" text-anchor="end">{{REVENUE_VALUE}}</text>
 
     <g filter="url(#cardShadow)">
       <rect x="72" y="476" width="286" height="190" rx="26" class="card"/>

--- a/tests/compiler/render-html.test.js
+++ b/tests/compiler/render-html.test.js
@@ -14,6 +14,19 @@ function extraSignals() {
   ];
 }
 
+function pointInTimeFixture() {
+  return {
+    mode: 'no_score',
+    signals: [
+      { metric: 'arr', label: 'ARR', value: '$4.98M', provenance: 'source' },
+      { metric: 'ndr', label: 'NDR', value: '80.7%', provenance: 'source' },
+      { metric: 'gross_margin', label: 'Gross Margin', value: '88.9%', provenance: 'source' },
+      { metric: 'cac_payback', label: 'CAC Payback', value: '9.4 mo', provenance: 'source' },
+      { metric: 'burn_multiple', label: 'Burn Multiple', value: '1.5x', provenance: 'source' }
+    ]
+  };
+}
+
 test('renders the same canonical decision state into a fixed HTML composition', () => {
   const html = renderHtml(fixture);
   assert.match(html, /Subscription health/);
@@ -75,4 +88,13 @@ test('refuses to render a payload that fails the decision-state schema', () => {
   const bad = structuredClone(fixture);
   bad.exceptions[0].action = 'Contact';
   assert.throws(() => renderHtml(bad), /failed schema validation/);
+});
+
+test('uses ARR as source-driven HTML revenue context without inventing MRR movement', () => {
+  const html = renderHtml(pointInTimeFixture());
+  assert.match(html, /ARR context/);
+  assert.match(html, /Current ARR/);
+  assert.match(html, /\$4\.98M/);
+  assert.doesNotMatch(html, /Current MRR/);
+  assert.doesNotMatch(html, /vs last month/);
 });

--- a/tests/compiler/render-svg.test.js
+++ b/tests/compiler/render-svg.test.js
@@ -14,6 +14,19 @@ function extraSignals() {
   ];
 }
 
+function pointInTimeFixture() {
+  return {
+    mode: 'no_score',
+    signals: [
+      { metric: 'arr', label: 'ARR', value: '$4.98M', provenance: 'source' },
+      { metric: 'ndr', label: 'NDR', value: '80.7%', provenance: 'source' },
+      { metric: 'gross_margin', label: 'Gross Margin', value: '88.9%', provenance: 'source' },
+      { metric: 'cac_payback', label: 'CAC Payback', value: '9.4 mo', provenance: 'source' },
+      { metric: 'burn_multiple', label: 'Burn Multiple', value: '1.5x', provenance: 'source' }
+    ]
+  };
+}
+
 test('renders a dominant no-score synthesis cluster from validated data', () => {
   const svg = renderSvg(fixture);
   assert.match(svg, /Subscription health/);
@@ -83,22 +96,20 @@ test('refuses to render a payload that fails the decision-state schema', () => {
 });
 
 test('renders point-in-time KPI values prominently without blank movement labels', () => {
-  const pointInTime = {
-    mode: 'no_score',
-    signals: [
-      { metric: 'arr', label: 'ARR', value: '$4.98M', provenance: 'source' },
-      { metric: 'ndr', label: 'NDR', value: '80.7%', provenance: 'source' },
-      { metric: 'gross_margin', label: 'Gross Margin', value: '88.9%', provenance: 'source' },
-      { metric: 'cac_payback', label: 'CAC Payback', value: '9.4 mo', provenance: 'source' },
-      { metric: 'burn_multiple', label: 'Burn Multiple', value: '1.5x', provenance: 'source' }
-    ]
-  };
-
-  const svg = renderSvg(pointInTime);
+  const svg = renderSvg(pointInTimeFixture());
   for (const value of ['$4.98M', '80.7%', '88.9%', '9.4 mo', '1.5x']) {
     assert.match(svg, new RegExp(value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
   }
   assert.match(svg, />UNKNOWN</);
   assert.doesNotMatch(svg, />\s*<\/text>/);
   assert.doesNotMatch(svg, /undefined/);
+});
+
+test('uses ARR as source-driven revenue context without inventing MRR movement', () => {
+  const svg = renderSvg(pointInTimeFixture());
+  assert.match(svg, /ARR context/);
+  assert.match(svg, /Current ARR/);
+  assert.match(svg, /\$4\.98M/);
+  assert.doesNotMatch(svg, /Current MRR/);
+  assert.doesNotMatch(svg, /vs last month/);
 });


### PR DESCRIPTION
## Real-world reproduction

The SaaSGrid executive dashboard exposes ARR, not MRR, and does not provide a per-card monthly delta. The current no-score renderer hardcodes the left context card to `MRR` and `vs last month`, which creates misleading placeholder copy even though the source evidence is ARR-only.

## Desired contract

- prefer exact source `mrr` when present, preserving canonical behavior;
- otherwise use exact source `arr` when present;
- label the context dynamically from the selected source metric;
- render movement comparison copy only when the selected source metric actually has a delta;
- never infer MRR from ARR or invent a comparison period.

This PR starts with a RED regression test for the ARR-only case.