### PR TITLE
Add adaptive Decision Brief intake

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@ Turn KPI-heavy dashboards into decision-first dashboards without letting the age
 Most dashboard prompts ask an LLM to **design**. This project treats dashboard redesign more like a small compiler:
 
 ```text
-source dashboard / verified source file
+source dashboard / verified source file + user context
+      ↓
+adaptive Decision Brief (0–5 one-at-a-time questions)
       ↓
 agent extraction + Metric Router + mode proposal
       ↓
@@ -34,7 +36,28 @@ Table
 
 The user still has to scan everything and construct the conclusion mentally.
 
-Decision-First Dashboard changes the information hierarchy first. The agent extracts evidence; the compiler verifies that the evidence can be mechanically grounded back to source bytes before the deterministic renderer owns the layout.
+Decision-First Dashboard changes the information hierarchy first. The agent clarifies the decision context, extracts evidence, and routes metrics; the compiler verifies that the evidence can be mechanically grounded back to source bytes before the deterministic renderer owns the layout.
+
+## Adaptive Decision Brief
+
+Users often know they need a dashboard without knowing which metrics, thresholds, drilldowns, or charts they actually need. Before metric routing, the skill builds an **adaptive Decision Brief** with the minimum context necessary to make a defensible design decision.
+
+The interaction is deliberately lightweight:
+
+- ask **one question at a time**;
+- ask **no more than five questions**;
+- stop early as soon as the information is sufficient;
+- never ask for information already provided or inferable from the request or uploaded data;
+- treat the five dimensions — Decision, Action, Exception, Diagnosis, and Audience/cadence — as a question pool rather than a fixed questionnaire.
+
+If the user cannot answer an open question, the skill first reduces it to 2–4 concrete choices. If the user is still unsure, it can infer the most defensible direction from the uploaded data and ask for confirmation. It never invents a business threshold merely to complete the brief.
+
+Both intake orders are supported:
+
+- **data-first** — profile uploaded fields, metrics, dimensions, time range, targets, and benchmarks first, then ask only for missing decision context;
+- **question-first** — clarify the decision context first, then request only the data needed to support that decision and its diagnosis path.
+
+The Decision Brief guides the Metric Router and information hierarchy, but it does not weaken source grounding. User intent or inferred needs do not become source evidence unless they are independently supported by the source and allowed by the decision-state contract.
 
 ## Metric Router
 
@@ -139,14 +162,15 @@ Give the agent a dashboard screenshot, Figma frame, existing dashboard code, or 
 
 The intended production execution path is:
 
-1. Extract verified facts only.
-2. Route metrics with the Metric Router and Action Trigger Test.
-3. Decide whether the evidence supports `no_score` or strict `composite` mode.
-4. Build a closed `decisionState` from the minimum sufficient visible signals and source-supported exceptions.
-5. Build the source hash, evidence ledger, and claim references in a grounded bundle.
-6. Run the grounding compiler gate.
-7. Render SVG and HTML only after `PASS`.
-8. Inspect the output for evidence and visual integrity.
+1. Build the adaptive Decision Brief. If data already exists, profile it first; ask 0–5 short questions one at a time and stop as soon as the decision context is sufficient.
+2. Extract verified facts only.
+3. Route metrics with the Metric Router and Action Trigger Test.
+4. Decide whether the evidence supports `no_score` or strict `composite` mode.
+5. Build a closed `decisionState` from the minimum sufficient visible signals and source-supported exceptions.
+6. Build the source hash, evidence ledger, and claim references in a grounded bundle.
+7. Run the grounding compiler gate.
+8. Render SVG and HTML only after `PASS`.
+9. Inspect the output for evidence and visual integrity.
 
 From the skill directory:
 
@@ -283,6 +307,7 @@ decision-first-dashboard/
     │   ├── golden/
     │   ├── grounding.test.js
     │   ├── compile-cli.test.js
+    │   ├── decision-brief-intake-contract.test.js
     │   ├── golden-snapshot.test.js
     │   ├── metric-router-contract.test.js
     │   ├── schema.test.js
@@ -308,7 +333,7 @@ npm run validate:saas
 npm run render:saas
 ```
 
