### PR TITLE
Require explicit user intent before skipping Decision Brief questions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Most dashboard prompts ask an LLM to **design**. This project treats dashboard r
 ```text
 source dashboard / verified source file + user context
       ↓
-adaptive Decision Brief (0–5 one-at-a-time questions)
+adaptive Decision Brief (1–5 questions unless Decision + Action are already explicit)
       ↓
 agent extraction + Metric Router + mode proposal
       ↓
@@ -46,16 +46,22 @@ The interaction is deliberately lightweight:
 
 - ask **one question at a time**;
 - ask **no more than five questions**;
-- stop early as soon as the information is sufficient;
-- never ask for information already provided or inferable from the request or uploaded data;
-- treat the five dimensions — Decision, Action, Exception, Diagnosis, and Audience/cadence — as a question pool rather than a fixed questionnaire.
+- stop early as soon as the confirmed information is sufficient;
+- do not ask the user to repeat source facts already visible or extractable from the request/data;
+- treat Decision, Action, Exception, Diagnosis, and Audience/cadence as a question pool rather than a fixed questionnaire.
+
+A critical distinction is enforced: **source facts are not business intent**. A screenshot, uploaded dataset, dashboard title, visible KPI mix, or domain pattern can suggest what the dashboard might be for, but cannot silently establish what the user actually wants to decide. Unless the user has already explicitly supplied both the **Decision** and the **Action**, the skill must ask **at least one question** and get confirmation before routing metrics or rendering.
+
+An inferred intent is only a candidate. The skill can turn that candidate into a short multiple-choice question, but it cannot count the inference itself as a completed Decision Brief.
 
 If the user cannot answer an open question, the skill first reduces it to 2–4 concrete choices. If the user is still unsure, it can infer the most defensible direction from the uploaded data and ask for confirmation. It never invents a business threshold merely to complete the brief.
 
 Both intake orders are supported:
 
-- **data-first** — profile uploaded fields, metrics, dimensions, time range, targets, and benchmarks first, then ask only for missing decision context;
+- **data-first** — profile uploaded fields, metrics, dimensions, time range, targets, and benchmarks first, then ask only for missing decision context; profiling does not waive intent confirmation;
 - **question-first** — clarify the decision context first, then request only the data needed to support that decision and its diagnosis path.
+
+The zero-question path is intentionally narrow: it applies only when the user's request or already-established conversation context explicitly states both what the dashboard should help decide and what action/prioritization changes based on that decision.
 
 The Decision Brief guides the Metric Router and information hierarchy, but it does not weaken source grounding. User intent or inferred needs do not become source evidence unless they are independently supported by the source and allowed by the decision-state contract.
 
@@ -162,7 +168,7 @@ Give the agent a dashboard screenshot, Figma frame, existing dashboard code, or 
 
 The intended production execution path is:
 
-1. Build the adaptive Decision Brief. If data already exists, profile it first; ask 0–5 short questions one at a time and stop as soon as the decision context is sufficient.
+1. Build the adaptive Decision Brief. If data already exists, profile it first. If Decision + Action are not already explicit, ask at least one short confirmation question; ask no more than five and stop as soon as the confirmed decision context is sufficient.
 2. Extract verified facts only.
 3. Route metrics with the Metric Router and Action Trigger Test.
 4. Decide whether the evidence supports `no_score` or strict `composite` mode.

--- a/skills/decision-first-dashboard/SKILL.md
+++ b/skills/decision-first-dashboard/SKILL.md
@@ -56,7 +56,9 @@ It returns one of four machine-readable transitions:
 
 ### 1. Build an adaptive Decision Brief
 
-Before routing metrics or choosing a visual mode, establish the minimum decision context needed to design the dashboard. Tell the user briefly that better dashboard design requires a few questions. Ask **one question at a time**, ask **no more than five questions**, and **stop immediately once enough information** exists to route metrics and make a defensible design decision. **Never ask for information already provided or inferable** from the user's request or uploaded data.
+Before routing metrics or choosing a visual mode, establish the minimum decision context needed to design the dashboard. Tell the user briefly that better dashboard design requires a few questions. Ask **one question at a time**, ask **no more than five questions**, and **stop immediately once enough information** exists to route metrics and make a defensible design decision.
+
+**Intent-confirmation gate:** a screenshot, uploaded dataset, dashboard title, visible KPI mix, domain pattern, or source structure can establish **data facts** and can suggest candidate intent, but a **screenshot alone cannot satisfy the Decision Brief**. Do not treat “this looks like a SaaS health dashboard” as proof that the user wants “overall business health,” “retention,” or any other specific decision. Unless the user has **explicitly stated both the Decision and the Action** in the request or prior conversation, ask **at least one question** and obtain user confirmation before Metric Router classification or rendering.
 
 The five intake dimensions are a question pool, not a fixed questionnaire or mandatory order:
 
@@ -66,7 +68,16 @@ The five intake dimensions are a question pool, not a fixed questionnaire or man
 - **Diagnosis** — where should the user investigate next after a problem appears?
 - **Audience / cadence** — who uses the dashboard, how quickly must they understand it, and how often is it reviewed?
 
-After every answer, run an information-sufficiency check. If the known Decision, Action, and the relevant Exception, Diagnosis, or Audience context already provide enough information for the Metric Router, stop. Do not ask all five questions merely for completeness. One to three questions should be sufficient whenever the existing context already covers the remaining dimensions.
+Use two different notions of “known”:
+
+- **Observed source fact** — directly visible or mechanically extracted from the source. Do not ask the user to repeat it.
+- **Business intent** — Decision, Action, exception policy, diagnosis priority, and audience/cadence. This is confirmed only when explicitly supplied by the user or confirmed by the user after the agent proposes an inferred candidate.
+
+An **inferred candidate requires confirmation**. It may be used to make the next question easier, but it does not count as a confirmed Decision Brief until the user responds. For example, after seeing churn, MRR, and account-cancellation data, ask a concrete question such as: “What should this dashboard help you decide first: overall subscription health, churn/retention risk, revenue growth, or something else?” Do not silently choose one.
+
+After every answer, run an information-sufficiency check. If the confirmed Decision, confirmed Action, and the relevant Exception, Diagnosis, or Audience context provide enough information for the Metric Router, stop. Do not ask all five questions merely for completeness. One to three questions should be sufficient whenever the user has already supplied most of the intent.
+
+The **zero-question path is narrow**: use it only when the user's request or already-established conversation context explicitly states both (1) what the dashboard should help decide and (2) what action or prioritization changes based on that decision. Source data by itself never qualifies for the zero-question path.
 
 Recommended opening, adapted to the user's language:
 
@@ -78,7 +89,8 @@ Question design rules:
 - prefer plain language over dashboard, analytics, or business jargon;
 - choose the largest remaining information gap rather than following a fixed sequence;
 - use the uploaded data and prior answers to make choices specific to the user's situation;
-- never repeat a question whose answer is already present in the request, prior answers, or source structure.
+- never ask the user to repeat **source facts** already present in the request, prior answers, or source structure;
+- do not use “inferable from the data” as a reason to skip confirmation of **business intent**.
 
 If the user is unsure:
 
@@ -91,7 +103,7 @@ If the user is unsure:
 
 Support both intake orders:
 
-- **data-first** — **profile the uploaded data before asking**. Identify fields, metrics, dimensions, time range, available targets/benchmarks, and obvious evidence gaps; then ask only for missing decision context.
+- **data-first** — **profile the uploaded data before asking**. Identify fields, metrics, dimensions, time range, available targets/benchmarks, and obvious evidence gaps; then ask only for missing decision context. Data profiling does not waive the intent-confirmation gate.
 - **question-first** — clarify the decision context first, then **request only the data needed** to support that decision, its likely diagnosis path, relevant exceptions, and evidence mode.
 
 The Decision Brief is internal design context. It may guide metric routing and information hierarchy, but it is not automatically source evidence. User intent, inferred audience needs, or suggested actions must not be represented as source-grounded business facts unless independently supported by the source and allowed by the decision-state contract.
@@ -285,8 +297,9 @@ Safety, compliance, security, regulatory, contractual, or outage conditions over
 
 Before delivery, verify:
 
-- the Decision Brief contains enough decision context to route metrics, and the intake stopped as soon as that context was sufficient;
-- no more than five questions were asked, one at a time, with no redundant request for information already known or inferable;
+- the Decision Brief contains enough **confirmed** decision context to route metrics, and the intake stopped as soon as that context was sufficient;
+- source facts were not mistaken for business intent; if Decision and Action were not explicitly stated beforehand, at least one user-confirmation question was asked;
+- no more than five questions were asked, one at a time, with no redundant request for source information already known;
 - user uncertainty did not cause invented business intent, thresholds, targets, or source claims;
 - the Metric Router has classified overloaded source metrics before the evidence mode is chosen;
 - the first view contains the minimum sufficient `primary_signal` set plus active source-supported exceptions, rather than a flat KPI inventory;

--- a/tests/compiler/decision-brief-intake-contract.test.js
+++ b/tests/compiler/decision-brief-intake-contract.test.js
@@ -34,6 +34,13 @@ test('skill supports both data-first and question-first intake without redundant
   assert.match(skill, /request only the data needed/i);
 });
 
+test('source facts alone cannot silently satisfy user intent', () => {
+  assert.match(skill, /at least one question/i);
+  assert.match(skill, /explicitly stated[^\n]*Decision[^\n]*Action/i);
+  assert.match(skill, /screenshot[^\n]*cannot[^\n]*satisfy[^\n]*Decision Brief/i);
+  assert.match(skill, /inferred candidate[^\n]*confirmation/i);
+});
+
 test('README documents Decision Brief before Metric Router', () => {
   assert.match(readme, /adaptive Decision Brief/i);
   assert.match(readme, /Decision Brief[\s\S]{0,400}Metric Router/i);

--- a/tests/compiler/decision-brief-intake-contract.test.js
+++ b/tests/compiler/decision-brief-intake-contract.test.js
@@ -12,7 +12,8 @@ test('skill defines an adaptive Decision Brief that minimizes user cognitive loa
   assert.match(skill, /one question at a time/i);
   assert.match(skill, /no more than five questions/i);
   assert.match(skill, /stop immediately once enough information/i);
-  assert.match(skill, /never ask for information already provided or inferable/i);
+  assert.match(skill, /never ask the user to repeat[^\n]*source facts/i);
+  assert.match(skill, /do not use[^\n]*inferable from the data[^\n]*skip confirmation[^\n]*business intent/i);
 
   for (const dimension of ['Decision', 'Action', 'Exception', 'Diagnosis', 'Audience']) {
     assert.match(skill, new RegExp(`\\b${dimension}\\b`), `missing ${dimension} intake dimension`);


### PR DESCRIPTION
Regression fix for dashboard screenshot/data-first intake silently inferring Decision, Action, and Audience without asking the user. First commit adds a failing contract test; implementation follows after RED is confirmed.