-GitHub Actions runs the complete compiler test suite, including grounded composite/no-score compilation and byte-level golden snapshots, then renders the canonical SaaS and SaaSGrid fixtures and uploads generated artifacts for visual QA.
+GitHub Actions runs the complete compiler test suite, including the Decision Brief intake contract, grounded composite/no-score compilation, and byte-level golden snapshots, then renders the canonical SaaS and SaaSGrid fixtures and uploads generated artifacts for visual QA.
 
 ## What this is not
 
@@ -316,7 +341,7 @@ This is not a generic chart library and not a prompt that asks the model to free
 
 The project separates three responsibilities:
 
-- **Layer 1 / Agent:** evidence extraction, Metric Router classification, and mode proposal.
+- **Layer 1 / Agent:** adaptive Decision Brief, evidence extraction, Metric Router classification, and mode proposal.
 - **Layer 2 / Compiler contract:** source grounding, claim coverage, schema/semantic validation, and machine-readable retry/fallback decisions.
 - **Layer 3 / Renderer:** deterministic SVG/HTML composition only.
 

--- a/skills/decision-first-dashboard/SKILL.md
+++ b/skills/decision-first-dashboard/SKILL.md
@@ -9,9 +9,9 @@ description: Use when redesigning KPI-heavy dashboards where users must scan mul
 
 Separate agent judgment from compiler judgment and deterministic rendering.
 
-**Source → grounded evidence bundle → compiler gate → deterministic renderer → SVG / HTML**
+**Source → Decision Brief → grounded evidence bundle → compiler gate → deterministic renderer → SVG / HTML**
 
-The agent may extract and classify evidence. It may not invent source support, bypass grounding, or choose a free-form dashboard layout.
+The agent may clarify decision intent, extract and classify evidence. It may not invent source support, bypass grounding, or choose a free-form dashboard layout.
 
 ## Three layers
 
@@ -19,6 +19,7 @@ The agent may extract and classify evidence. It may not invent source support, b
 
 The agent may:
 
+- build an adaptive Decision Brief from user context and source structure;
 - extract literal source facts;
 - classify decision roles with the Metric Router;
 - choose a proposed mode;
@@ -53,13 +54,55 @@ It returns one of four machine-readable transitions:
 
 ## Workflow
 
-### 1. Extract verified facts only
+### 1. Build an adaptive Decision Brief
 
-Identify the primary user and decision, then capture only source-supported metrics, deltas, account states, events, targets, thresholds, and score rules.
+Before routing metrics or choosing a visual mode, establish the minimum decision context needed to design the dashboard. Tell the user briefly that better dashboard design requires a few questions. Ask **one question at a time**, ask **no more than five questions**, and **stop immediately once enough information** exists to route metrics and make a defensible design decision. **Never ask for information already provided or inferable** from the user's request or uploaded data.
+
+The five intake dimensions are a question pool, not a fixed questionnaire or mandatory order:
+
+- **Decision** — what should the dashboard help the user determine?
+- **Action** — what decision or action changes when an important signal changes?
+- **Exception** — what condition deserves immediate attention?
+- **Diagnosis** — where should the user investigate next after a problem appears?
+- **Audience / cadence** — who uses the dashboard, how quickly must they understand it, and how often is it reviewed?
+
+After every answer, run an information-sufficiency check. If the known Decision, Action, and the relevant Exception, Diagnosis, or Audience context already provide enough information for the Metric Router, stop. Do not ask all five questions merely for completeness. One to three questions should be sufficient whenever the existing context already covers the remaining dimensions.
+
+Recommended opening, adapted to the user's language:
+
+> To design this dashboard well, I need to understand the decision it should support. I'll ask one question at a time, up to five; if I have enough information earlier, I'll stop.
+
+Question design rules:
+
+- keep each question short, concrete, and limited to one concept;
+- prefer plain language over dashboard, analytics, or business jargon;
+- choose the largest remaining information gap rather than following a fixed sequence;
+- use the uploaded data and prior answers to make choices specific to the user's situation;
+- never repeat a question whose answer is already present in the request, prior answers, or source structure.
+
+If the user is unsure:
+
+1. reduce the open question to **2–4 concrete choices** that are grounded in the known context;
+2. include an explicit “I'm not sure — help me decide” path;
+3. if the user remains unsure, **infer the most defensible answer from the data** and **ask for confirmation**;
+4. if the data cannot support a defensible inference, leave that dimension unresolved and proceed conservatively rather than inventing business intent.
+
+**Do not invent a threshold.** If the user cannot supply one, use only source-backed targets, historical ranges, peer baselines, or explicit rules when they exist. If none exist, do not manufacture an exception threshold or present a statistical anomaly as a business rule without labeling its basis.
+
+Support both intake orders:
+
+- **data-first** — **profile the uploaded data before asking**. Identify fields, metrics, dimensions, time range, available targets/benchmarks, and obvious evidence gaps; then ask only for missing decision context.
+- **question-first** — clarify the decision context first, then **request only the data needed** to support that decision, its likely diagnosis path, relevant exceptions, and evidence mode.
+
+The Decision Brief is internal design context. It may guide metric routing and information hierarchy, but it is not automatically source evidence. User intent, inferred audience needs, or suggested actions must not be represented as source-grounded business facts unless independently supported by the source and allowed by the decision-state contract.
+
+### 2. Extract verified facts only
+
+Identify the primary user and decision from the Decision Brief, then capture only source-supported metrics, deltas, account states, events, targets, thresholds, and score rules.
 
 Never invent scores, targets, thresholds, customer states, events, workflows, actions, or causal claims. Direction is not the same as health.
 
-### 2. Route metrics before choosing a mode
+### 3. Route metrics before choosing a mode
 
 Use the **Metric Router** whenever the source exposes more metrics than a user can reasonably scan at first view. The canonical stress case is **70-KPI overload**: a dashboard may contain roughly 70 valid KPIs, but validity does not make every KPI a first-view peer.
 
@@ -89,7 +132,7 @@ Routing rules:
 - Active `exception` facts may be visible even when they are not part of the central synthesis.
 - The role taxonomy belongs to Layer 1 routing. Do not leak `primary_signal`, `diagnostic`, `exception`, `drilldown`, or `scorecard_only` labels into product UI, and do not add unclaimed hidden metrics to the grounded bundle merely to prove they were preserved. The closed grounded bundle should contain only facts used by the rendered decision state and its required claims.
 
-### 3. Choose the evidence mode
+### 4. Choose the evidence mode
 
 The compiler supports two mutually exclusive decision-state modes.
 
@@ -121,7 +164,7 @@ Three dimensions are sufficient and must render as a triangle. Fewer than three 
 
 Radar is a **profile chart**, not a generic multi-metric chart. Do not connect heterogeneous raw KPIs such as revenue dollars, customer counts, percentages, latency, ratios, or unrelated business outcomes merely because several numbers are available. Do not derive or guess normalization for visual convenience. If a shared source-backed scale is absent, keep the metrics in the non-radar `no_score` expression.
 
-### 4. Build a grounded bundle
+### 5. Build a grounded bundle
 
 The production contract has four top-level fields:
 
@@ -157,7 +200,7 @@ The compiler verifies the source file hash before checking any claim.
 
 Image-only coordinates are not strong composite grounding in V3 because this repository has no deterministic OCR/token extractor. For screenshot inputs, first produce a verifiable text/JSON sidecar. Do not represent an unverified screenshot interpretation as strong composite evidence.
 
-### 5. Required grounding coverage
+### 6. Required grounding coverage
 
 For `composite`, ground all source-dependent scoring facts:
 
@@ -179,7 +222,7 @@ A missing radar-scale or normalized-score claim returns to evidence extraction. 
 
 Do not ground deterministic renderer synthesis as if it were a source fact.
 
-### 6. Compile through the grounding gate
+### 7. Compile through the grounding gate
 
 Production execution is:
 
@@ -196,7 +239,7 @@ On any non-`PASS` transition, it exits non-zero and does not render dashboard ou
 
 Treat `validate.js` and `render.js` as lower-level compiler/renderer tools. Do not use direct rendering as a substitute for the V3 grounded production path.
 
-### 7. Follow failure transitions literally
+### 8. Follow failure transitions literally
 
 - `FIX_DECISION_STATE` → repair contract/schema errors only; do not weaken validation.
 - `RETURN_TO_EVIDENCE_EXTRACTION` → re-read the source and repair evidence/claims.
@@ -242,6 +285,9 @@ Safety, compliance, security, regulatory, contractual, or outage conditions over
 
 Before delivery, verify:
 
+- the Decision Brief contains enough decision context to route metrics, and the intake stopped as soon as that context was sufficient;
+- no more than five questions were asked, one at a time, with no redundant request for information already known or inferable;
+- user uncertainty did not cause invented business intent, thresholds, targets, or source claims;
 - the Metric Router has classified overloaded source metrics before the evidence mode is chosen;
 - the first view contains the minimum sufficient `primary_signal` set plus active source-supported exceptions, rather than a flat KPI inventory;
 - the grounded-bundle schema passes;

--- a/tests/compiler/decision-brief-intake-contract.test.js
+++ b/tests/compiler/decision-brief-intake-contract.test.js
@@ -1,0 +1,40 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const root = process.cwd();
+const skill = fs.readFileSync(path.join(root, 'skills/decision-first-dashboard/SKILL.md'), 'utf8');
+const readme = fs.readFileSync(path.join(root, 'README.md'), 'utf8');
+
+test('skill defines an adaptive Decision Brief that minimizes user cognitive load', () => {
+  assert.match(skill, /Decision Brief/);
+  assert.match(skill, /one question at a time/i);
+  assert.match(skill, /no more than five questions/i);
+  assert.match(skill, /stop immediately once enough information/i);
+  assert.match(skill, /never ask for information already provided or inferable/i);
+
+  for (const dimension of ['Decision', 'Action', 'Exception', 'Diagnosis', 'Audience']) {
+    assert.match(skill, new RegExp(`\\b${dimension}\\b`), `missing ${dimension} intake dimension`);
+  }
+});
+
+test('skill has a guided fallback when the user cannot answer', () => {
+  assert.match(skill, /If the user is unsure/i);
+  assert.match(skill, /2–4 concrete choices/i);
+  assert.match(skill, /infer the most defensible answer from the data/i);
+  assert.match(skill, /ask for confirmation/i);
+  assert.match(skill, /Do not invent a threshold/i);
+});
+
+test('skill supports both data-first and question-first intake without redundant questions', () => {
+  assert.match(skill, /data-first/i);
+  assert.match(skill, /question-first/i);
+  assert.match(skill, /profile the uploaded data before asking/i);
+  assert.match(skill, /request only the data needed/i);
+});
+
+test('README documents Decision Brief before Metric Router', () => {
+  assert.match(readme, /adaptive Decision Brief/i);
+  assert.match(readme, /Decision Brief[\s\S]{0,400}Metric Router/i);
+});


### PR DESCRIPTION
Adds an adaptive pre-dashboard intake contract: one question at a time, at most five, early stop when sufficient, data-first/question-first paths, and guided fallbacks when the user cannot answer. This PR is being implemented test-first; the initial commit intentionally adds the contract test before the Skill changes.