### PR TITLE
Enforce Metric Router in production compiler

### DIFF
--- a/.github/workflows/compiler-tests.yml
+++ b/.github/workflows/compiler-tests.yml
@@ -35,6 +35,10 @@ jobs:
         run: node skills/decision-first-dashboard/scripts/compile.js tests/compiler/fixtures/grounding/composite.grounded.json tests/compiler/generated/v3-composite
       - name: Compile grounded no-score fixture
         run: node skills/decision-first-dashboard/scripts/compile.js tests/compiler/fixtures/grounding/no-score.grounded.json tests/compiler/generated/v3-no-score
+      - name: Compile routed composite fixture
+        run: node skills/decision-first-dashboard/scripts/compile-dashboard.js tests/compiler/fixtures/routing/composite.routing.json tests/compiler/fixtures/grounding/composite.grounded.json tests/compiler/generated/routed-composite
+      - name: Compile routed no-score fixture
+        run: node skills/decision-first-dashboard/scripts/compile-dashboard.js tests/compiler/fixtures/routing/no-score.routing.json tests/compiler/fixtures/grounding/no-score.grounded.json tests/compiler/generated/routed-no-score
       - uses: actions/upload-artifact@v4
         with:
           name: saas-no-score-render
@@ -47,3 +51,7 @@ jobs:
             tests/compiler/generated/v3-composite/output.composite.html
             tests/compiler/generated/v3-no-score/output.no-score.svg
             tests/compiler/generated/v3-no-score/output.no-score.html
+            tests/compiler/generated/routed-composite/output.composite.svg
+            tests/compiler/generated/routed-composite/output.composite.html
+            tests/compiler/generated/routed-no-score/output.no-score.svg
+            tests/compiler/generated/routed-no-score/output.no-score.html

--- a/README.md
+++ b/README.md
@@ -9,11 +9,13 @@ source dashboard / verified source file + user context
       ↓
 adaptive Decision Brief (1–5 questions unless Decision + Action are already explicit)
       ↓
-agent extraction + Metric Router + mode proposal
+agent extraction + Metric Router
       ↓
-grounded evidence bundle
+Metric Routing Manifest
       ↓
-grounding + decision-state validation
+mode proposal + grounded evidence bundle
+      ↓
+routing gate + grounding + decision-state validation
       ↓
 deterministic renderer
       ↓
@@ -36,7 +38,7 @@ Table
 
 The user still has to scan everything and construct the conclusion mentally.
 
-Decision-First Dashboard changes the information hierarchy first. The agent clarifies the decision context, extracts evidence, and routes metrics; the compiler verifies that the evidence can be mechanically grounded back to source bytes before the deterministic renderer owns the layout.
+Decision-First Dashboard changes the information hierarchy first. The agent clarifies the decision context, extracts evidence, and routes metrics; the production compiler verifies routing discipline and source grounding before the deterministic renderer owns the layout.
 
 ## Adaptive Decision Brief
 
@@ -69,11 +71,24 @@ The Decision Brief guides the Metric Router and information hierarchy, but it do
 
 A source can contain many valid metrics without needing to display them all as peers. The canonical **70-KPI overload** case is routed before rendering using the **Action Trigger Test**: if a metric changes materially, what decision or action changes?
 
-Each metric is classified as `primary_signal`, `diagnostic`, `exception`, `drilldown`, or `scorecard_only`. The first view keeps only the minimum sufficient decision signals plus active exceptions; explanatory, investigative, and completeness metrics stay available in the source/extraction inventory rather than competing for equal visual weight.
+Each metric is classified as `primary_signal`, `diagnostic`, `exception`, `drilldown`, or `scorecard_only`.
 
 > **Preserve everything without showing everything.**
 
-The router is a Layer 1 classification step. It does not weaken the closed grounded-bundle contract or add hidden, unused evidence to the compiler input.
+The complete extracted inventory is preserved in a separate **Metric Routing Manifest** governed by `skills/decision-first-dashboard/schemas/metric-routing.schema.json`. The manifest records the confirmed Decision and Action, `inventoryCount`, and exactly one route per extracted metric.
+
+The compiler enforces routing semantics instead of merely documenting them:
+
+- `inventoryCount` must equal the number of routed metrics; duplicate or missing routes fail.
+- `primary_signal` must pass the Action Trigger Test, declare `decisionImpact`, and remain `first_view`.
+- The current first-view center accepts **3–6 primary signals**. A 70-KPI source does not become a 70-KPI dashboard.
+- The routed primary metric IDs must exactly match the rendered `no_score` signals or `composite` components.
+- `diagnostic` must explain a routed primary signal or exception and remain supporting/on-demand.
+- `drilldown` remains on-demand; `scorecard_only` remains outside the decision-first view.
+- Active exceptions cannot be hidden to make the dashboard look healthier. They must be `first_view` and map through `surfacePath` to an actually rendered exception/event.
+- The current first-view information budget is at most 11 decision items: 3–6 primary signals plus active exceptions.
+
+The routing inventory is intentionally not passed into `render.js`. Hidden diagnostic, drilldown, and scorecard metrics stay preserved for traceability without becoming hidden DOM, eager chart work, or equal-weight visual clutter.
 
 ## Two strict evidence modes
 
@@ -128,29 +143,34 @@ The original `examples/saas/after.png` is retained. `examples/saas/composite-mod
 
 The repository's composite JSON fixture lives under `tests/compiler/fixtures/` and is synthetic contract data used only for automated validation and rendering tests.
 
-## V3 evidence grounding
+## Routing + V3 evidence grounding
 
-V3 adds a hard grounding layer in front of the existing `no_score` / `composite` compiler. A source claim is no longer accepted merely because an agent writes `provenance: "source"`.
+The production path now has two independent hard gates.
 
-The production input is a **grounded bundle** containing:
+**Routing gate:** validates the Metric Routing Manifest before any grounding/rendering work. If routing is invalid, production compilation returns `FIX_METRIC_ROUTING` and emits no SVG/HTML.
+
+**Grounding gate:** verifies that source claims can be mechanically resolved back to source bytes. A source claim is not accepted merely because an agent writes `provenance: "source"`.
+
+The grounded bundle contains:
 
 - a source file path, source kind, and SHA-256;
 - the closed `decisionState`;
 - an evidence ledger;
 - claim references from exact decision-state JSON Pointer paths to evidence IDs.
 
-The compiler supports mechanically verifiable JSON Pointer grounding and exact text-span grounding. Composite scoring facts must all be grounded. Any missing or mismatched composite scoring evidence returns `FALLBACK_TO_NO_SCORE` and produces no composite dashboard.
+The compiler supports mechanically verifiable JSON Pointer grounding and exact text-span grounding. Composite scoring facts must all be grounded. Missing or mismatched composite scoring evidence returns `FALLBACK_TO_NO_SCORE` and produces no composite dashboard.
 
 Machine-readable transitions are:
 
 ```text
 PASS
+FIX_METRIC_ROUTING
 RETURN_TO_EVIDENCE_EXTRACTION
 FALLBACK_TO_NO_SCORE
 FIX_DECISION_STATE
 ```
 
-Image-only/bounding-box claims are not treated as strong composite evidence in V3 because the repository does not currently ship a deterministic OCR/token extractor. Screenshot workflows should first create a verifiable text/JSON sidecar.
+Image-only/bounding-box claims are not treated as strong composite evidence because the repository does not currently ship a deterministic OCR/token extractor. Screenshot workflows should first create a verifiable text/JSON sidecar.
 
 ## Install
 
@@ -158,7 +178,7 @@ Image-only/bounding-box claims are not treated as strong composite evidence in V
 npx skills add fourleaf13-hue/decision-first-dashboard
 ```
 
-The skill directory contains its own schema, validator, templates, and renderer. Runtime validation has no third-party dependency.
+The skill directory contains its own schemas, routing validator, grounding validator, templates, and renderer. Runtime validation has no third-party dependency.
 
 ## Use
 
@@ -170,21 +190,21 @@ The intended production execution path is:
 
 1. Build the adaptive Decision Brief. If data already exists, profile it first. If Decision + Action are not already explicit, ask at least one short confirmation question; ask no more than five and stop as soon as the confirmed decision context is sufficient.
 2. Extract verified facts only.
-3. Route metrics with the Metric Router and Action Trigger Test.
+3. Route every extracted metric with the Metric Router and Action Trigger Test, preserving the complete inventory in a routing manifest.
 4. Decide whether the evidence supports `no_score` or strict `composite` mode.
-5. Build a closed `decisionState` from the minimum sufficient visible signals and source-supported exceptions.
+5. Build a closed `decisionState` from the minimum sufficient visible primary signals and source-supported exceptions.
 6. Build the source hash, evidence ledger, and claim references in a grounded bundle.
-7. Run the grounding compiler gate.
-8. Render SVG and HTML only after `PASS`.
+7. Run the routed production compiler. It validates routing first, then grounding.
+8. Render SVG and HTML only after final `PASS`.
 9. Inspect the output for evidence and visual integrity.
 
 From the skill directory:
 
 ```bash
-node scripts/compile.js path/to/grounded-bundle.json path/to/output-directory
+node scripts/compile-dashboard.js path/to/routing-manifest.json path/to/grounded-bundle.json path/to/output-directory
 ```
 
-`validate.js` and `render.js` remain lower-level Layer 2 / Layer 3 tools for tests and internal compiler use; V3 agent workflows should not bypass `compile.js`.
+`compile.js` remains the lower-level grounding-only compiler for tests and compatibility. `validate.js` and `render.js` remain lower-level Layer 2 / Layer 3 tools. Ordinary Decision-First workflows should not bypass `compile-dashboard.js`.
 
 The renderer writes mode-specific filenames:
 
@@ -195,7 +215,11 @@ composite  → output.composite.svg / output.composite.html
 
 ## Anti-hallucination contract
 
-Both contracts are closed: `grounded-bundle.schema.json` constrains source/evidence/claim structure, and `decision-state.schema.json` constrains mutually exclusive `no_score` and `composite` states.
+Three contracts now work together:
+
+- `metric-routing.schema.json` constrains the Layer 1 routing-manifest shape;
+- `grounded-bundle.schema.json` constrains source/evidence/claim structure;
+- `decision-state.schema.json` constrains mutually exclusive `no_score` and `composite` states.
 
 ### No-score safeguards
 
@@ -247,15 +271,15 @@ Both rendering branches use fixed templates and the same shared visual system.
 ### No-score composition
 
 - one dominant center directional synthesis area;
-- 3–6 signals converging on the center;
-- when all 3–6 peer dimensions have source-grounded normalized scores on one source-grounded shared scale, a true closed radar profile is permitted;
+- 3–6 routed primary signals converging on the center;
+- a radar is permitted only when 3–6 peer dimensions share one source-grounded scale **and** each dimension passes the Action Trigger Test as a `primary_signal`;
 - compact left business context;
 - compact right account exceptions and events.
 
 ### Composite composition
 
 - one dominant center source-supported score and band;
-- 3–6 normalized weighted score components form a true closed radar profile;
+- 3–6 routed normalized weighted score components form a true closed radar profile;
 - compact left score trend and score composition;
 - compact right account exceptions and events.
 
@@ -265,9 +289,11 @@ Both rendering branches use fixed templates and the same shared visual system.
 - no dominant full-width customer table;
 - no invented action buttons;
 - no compiler/framework labels in visible UI;
-- restrained SaaS visual styling.
+- restrained SaaS visual styling;
+- active negative/critical exceptions cannot be cosmetically suppressed;
+- hidden diagnostic/drilldown/scorecard routes are not eagerly rendered.
 
-SVG is the compatibility baseline. HTML/CSS is the higher-fidelity output. Both consume the same validated JSON.
+SVG is the compatibility baseline. HTML/CSS is the higher-fidelity output. Both consume the same validated decision state.
 
 ## Repository structure
 
@@ -289,9 +315,12 @@ decision-first-dashboard/
 │   └── decision-first-dashboard/
 │       ├── SKILL.md
 │       ├── schemas/
+│       │   ├── metric-routing.schema.json
 │       │   ├── grounded-bundle.schema.json
 │       │   └── decision-state.schema.json
 │       ├── scripts/
+│       │   ├── routing.js
+│       │   ├── compile-dashboard.js
 │       │   ├── grounding.js
 │       │   ├── compile.js
 │       │   ├── validate.js
@@ -304,20 +333,25 @@ decision-first-dashboard/
 │       │   └── dashboard.css
 │       └── references/
 │           ├── visual-pattern.md
+│           ├── visual-stack-routing.md
 │           └── after-reference.png
 └── tests/
     ├── compiler/
     │   ├── fixtures/
     │   │   ├── composite.valid.json
-    │   │   └── grounding/
+    │   │   ├── grounding/
+    │   │   └── routing/
     │   ├── golden/
     │   ├── grounding.test.js
     │   ├── compile-cli.test.js
+    │   ├── compile-dashboard.test.js
     │   ├── decision-brief-intake-contract.test.js
     │   ├── golden-snapshot.test.js
     │   ├── metric-router-contract.test.js
+    │   ├── metric-routing.test.js
     │   ├── schema.test.js
     │   ├── composite-schema.test.js
+    │   ├── radar-render.test.js
     │   ├── render-svg.test.js
     │   ├── render-html.test.js
     │   ├── render-composite-svg.test.js
@@ -339,7 +373,7 @@ npm run validate:saas
 npm run render:saas
 ```
 
-GitHub Actions runs the complete compiler test suite, including the Decision Brief intake contract, grounded composite/no-score compilation, and byte-level golden snapshots, then renders the canonical SaaS and SaaSGrid fixtures and uploads generated artifacts for visual QA.
+GitHub Actions runs the complete compiler test suite, including Decision Brief intake, 70-KPI Metric Router behavior, routed production compilation, grounded composite/no-score compilation, and byte-level golden snapshots. It also renders the canonical SaaS and SaaSGrid fixtures and uploads generated artifacts for visual QA.
 
 ## What this is not
 
@@ -347,11 +381,11 @@ This is not a generic chart library and not a prompt that asks the model to free
 
 The project separates three responsibilities:
 
-- **Layer 1 / Agent:** adaptive Decision Brief, evidence extraction, Metric Router classification, and mode proposal.
-- **Layer 2 / Compiler contract:** source grounding, claim coverage, schema/semantic validation, and machine-readable retry/fallback decisions.
+- **Layer 1 / Agent:** adaptive Decision Brief, evidence extraction, Metric Router classification, and routing-manifest creation.
+- **Layer 2 / Compiler contract:** routing semantics, source grounding, claim coverage, schema/semantic validation, and machine-readable retry/fallback decisions.
 - **Layer 3 / Renderer:** deterministic SVG/HTML composition only.
 
-That separation is what makes the output repeatable across agents while making source support auditable.
+That separation is what makes the output repeatable across agents while making routing decisions and source support auditable.
 
 ## License
 

--- a/skills/decision-first-dashboard/SKILL.md
+++ b/skills/decision-first-dashboard/SKILL.md
@@ -9,9 +9,11 @@ description: Use when redesigning KPI-heavy dashboards where users must scan mul
 
 Separate agent judgment from compiler judgment and deterministic rendering.
 
-**Source → Decision Brief → grounded evidence bundle → compiler gate → deterministic renderer → SVG / HTML**
+**Source → Decision Brief → Metric Routing Manifest → grounded evidence bundle → routed compiler gate → deterministic renderer → SVG / HTML**
 
-The agent may clarify decision intent, extract and classify evidence. It may not invent source support, bypass grounding, or choose a free-form dashboard layout.
+The agent may clarify decision intent, extract and classify evidence, and propose routing. It may not invent source support, bypass routing/grounding gates, or choose a free-form dashboard layout during ordinary compilation.
+
+A dashboard earns first-view screen space only when the information can change a decision, trigger an action, surface an exception, explain a primary signal, or support deliberate drill-down.
 
 ## Three layers
 
@@ -21,36 +23,43 @@ The agent may:
 
 - build an adaptive Decision Brief from user context and source structure;
 - extract literal source facts;
-- classify decision roles with the Metric Router;
-- choose a proposed mode;
+- classify every extracted metric with the Metric Router;
+- produce a Metric Routing Manifest;
+- choose a proposed evidence mode;
 - create evidence anchors and claim references.
 
 The agent must not render UI or fabricate score-model evidence.
 
 ### Layer 2 — Compiler contract
 
-Code decides whether the grounded bundle can proceed.
+Code decides whether routing and grounding can proceed.
 
-The compiler validates:
+The production compiler validates, in order:
 
-- the closed grounded-bundle contract;
-- the closed `decision-state` contract;
-- source file SHA-256;
-- evidence reference integrity;
-- exact JSON Pointer or text-span grounding;
-- required claim coverage;
-- composite score mathematics and score-band semantics.
+1. the Metric Routing Manifest and its semantic rules;
+2. exact agreement between routed `primary_signal` metrics and the visible center metrics/components;
+3. active-exception surfacing rules;
+4. the closed grounded-bundle contract;
+5. the closed `decision-state` contract;
+6. source file SHA-256;
+7. evidence reference integrity;
+8. exact JSON Pointer or text-span grounding;
+9. required claim coverage;
+10. composite score mathematics and score-band semantics.
 
-It returns one of four machine-readable transitions:
+Machine-readable transitions are:
 
 - `PASS`;
+- `FIX_METRIC_ROUTING`;
 - `RETURN_TO_EVIDENCE_EXTRACTION`;
 - `FALLBACK_TO_NO_SCORE`;
 - `FIX_DECISION_STATE`.
 
 ### Layer 3 — Deterministic renderer
 
-`render.js` consumes only validated decision state and fills fixed SVG/HTML templates. It does not inspect source data or invent business meaning.
+`render.js` consumes only validated decision state and fills fixed SVG/HTML templates. It does not inspect the hidden routing inventory, source data, or invent business meaning.
+
+Keeping hidden routing inventory out of the renderer is intentional: metrics assigned to `diagnostic`, `drilldown`, or `scorecard_only` stay preserved for traceability without becoming hidden DOM, eager chart work, or first-view clutter.
 
 ## Workflow
 
@@ -58,9 +67,9 @@ It returns one of four machine-readable transitions:
 
 Before routing metrics or choosing a visual mode, establish the minimum decision context needed to design the dashboard. Tell the user briefly that better dashboard design requires a few questions. Ask **one question at a time**, ask **no more than five questions**, and **stop immediately once enough information** exists to route metrics and make a defensible design decision.
 
-**Intent-confirmation gate:** a screenshot, uploaded dataset, dashboard title, visible KPI mix, domain pattern, or source structure can establish **data facts** and can suggest candidate intent, but a **screenshot alone cannot satisfy the Decision Brief**. Do not treat “this looks like a SaaS health dashboard” as proof that the user wants “overall business health,” “retention,” or any other specific decision. Unless the user has **explicitly stated both the Decision and the Action** in the request or prior conversation, ask **at least one question** and obtain user confirmation before Metric Router classification or rendering.
+**Intent-confirmation gate:** a screenshot, uploaded dataset, dashboard title, visible KPI mix, domain pattern, or source structure can establish data facts and suggest candidate intent, but a **screenshot alone cannot satisfy the Decision Brief**. Unless the user has **explicitly stated both the Decision and the Action** in the request or prior conversation, ask **at least one question** and obtain user confirmation before Metric Router classification or rendering.
 
-The five intake dimensions are a question pool, not a fixed questionnaire or mandatory order:
+The five intake dimensions are a question pool, not a fixed questionnaire:
 
 - **Decision** — what should the dashboard help the user determine?
 - **Action** — what decision or action changes when an important signal changes?
@@ -68,45 +77,32 @@ The five intake dimensions are a question pool, not a fixed questionnaire or man
 - **Diagnosis** — where should the user investigate next after a problem appears?
 - **Audience / cadence** — who uses the dashboard, how quickly must they understand it, and how often is it reviewed?
 
-Use two different notions of “known”:
+Use two notions of “known”:
 
-- **Observed source fact** — directly visible or mechanically extracted from the source. Do not ask the user to repeat it.
+- **Observed source fact** — directly visible or mechanically extracted from source. Never ask the user to repeat source facts already present in the request, prior answers, or source structure.
 - **Business intent** — Decision, Action, exception policy, diagnosis priority, and audience/cadence. This is confirmed only when explicitly supplied by the user or confirmed by the user after the agent proposes an inferred candidate.
 
-An **inferred candidate requires confirmation**. It may be used to make the next question easier, but it does not count as a confirmed Decision Brief until the user responds. For example, after seeing churn, MRR, and account-cancellation data, ask a concrete question such as: “What should this dashboard help you decide first: overall subscription health, churn/retention risk, revenue growth, or something else?” Do not silently choose one.
+An **inferred candidate requires confirmation**. It may make the next question easier, but it does not count as a completed Decision Brief until the user responds. Do not use “inferable from the data” as a reason to skip confirmation of business intent.
 
-After every answer, run an information-sufficiency check. If the confirmed Decision, confirmed Action, and the relevant Exception, Diagnosis, or Audience context provide enough information for the Metric Router, stop. Do not ask all five questions merely for completeness. One to three questions should be sufficient whenever the user has already supplied most of the intent.
+After every answer, run an information-sufficiency check. If the confirmed Decision, confirmed Action, and relevant Exception, Diagnosis, or Audience context provide enough information for routing, stop. Do not ask all five questions merely for completeness.
 
-The **zero-question path is narrow**: use it only when the user's request or already-established conversation context explicitly states both (1) what the dashboard should help decide and (2) what action or prioritization changes based on that decision. Source data by itself never qualifies for the zero-question path.
-
-Recommended opening, adapted to the user's language:
-
-> To design this dashboard well, I need to understand the decision it should support. I'll ask one question at a time, up to five; if I have enough information earlier, I'll stop.
-
-Question design rules:
-
-- keep each question short, concrete, and limited to one concept;
-- prefer plain language over dashboard, analytics, or business jargon;
-- choose the largest remaining information gap rather than following a fixed sequence;
-- use the uploaded data and prior answers to make choices specific to the user's situation;
-- never ask the user to repeat **source facts** already present in the request, prior answers, or source structure;
-- do not use “inferable from the data” as a reason to skip confirmation of **business intent**.
+The zero-question path is narrow: use it only when the user's request or already-established conversation context explicitly states both what the dashboard should help decide and what action/prioritization changes based on that decision. Source data by itself never qualifies.
 
 If the user is unsure:
 
-1. reduce the open question to **2–4 concrete choices** that are grounded in the known context;
+1. reduce the open question to **2–4 concrete choices** grounded in known context;
 2. include an explicit “I'm not sure — help me decide” path;
-3. if the user remains unsure, **infer the most defensible answer from the data** and **ask for confirmation**;
-4. if the data cannot support a defensible inference, leave that dimension unresolved and proceed conservatively rather than inventing business intent.
+3. if uncertainty remains, **infer the most defensible answer from the data** and **ask for confirmation**;
+4. if the data cannot support a defensible inference, leave that dimension unresolved and proceed conservatively.
 
-**Do not invent a threshold.** If the user cannot supply one, use only source-backed targets, historical ranges, peer baselines, or explicit rules when they exist. If none exist, do not manufacture an exception threshold or present a statistical anomaly as a business rule without labeling its basis.
+**Do not invent a threshold.** Use only source-backed targets, historical ranges, peer baselines, or explicit rules when they exist.
 
 Support both intake orders:
 
-- **data-first** — **profile the uploaded data before asking**. Identify fields, metrics, dimensions, time range, available targets/benchmarks, and obvious evidence gaps; then ask only for missing decision context. Data profiling does not waive the intent-confirmation gate.
-- **question-first** — clarify the decision context first, then **request only the data needed** to support that decision, its likely diagnosis path, relevant exceptions, and evidence mode.
+- **data-first** — **profile the uploaded data before asking**. Identify fields, metrics, dimensions, time range, targets/benchmarks, and evidence gaps; then ask only for missing decision context.
+- **question-first** — clarify the decision context first, then **request only the data needed** to support that decision, its diagnosis path, relevant exceptions, and evidence mode.
 
-The Decision Brief is internal design context. It may guide metric routing and information hierarchy, but it is not automatically source evidence. User intent, inferred audience needs, or suggested actions must not be represented as source-grounded business facts unless independently supported by the source and allowed by the decision-state contract.
+The Decision Brief is internal design context. It may guide routing and information hierarchy, but it is not automatically source evidence.
 
 ### 2. Extract verified facts only
 
@@ -114,47 +110,61 @@ Identify the primary user and decision from the Decision Brief, then capture onl
 
 Never invent scores, targets, thresholds, customer states, events, workflows, actions, or causal claims. Direction is not the same as health.
 
-### 3. Route metrics before choosing a mode
+### 3. Route every extracted metric
 
-Use the **Metric Router** whenever the source exposes more metrics than a user can reasonably scan at first view. The canonical stress case is **70-KPI overload**: a dashboard may contain roughly 70 valid KPIs, but validity does not make every KPI a first-view peer.
+Use the **Metric Router** whenever the source exposes more metrics than a user can reasonably scan at first view. The canonical stress case is **70-KPI overload**: a source may contain roughly 70 valid KPIs, but validity does not make every KPI a first-view peer.
 
 > **Preserve everything without showing everything.**
 
-Preserve the complete source/extraction inventory for traceability. Route each metric to exactly one decision role before constructing the visible decision state:
+Preserve the full extracted metric inventory in a separate routing manifest. The manifest must match:
 
-- `primary_signal` — directly changes the main decision or next action; eligible for first-view emphasis.
-- `diagnostic` — explains why a primary signal moved or why the current state exists; supporting context, not a peer headline by default.
-- `exception` — a source-supported breach, outlier, critical account/event, or hard-stop condition that requires attention even when the summary looks acceptable.
-- `drilldown` — useful investigation detail that should be available on demand rather than occupying the default composition.
-- `scorecard_only` — retained for completeness, audit, or secondary scorecard use, but not promoted to the decision-first view unless the user explicitly requests it.
+`schemas/metric-routing.schema.json`
+
+It contains confirmed `decision`, confirmed `action`, `inventoryCount`, and one routing entry per extracted metric. `inventoryCount` must equal the number of routing entries; duplicate or missing metric routes are invalid.
+
+Route each metric to exactly one role:
+
+- `primary_signal` — directly changes the main decision or next action;
+- `diagnostic` — explains a routed primary signal or exception;
+- `exception` — a breach, outlier, critical account/event, or hard-stop condition requiring attention;
+- `drilldown` — useful only after deliberate investigation begins;
+- `scorecard_only` — retained for completeness, audit, or secondary scorecard use, but not promoted to the decision-first view.
 
 Apply the **Action Trigger Test** to every candidate metric:
 
 1. If this metric changes materially, does the user's decision or action change?
-2. If yes in the normal decision loop, route it to `primary_signal`.
-3. If it requires attention because a threshold, safety, compliance, contractual, outage, or other critical condition is breached, route it to `exception`; exceptions override ordinary synthesis rather than being averaged away.
-4. If it mainly explains a primary signal, route it to `diagnostic`.
-5. If it matters only after the user chooses to investigate, route it to `drilldown`.
+2. If yes in the ordinary decision loop, route it to `primary_signal` and state the `decisionImpact`.
+3. If a threshold, safety, compliance, contractual, outage, or other critical condition is breached, route it to `exception`.
+4. If it mainly explains a primary signal or exception, route it to `diagnostic` and identify what it `explains`.
+5. If it matters only after investigation begins, route it to `drilldown`.
 6. If no decision, action, diagnosis, or exception handling changes, route it to `scorecard_only`.
 
-Routing rules:
+Compiler-enforced routing rules:
 
+- `primary_signal` must have `changesDecision: true`, a non-empty `decisionImpact`, and `visibility: "first_view"`.
+- The current deterministic renderer accepts **3–6 primary signals**; more than six fails the first-view information budget instead of silently squeezing more KPI peers into the layout.
+- The routed `primary_signal` metric IDs must exactly equal `decisionState.signals[*].metric` in `no_score`, or `decisionState.model.components[*].metric` in `composite`.
+- `diagnostic` metrics must have `changesDecision: false`, must point via `explains` to a routed `primary_signal` or `exception`, and must stay `supporting` or `on_demand`.
+- `drilldown` metrics must stay `on_demand`.
+- `scorecard_only` metrics must stay `scorecard` and cannot claim to change the current decision.
+- **Active exceptions cannot be hidden** because a stakeholder dislikes red or negative states. An active exception must use `visibility: "first_view"` and its `surfacePath` must resolve to an actually rendered `/exceptions/<n>` or `/events/<n>` item in the decision state.
+- Current first-view information budget is at most 11 decision items: 3–6 primary signals plus active exceptions. Do not solve overload by shrinking type or adding more equal-weight cards.
 - Do not promote a metric because it is easy to visualize, numerically large, or already placed in a KPI card.
-- Prefer the minimum sufficient set of `primary_signal` metrics. The current deterministic no-score renderer supports 3–6 visible signals; when the source contains more, route the remainder to `diagnostic`, `exception`, `drilldown`, or `scorecard_only` instead of deleting source evidence.
-- Active `exception` facts may be visible even when they are not part of the central synthesis.
-- The role taxonomy belongs to Layer 1 routing. Do not leak `primary_signal`, `diagnostic`, `exception`, `drilldown`, or `scorecard_only` labels into product UI, and do not add unclaimed hidden metrics to the grounded bundle merely to prove they were preserved. The closed grounded bundle should contain only facts used by the rendered decision state and its required claims.
+- Do not leak role labels such as `primary_signal` or `scorecard_only` into product UI.
+
+The routing manifest is a durable decision trace. It preserves what was considered, why it was promoted or demoted, and what would change the decision, so later analysis does not have to rediscover the same KPI-prioritization logic from scratch.
 
 ### 4. Choose the evidence mode
 
 The compiler supports two mutually exclusive decision-state modes.
 
-Use `composite` only when the source already provides **all** of the following:
+Use `composite` only when the source already provides all of the following:
 
 - an overall score and score scale;
 - normalized component scores;
 - component weights;
 - a weighted-average aggregation rule;
-- complete score bands / thresholds that determine the displayed status.
+- complete score bands / thresholds that determine displayed status.
 
 Composite accepts only:
 
@@ -162,23 +172,30 @@ Composite accepts only:
 - `aggregation: "weighted_average"`;
 - source-grounded score, component, weight, band, exception, event, and trend facts.
 
-If any required composite scoring fact cannot be mechanically grounded, the transition is `FALLBACK_TO_NO_SCORE`. Do not fill the gap with an inferred formula, guessed weight, or benchmark.
+If any required composite scoring fact cannot be mechanically grounded, transition to `FALLBACK_TO_NO_SCORE`. Do not fill gaps with inferred formulas, guessed weights, or invented benchmarks.
 
 For `no_score`, do not create `Healthy`, `Marginal`, `At risk`, or a 0–100 overall score. Overall direction remains a deterministic renderer derivation from validated signal directions.
 
-**Radar eligibility is independent of overall-score eligibility.** A `no_score` dashboard may render a closed radar profile only when the source explicitly provides all of the following:
+**Radar eligibility is independent of overall-score eligibility.** A `no_score` dashboard may render a closed radar profile only when the source explicitly provides:
 
-- **3–6 peer dimensions** that describe the same object or condition as one profile;
+- **3–6 peer dimensions** describing the same object or condition as one profile;
 - one shared, source-backed numeric scale in `radarScale.min` / `radarScale.max`;
-- a source-backed `normalizedScore` for every displayed dimension.
+- a source-grounded `normalizedScore` for every displayed dimension.
 
-Three dimensions are sufficient and must render as a triangle. Fewer than three dimensions are not radar-eligible. Four to six dimensions render with the corresponding number of vertices.
+Three dimensions are sufficient and render as a triangle. **Fewer than three dimensions are not radar-eligible.** Four to six dimensions render with the corresponding number of vertices.
 
-Radar is a **profile chart**, not a generic multi-metric chart. Do not connect heterogeneous raw KPIs such as revenue dollars, customer counts, percentages, latency, ratios, or unrelated business outcomes merely because several numbers are available. Do not derive or guess normalization for visual convenience. If a shared source-backed scale is absent, keep the metrics in the non-radar `no_score` expression.
+Radar is a profile chart, not a generic multi-metric chart. Do not connect heterogeneous raw KPIs such as revenue dollars, customer counts, percentages, latency, ratios, or unrelated business outcomes merely because several numbers exist.
+
+A radar must pass two gates:
+
+- **Profile Test** — 3–6 peer dimensions, same object, same grounded scale;
+- **Action Trigger Test** — every displayed radar dimension must also be a routed `primary_signal`, meaning a material change can alter the confirmed decision or action.
+
+If the Profile Test passes but the Action Trigger Test fails, keep those dimensions in diagnostic/drilldown/scorecard layers instead of using a decorative radar as the dominant visual.
 
 ### 5. Build a grounded bundle
 
-The production contract has four top-level fields:
+The grounded bundle remains separate from the routing inventory and contains only facts used by the rendered decision state:
 
 ```json
 {
@@ -193,24 +210,16 @@ The production contract has four top-level fields:
 }
 ```
 
-The envelope must match:
+The envelope must match `schemas/grounded-bundle.schema.json` and `decisionState` must independently match `schemas/decision-state.schema.json`.
 
-`schemas/grounded-bundle.schema.json`
-
-`decisionState` must independently match:
-
-`schemas/decision-state.schema.json`
-
-`evidence` is a ledger of source anchors. `claims` maps exact decision-state JSON Pointer paths to evidence IDs.
-
-Supported source grounding in V3:
+Supported source grounding:
 
 - JSON source → `json_pointer` anchor;
 - text source → exact `text_span` anchor with `literal` and `valueText`.
 
-The compiler verifies the source file hash before checking any claim.
+The compiler verifies the source file hash before accepting source claims.
 
-Image-only coordinates are not strong composite grounding in V3 because this repository has no deterministic OCR/token extractor. For screenshot inputs, first produce a verifiable text/JSON sidecar. Do not represent an unverified screenshot interpretation as strong composite evidence.
+Image-only coordinates are not strong composite grounding because this repository has no deterministic OCR/token extractor. For screenshot inputs, first produce a verifiable text/JSON sidecar.
 
 ### 6. Required grounding coverage
 
@@ -232,41 +241,42 @@ For a `no_score` radar, additionally ground:
 
 A missing radar-scale or normalized-score claim returns to evidence extraction. Do not silently fall back to an ungrounded radar.
 
-Do not ground deterministic renderer synthesis as if it were a source fact.
+Do not ground deterministic renderer synthesis or Metric Router role decisions as if they were source facts.
 
-### 7. Compile through the grounding gate
+### 7. Compile through both gates
 
 Production execution is:
 
 ```bash
-node scripts/compile.js <grounded-bundle.json> <output-dir>
+node scripts/compile-dashboard.js <routing-manifest.json> <grounded-bundle.json> <output-dir>
 ```
 
-On `PASS`, the CLI writes:
+The production gate runs Metric Router validation first. On routing failure it returns `FIX_METRIC_ROUTING` and produces no SVG/HTML. Only after routing passes does it run the existing grounding compiler.
+
+On final `PASS`, the CLI writes:
 
 - `no_score` → `output.no-score.svg` and `output.no-score.html`;
 - `composite` → `output.composite.svg` and `output.composite.html`.
 
-On any non-`PASS` transition, it exits non-zero and does not render dashboard output.
-
-Treat `validate.js` and `render.js` as lower-level compiler/renderer tools. Do not use direct rendering as a substitute for the V3 grounded production path.
+`compile.js` remains the lower-level grounding-only compiler for tests and internal compatibility. `validate.js` and `render.js` remain lower-level Layer 2 / Layer 3 tools. Do not use these lower-level entry points as a substitute for `compile-dashboard.js` in ordinary Decision-First production workflows.
 
 ### 8. Follow failure transitions literally
 
+- `FIX_METRIC_ROUTING` → repair routing roles, action-trigger logic, first-view budget, primary/visible mismatch, or exception surfacing; do not bypass the gate.
 - `FIX_DECISION_STATE` → repair contract/schema errors only; do not weaken validation.
-- `RETURN_TO_EVIDENCE_EXTRACTION` → re-read the source and repair evidence/claims.
-- `FALLBACK_TO_NO_SCORE` → abandon composite and rebuild a grounded no-score state from available evidence.
+- `RETURN_TO_EVIDENCE_EXTRACTION` → re-read source and repair evidence/claims.
+- `FALLBACK_TO_NO_SCORE` → abandon unsupported composite scoring and rebuild a grounded no-score state.
 - `PASS` → render deterministically.
 
-Do not turn a failed grounding check into an invitation to guess.
+Do not turn a failed routing or grounding check into an invitation to guess.
 
 ## Visual contract
 
-The renderer owns the layout.
+The renderer owns layout after routing and grounding have passed.
 
 For `no_score`:
 
-- when all 3–6 peer dimensions have source-grounded `normalizedScore` values on one source-grounded `radarScale`, render a true closed radar profile;
+- when all 3–6 routed primary dimensions have grounded `normalizedScore` values on one grounded `radarScale`, render a true closed radar profile;
 - otherwise use the non-radar signal layout and never connect heterogeneous raw KPI values into a fake radar;
 - compact left business context;
 - compact right exceptions/events.
@@ -274,41 +284,47 @@ For `no_score`:
 For `composite`:
 
 - dominant center source-supported score and band;
-- 3–6 normalized weighted components form a true closed radar profile;
+- 3–6 routed normalized weighted components form a true closed radar profile;
 - compact left score trend and score composition;
 - compact right exceptions/events.
 
 For both modes:
 
-- no four-card KPI strip;
+- no flat KPI wall;
 - no dominant full-width customer table;
 - no invented action controls;
 - product-native labels only;
 - no compiler/framework methodology labels in visible UI;
-- restrained color and generous whitespace.
+- restrained color and generous whitespace;
+- negative or critical states may not be cosmetically suppressed;
+- hidden diagnostic/drilldown/scorecard routes are not rendered eagerly.
 
-See `references/visual-pattern.md`.
+See `references/visual-pattern.md` and `references/visual-stack-routing.md`.
 
 ## Hard stops
 
-Safety, compliance, security, regulatory, contractual, or outage conditions override ordinary synthesis. Never average them into a reassuring status. Do not force a hard-stop case through the current SaaS renderers.
+Safety, compliance, security, regulatory, contractual, or outage conditions override ordinary synthesis. Never average them into a reassuring status. Never hide them because a stakeholder wants the dashboard to look more positive.
 
 ## Final gate
 
 Before delivery, verify:
 
-- the Decision Brief contains enough **confirmed** decision context to route metrics, and the intake stopped as soon as that context was sufficient;
+- the Decision Brief contains enough confirmed decision context to route metrics, and intake stopped as soon as that context was sufficient;
 - source facts were not mistaken for business intent; if Decision and Action were not explicitly stated beforehand, at least one user-confirmation question was asked;
 - no more than five questions were asked, one at a time, with no redundant request for source information already known;
 - user uncertainty did not cause invented business intent, thresholds, targets, or source claims;
-- the Metric Router has classified overloaded source metrics before the evidence mode is chosen;
-- the first view contains the minimum sufficient `primary_signal` set plus active source-supported exceptions, rather than a flat KPI inventory;
+- `schemas/metric-routing.schema.json` is respected;
+- `inventoryCount` equals the routed metric inventory and no metric is duplicated or omitted;
+- every `primary_signal` passes the Action Trigger Test and the visible center matches the primary set exactly;
+- diagnostics explain routed primary/exception items rather than competing as peer headlines;
+- active exceptions cannot be hidden and every active exception has a valid rendered `surfacePath`;
+- the first-view information budget is respected instead of shrinking typography or adding equal-weight KPI cards;
 - the grounded-bundle schema passes;
-- the source SHA-256 matches the actual source bytes;
+- source SHA-256 matches actual source bytes;
 - every required visible/source scoring fact has a resolvable claim and evidence anchor;
 - every grounded value matches the referenced decision-state value under allowed deterministic normalization only;
-- `no_score` overall direction matches the signal directions;
-- a `no_score` radar appears only for 3–6 peer dimensions with a source-grounded shared scale and a grounded normalized score for every vertex;
+- `no_score` overall direction matches signal directions;
+- a `no_score` radar passes both the Profile Test and Action Trigger Test;
 - raw mixed-unit KPIs never masquerade as radar dimensions;
 - `composite` weights, weighted score, score scale, and score band pass semantic validation;
 - no unsupported score/status/target/action appears;

--- a/skills/decision-first-dashboard/schemas/metric-routing.schema.json
+++ b/skills/decision-first-dashboard/schemas/metric-routing.schema.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["decision", "action", "inventoryCount", "metrics"],
+  "properties": {
+    "decision": { "type": "string", "minLength": 1, "maxLength": 240 },
+    "action": { "type": "string", "minLength": 1, "maxLength": 240 },
+    "inventoryCount": { "type": "integer", "minimum": 1, "maximum": 200 },
+    "metrics": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 200,
+      "items": { "$ref": "#/definitions/metricRoute" }
+    }
+  },
+  "definitions": {
+    "metricRoute": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["metric", "role", "changesDecision", "visibility"],
+      "properties": {
+        "metric": { "type": "string", "pattern": "^[a-z0-9_]{1,64}$" },
+        "role": {
+          "enum": ["primary_signal", "diagnostic", "exception", "drilldown", "scorecard_only"]
+        },
+        "changesDecision": { "type": "boolean" },
+        "decisionImpact": { "type": "string", "minLength": 1, "maxLength": 240 },
+        "visibility": {
+          "enum": ["first_view", "supporting", "on_demand", "scorecard"]
+        },
+        "explains": { "type": "string", "pattern": "^[a-z0-9_]{1,64}$" },
+        "active": { "type": "boolean" },
+        "surfacePath": { "type": "string", "pattern": "^/(exceptions|events)/[0-9]+$" }
+      }
+    }
+  }
+}

--- a/skills/decision-first-dashboard/scripts/compile-dashboard.js
+++ b/skills/decision-first-dashboard/scripts/compile-dashboard.js
@@ -1,0 +1,68 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { compileGroundedBundle } from './compile.js';
+import { validateMetricRouting } from './routing.js';
+
+const currentFile = fileURLToPath(import.meta.url);
+
+export function compileDecisionDashboard(routingManifest, bundle, { baseDir = process.cwd() } = {}) {
+  const routing = validateMetricRouting(routingManifest, bundle?.decisionState);
+  if (!routing.valid) {
+    return {
+      result: {
+        valid: false,
+        stage: 'routing',
+        transition: 'FIX_METRIC_ROUTING',
+        errors: routing.errors,
+        routingSummary: routing.summary
+      },
+      svg: null,
+      html: null,
+      outputMode: null
+    };
+  }
+
+  const compiled = compileGroundedBundle(bundle, { baseDir });
+  return {
+    ...compiled,
+    result: {
+      ...compiled.result,
+      routingSummary: routing.summary
+    }
+  };
+}
+
+if (process.argv[1] === currentFile) {
+  const routingPath = process.argv[2];
+  const bundlePath = process.argv[3];
+  const outputDir = process.argv[4] ?? path.dirname(bundlePath ?? '.');
+
+  if (!routingPath || !bundlePath) {
+    process.stderr.write(`${JSON.stringify({
+      valid: false,
+      stage: 'routing',
+      transition: 'FIX_METRIC_ROUTING',
+      errors: [{ code: 'ROUTING_MANIFEST_INVALID', path: '', message: 'Usage: node compile-dashboard.js <routing-manifest.json> <grounded-bundle.json> [output-dir]' }]
+    })}\n`);
+    process.exit(2);
+  }
+
+  const absoluteRouting = path.resolve(routingPath);
+  const absoluteBundle = path.resolve(bundlePath);
+  const routingManifest = JSON.parse(fs.readFileSync(absoluteRouting, 'utf8'));
+  const bundle = JSON.parse(fs.readFileSync(absoluteBundle, 'utf8'));
+  const compiled = compileDecisionDashboard(routingManifest, bundle, { baseDir: path.dirname(absoluteBundle) });
+
+  if (!compiled.result.valid) {
+    process.stderr.write(`${JSON.stringify(compiled.result)}\n`);
+    process.exit(1);
+  }
+
+  fs.mkdirSync(outputDir, { recursive: true });
+  const svgOutput = path.join(outputDir, `output.${compiled.outputMode}.svg`);
+  const htmlOutput = path.join(outputDir, `output.${compiled.outputMode}.html`);
+  fs.writeFileSync(svgOutput, compiled.svg);
+  fs.writeFileSync(htmlOutput, compiled.html);
+  process.stdout.write(`${svgOutput}\n${htmlOutput}\n`);
+}

--- a/skills/decision-first-dashboard/scripts/routing.js
+++ b/skills/decision-first-dashboard/scripts/routing.js
@@ -1,3 +1,10 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { validateAgainstSchema } from './validate.js';
+
+const currentDir = path.dirname(fileURLToPath(import.meta.url));
+const routingSchema = JSON.parse(fs.readFileSync(path.resolve(currentDir, '../schemas/metric-routing.schema.json'), 'utf8'));
 const ROLES = new Set(['primary_signal', 'diagnostic', 'exception', 'drilldown', 'scorecard_only']);
 const VISIBILITIES = new Set(['first_view', 'supporting', 'on_demand', 'scorecard']);
 
@@ -31,6 +38,19 @@ function sameSet(a, b) {
 }
 
 export function validateMetricRouting(manifest, decisionState) {
+  const schemaResult = validateAgainstSchema(manifest, routingSchema);
+  if (!schemaResult.valid) {
+    return {
+      valid: false,
+      errors: schemaResult.errors.map((error) => ({
+        code: 'ROUTING_SCHEMA_INVALID',
+        path: error.instancePath,
+        message: `${error.keyword}: ${error.message}`
+      })),
+      summary: null
+    };
+  }
+
   const errors = [];
   if (!manifest || typeof manifest !== 'object' || Array.isArray(manifest)) {
     return { valid: false, errors: [{ code: 'ROUTING_MANIFEST_INVALID', path: '', message: 'routing manifest must be an object' }], summary: null };

--- a/skills/decision-first-dashboard/scripts/routing.js
+++ b/skills/decision-first-dashboard/scripts/routing.js
@@ -1,0 +1,134 @@
+const ROLES = new Set(['primary_signal', 'diagnostic', 'exception', 'drilldown', 'scorecard_only']);
+const VISIBILITIES = new Set(['first_view', 'supporting', 'on_demand', 'scorecard']);
+
+function add(errors, code, path, message) {
+  errors.push({ code, path, message });
+}
+
+function visibleMetricIds(decisionState) {
+  if (!decisionState || typeof decisionState !== 'object') return [];
+  if (decisionState.mode === 'no_score') return (decisionState.signals ?? []).map((item) => item.metric).filter(Boolean);
+  if (decisionState.mode === 'composite') return (decisionState.model?.components ?? []).map((item) => item.metric).filter(Boolean);
+  return [];
+}
+
+function resolvePointer(root, pointer) {
+  if (typeof pointer !== 'string' || !pointer.startsWith('/')) return { found: false };
+  let node = root;
+  for (const raw of pointer.slice(1).split('/')) {
+    const key = raw.replaceAll('~1', '/').replaceAll('~0', '~');
+    if (node === null || typeof node !== 'object' || !Object.hasOwn(node, key)) return { found: false };
+    node = node[key];
+  }
+  return { found: true, value: node };
+}
+
+function sameSet(a, b) {
+  if (a.length !== b.length) return false;
+  const left = new Set(a);
+  if (left.size !== a.length) return false;
+  return b.every((item) => left.has(item));
+}
+
+export function validateMetricRouting(manifest, decisionState) {
+  const errors = [];
+  if (!manifest || typeof manifest !== 'object' || Array.isArray(manifest)) {
+    return { valid: false, errors: [{ code: 'ROUTING_MANIFEST_INVALID', path: '', message: 'routing manifest must be an object' }], summary: null };
+  }
+
+  if (typeof manifest.decision !== 'string' || manifest.decision.trim().length === 0) add(errors, 'DECISION_REQUIRED', '/decision', 'confirmed decision is required');
+  if (typeof manifest.action !== 'string' || manifest.action.trim().length === 0) add(errors, 'ACTION_REQUIRED', '/action', 'confirmed action is required');
+  if (!Number.isInteger(manifest.inventoryCount) || manifest.inventoryCount < 1 || manifest.inventoryCount > 200) add(errors, 'INVENTORY_COUNT_INVALID', '/inventoryCount', 'inventoryCount must be an integer from 1 to 200');
+  if (!Array.isArray(manifest.metrics) || manifest.metrics.length === 0 || manifest.metrics.length > 200) {
+    add(errors, 'ROUTING_METRICS_INVALID', '/metrics', 'metrics must contain 1 to 200 routing entries');
+  }
+
+  const metrics = Array.isArray(manifest.metrics) ? manifest.metrics : [];
+  if (Number.isInteger(manifest.inventoryCount) && manifest.inventoryCount !== metrics.length) {
+    add(errors, 'INVENTORY_COUNT_MISMATCH', '/inventoryCount', 'every extracted metric must have exactly one routing entry');
+  }
+
+  const byMetric = new Map();
+  for (const [index, item] of metrics.entries()) {
+    const base = `/metrics/${index}`;
+    if (!item || typeof item !== 'object' || Array.isArray(item)) {
+      add(errors, 'ROUTING_ENTRY_INVALID', base, 'routing entry must be an object');
+      continue;
+    }
+    if (typeof item.metric !== 'string' || !/^[a-z0-9_]{1,64}$/.test(item.metric)) {
+      add(errors, 'METRIC_ID_INVALID', `${base}/metric`, 'metric must be a stable snake_case identifier');
+      continue;
+    }
+    if (byMetric.has(item.metric)) add(errors, 'DUPLICATE_METRIC_ROUTE', `${base}/metric`, 'each extracted metric may be routed only once');
+    else byMetric.set(item.metric, item);
+
+    if (!ROLES.has(item.role)) add(errors, 'ROLE_INVALID', `${base}/role`, 'metric role is not supported');
+    if (typeof item.changesDecision !== 'boolean') add(errors, 'ACTION_TRIGGER_INVALID', `${base}/changesDecision`, 'changesDecision must be boolean');
+    if (!VISIBILITIES.has(item.visibility)) add(errors, 'VISIBILITY_INVALID', `${base}/visibility`, 'visibility is not supported');
+
+    if (item.role === 'primary_signal') {
+      if (item.changesDecision !== true || typeof item.decisionImpact !== 'string' || item.decisionImpact.trim().length === 0) {
+        add(errors, 'ACTION_TRIGGER_REQUIRED', base, 'primary signals must state how a material change alters the decision or action');
+      }
+      if (item.visibility !== 'first_view') add(errors, 'PRIMARY_SIGNAL_MUST_SURFACE', `${base}/visibility`, 'primary signals must be visible on the first view');
+    }
+
+    if (item.role === 'exception') {
+      if (item.changesDecision !== true || typeof item.decisionImpact !== 'string' || item.decisionImpact.trim().length === 0) {
+        add(errors, 'EXCEPTION_TRIGGER_REQUIRED', base, 'exceptions must state the required attention or decision impact');
+      }
+      if (item.active !== true && item.active !== false) add(errors, 'EXCEPTION_STATE_REQUIRED', `${base}/active`, 'exception routes must declare whether the exception is active');
+      if (item.active === true && item.visibility !== 'first_view') add(errors, 'ACTIVE_EXCEPTION_MUST_SURFACE', `${base}/visibility`, 'active exceptions cannot be hidden or deferred for visual preference');
+      if (item.active === true) {
+        const surface = resolvePointer(decisionState, item.surfacePath);
+        if (typeof item.surfacePath !== 'string' || !/^\/(exceptions|events)\/\d+$/.test(item.surfacePath) || !surface.found) {
+          add(errors, 'ACTIVE_EXCEPTION_NOT_SURFACED', `${base}/surfacePath`, 'active exceptions must map to a visible decision-state exception or event');
+        }
+      }
+    }
+
+    if (item.role === 'diagnostic') {
+      if (item.changesDecision !== false) add(errors, 'DIAGNOSTIC_NOT_PRIMARY', `${base}/changesDecision`, 'a diagnostic that changes the decision belongs in primary_signal');
+      if (typeof item.explains !== 'string' || item.explains.length === 0) add(errors, 'DIAGNOSTIC_TARGET_REQUIRED', `${base}/explains`, 'diagnostics must identify the primary signal or exception they explain');
+      if (!['supporting', 'on_demand'].includes(item.visibility)) add(errors, 'DIAGNOSTIC_VISIBILITY_INVALID', `${base}/visibility`, 'diagnostics must stay supporting or on demand');
+    }
+
+    if (item.role === 'drilldown') {
+      if (item.changesDecision !== false) add(errors, 'DRILLDOWN_NOT_PRIMARY', `${base}/changesDecision`, 'a drilldown that changes the decision belongs in primary_signal');
+      if (item.visibility !== 'on_demand') add(errors, 'DRILLDOWN_VISIBILITY_INVALID', `${base}/visibility`, 'drilldown metrics must remain on demand');
+    }
+
+    if (item.role === 'scorecard_only') {
+      if (item.changesDecision !== false) add(errors, 'SCORECARD_NOT_PRIMARY', `${base}/changesDecision`, 'a scorecard-only metric cannot claim to change the active decision');
+      if (item.visibility !== 'scorecard') add(errors, 'SCORECARD_VISIBILITY_INVALID', `${base}/visibility`, 'scorecard-only metrics must stay out of the decision-first view');
+    }
+  }
+
+  const primaries = metrics.filter((item) => item?.role === 'primary_signal');
+  const activeExceptions = metrics.filter((item) => item?.role === 'exception' && item.active === true);
+  if (primaries.length < 3) add(errors, 'PRIMARY_SIGNAL_MINIMUM_NOT_MET', '/metrics', 'the current deterministic renderer requires at least 3 primary signals');
+  if (primaries.length > 6) add(errors, 'PRIMARY_SIGNAL_BUDGET_EXCEEDED', '/metrics', 'the first view may contain at most 6 primary signals');
+  if (primaries.length + activeExceptions.length > 11) add(errors, 'FIRST_VIEW_BUDGET_EXCEEDED', '/metrics', 'first-view primary signals plus active exceptions exceed the current information budget');
+
+  const explainable = new Set(metrics.filter((item) => item?.role === 'primary_signal' || item?.role === 'exception').map((item) => item.metric));
+  for (const [index, item] of metrics.entries()) {
+    if (item?.role === 'diagnostic' && typeof item.explains === 'string' && !explainable.has(item.explains)) {
+      add(errors, 'DIAGNOSTIC_TARGET_INVALID', `/metrics/${index}/explains`, 'diagnostic must explain a routed primary signal or exception');
+    }
+  }
+
+  const routedPrimaryIds = primaries.map((item) => item.metric);
+  const renderedIds = visibleMetricIds(decisionState);
+  if (!sameSet(routedPrimaryIds, renderedIds)) {
+    add(errors, 'VISIBLE_PRIMARY_MISMATCH', '/metrics', 'rendered center metrics must exactly match the routed primary_signal set');
+  }
+
+  const summary = {
+    inventoryCount: metrics.length,
+    primaryCount: primaries.length,
+    activeExceptionCount: activeExceptions.length,
+    hiddenCount: metrics.length - primaries.length - activeExceptions.length,
+    firstViewCount: primaries.length + activeExceptions.length
+  };
+  return { valid: errors.length === 0, errors, summary };
+}

--- a/tests/compiler/compile-dashboard.test.js
+++ b/tests/compiler/compile-dashboard.test.js
@@ -1,0 +1,67 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { compileDecisionDashboard } from '../../skills/decision-first-dashboard/scripts/compile-dashboard.js';
+
+const root = path.resolve(fileURLToPath(new URL('../..', import.meta.url)));
+const groundingDir = fileURLToPath(new URL('./fixtures/grounding/', import.meta.url));
+const routingDir = fileURLToPath(new URL('./fixtures/routing/', import.meta.url));
+const noScoreBundle = JSON.parse(fs.readFileSync(path.join(groundingDir, 'no-score.grounded.json'), 'utf8'));
+const noScoreRouting = JSON.parse(fs.readFileSync(path.join(routingDir, 'no-score.routing.json'), 'utf8'));
+
+function runCli(routingName, bundleName) {
+  const outputDir = fs.mkdtempSync(path.join(os.tmpdir(), 'decision-first-routed-'));
+  const script = path.join(root, 'skills/decision-first-dashboard/scripts/compile-dashboard.js');
+  const result = spawnSync(process.execPath, [
+    script,
+    path.join(routingDir, routingName),
+    path.join(groundingDir, bundleName),
+    outputDir
+  ], { cwd: root, encoding: 'utf8' });
+  return { result, outputDir };
+}
+
+test('routed production compile passes routing before grounding and rendering', () => {
+  const compiled = compileDecisionDashboard(noScoreRouting, noScoreBundle, { baseDir: groundingDir });
+  assert.equal(compiled.result.valid, true);
+  assert.equal(compiled.result.transition, 'PASS');
+  assert.equal(compiled.result.routingSummary.inventoryCount, 5);
+  assert.equal(compiled.result.routingSummary.primaryCount, 5);
+  assert.match(compiled.svg, /Subscription health/);
+  assert.match(compiled.html, /Subscription health/);
+});
+
+test('invalid Metric Router output blocks compilation before grounding', () => {
+  const routing = structuredClone(noScoreRouting);
+  routing.metrics[0].changesDecision = false;
+  delete routing.metrics[0].decisionImpact;
+
+  const bundle = structuredClone(noScoreBundle);
+  bundle.source.sha256 = '0'.repeat(64);
+
+  const compiled = compileDecisionDashboard(routing, bundle, { baseDir: groundingDir });
+  assert.equal(compiled.result.valid, false);
+  assert.equal(compiled.result.stage, 'routing');
+  assert.equal(compiled.result.transition, 'FIX_METRIC_ROUTING');
+  assert.ok(compiled.result.errors.some((error) => error.code === 'ACTION_TRIGGER_REQUIRED'));
+  assert.equal(compiled.svg, null);
+  assert.equal(compiled.html, null);
+});
+
+test('routed CLI writes no-score output only after both gates pass', () => {
+  const { result, outputDir } = runCli('no-score.routing.json', 'no-score.grounded.json');
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(fs.existsSync(path.join(outputDir, 'output.no-score.svg')), true);
+  assert.equal(fs.existsSync(path.join(outputDir, 'output.no-score.html')), true);
+});
+
+test('routed CLI writes composite output only after both gates pass', () => {
+  const { result, outputDir } = runCli('composite.routing.json', 'composite.grounded.json');
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(fs.existsSync(path.join(outputDir, 'output.composite.svg')), true);
+  assert.equal(fs.existsSync(path.join(outputDir, 'output.composite.html')), true);
+});

--- a/tests/compiler/fixtures/routing/composite.routing.json
+++ b/tests/compiler/fixtures/routing/composite.routing.json
@@ -1,0 +1,10 @@
+{
+  "decision": "Decide whether subscription health requires intervention",
+  "action": "Prioritize retention, growth, or conversion intervention",
+  "inventoryCount": 3,
+  "metrics": [
+    { "metric": "retention", "role": "primary_signal", "changesDecision": true, "decisionImpact": "Retention changes intervention priority", "visibility": "first_view" },
+    { "metric": "growth", "role": "primary_signal", "changesDecision": true, "decisionImpact": "Growth changes intervention priority", "visibility": "first_view" },
+    { "metric": "conversion", "role": "primary_signal", "changesDecision": true, "decisionImpact": "Conversion changes intervention priority", "visibility": "first_view" }
+  ]
+}

--- a/tests/compiler/fixtures/routing/no-score.routing.json
+++ b/tests/compiler/fixtures/routing/no-score.routing.json
@@ -1,0 +1,12 @@
+{
+  "decision": "Decide whether the SaaS business needs intervention",
+  "action": "Prioritize the next business follow-up",
+  "inventoryCount": 5,
+  "metrics": [
+    { "metric": "arr", "role": "primary_signal", "changesDecision": true, "decisionImpact": "ARR changes growth and investment prioritization", "visibility": "first_view" },
+    { "metric": "ndr", "role": "primary_signal", "changesDecision": true, "decisionImpact": "NDR changes retention and expansion prioritization", "visibility": "first_view" },
+    { "metric": "gross_margin", "role": "primary_signal", "changesDecision": true, "decisionImpact": "Gross margin changes efficiency prioritization", "visibility": "first_view" },
+    { "metric": "cac_payback", "role": "primary_signal", "changesDecision": true, "decisionImpact": "CAC payback changes acquisition-spend prioritization", "visibility": "first_view" },
+    { "metric": "burn_multiple", "role": "primary_signal", "changesDecision": true, "decisionImpact": "Burn multiple changes capital-efficiency prioritization", "visibility": "first_view" }
+  ]
+}

--- a/tests/compiler/metric-router-contract.test.js
+++ b/tests/compiler/metric-router-contract.test.js
@@ -25,6 +25,16 @@ test('skill defines the Metric Router contract for overloaded KPI sources', () =
   }
 });
 
+test('skill documents the compiler-enforced routing manifest and production gate', () => {
+  assert.match(skill, /metric-routing\.schema\.json/);
+  assert.match(skill, /compile-dashboard\.js/);
+  assert.match(skill, /FIX_METRIC_ROUTING/);
+  assert.match(skill, /inventoryCount/);
+  assert.match(skill, /active exceptions cannot be hidden/i);
+  assert.match(skill, /surfacePath/);
+  assert.match(skill, /first-view information budget/i);
+});
+
 test('README distinguishes no-score and composite examples without overstating capability', () => {
   assert.match(readme, /No-score mode — no unsupported score invented/);
   assert.match(readme, /Composite mode — when the evidence supports it/);
@@ -38,4 +48,5 @@ test('radar grounding contract remains present while Metric Router is added', ()
   assert.match(skill, /3–6 peer dimensions/);
   assert.match(skill, /Fewer than three dimensions are not radar-eligible/);
   assert.match(skill, /source-grounded `normalizedScore`/);
+  assert.match(skill, /Profile Test[\s\S]{0,500}Action Trigger Test/);
 });

--- a/tests/compiler/metric-routing.test.js
+++ b/tests/compiler/metric-routing.test.js
@@ -1,0 +1,123 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { validateMetricRouting } from '../../skills/decision-first-dashboard/scripts/routing.js';
+
+function makeMetric(metric, role, extra = {}) {
+  const base = {
+    metric,
+    role,
+    changesDecision: role === 'primary_signal' || role === 'exception',
+    visibility: role === 'primary_signal' || role === 'exception'
+      ? 'first_view'
+      : role === 'diagnostic'
+        ? 'supporting'
+        : role === 'drilldown'
+          ? 'on_demand'
+          : 'scorecard'
+  };
+  if (role === 'primary_signal' || role === 'exception') base.decisionImpact = `${metric} changes the decision`;
+  if (role === 'exception') base.active = true;
+  return { ...base, ...extra };
+}
+
+function make70() {
+  const metrics = [
+    makeMetric('m1', 'primary_signal'),
+    makeMetric('m2', 'primary_signal'),
+    makeMetric('m3', 'primary_signal'),
+    makeMetric('m4', 'primary_signal'),
+    makeMetric('m5', 'diagnostic', { explains: 'm1' }),
+    makeMetric('m6', 'diagnostic', { explains: 'm2' }),
+    makeMetric('m7', 'drilldown'),
+    makeMetric('m8', 'drilldown')
+  ];
+  for (let i = 9; i <= 70; i++) metrics.push(makeMetric(`m${i}`, 'scorecard_only'));
+  return {
+    decision: 'Decide whether intervention is needed',
+    action: 'Prioritize the next intervention',
+    inventoryCount: 70,
+    metrics
+  };
+}
+
+function noScoreState(metrics = ['m1', 'm2', 'm3', 'm4']) {
+  return { mode: 'no_score', signals: metrics.map((metric) => ({ metric })) };
+}
+
+test('accepts a 70-KPI inventory while keeping only a small primary set', () => {
+  const result = validateMetricRouting(make70(), noScoreState());
+  assert.equal(result.valid, true);
+  assert.equal(result.summary.inventoryCount, 70);
+  assert.equal(result.summary.primaryCount, 4);
+  assert.equal(result.summary.hiddenCount, 66);
+});
+
+test('rejects KPI sprawl when too many metrics are promoted to first-view primary signals', () => {
+  const manifest = make70();
+  manifest.metrics = manifest.metrics.map((item) => ({
+    ...item,
+    role: 'primary_signal',
+    changesDecision: true,
+    decisionImpact: 'changes decision',
+    visibility: 'first_view'
+  }));
+  const result = validateMetricRouting(manifest, noScoreState(manifest.metrics.map(({ metric }) => metric)));
+  assert.equal(result.valid, false);
+  assert.ok(result.errors.some((error) => error.code === 'PRIMARY_SIGNAL_BUDGET_EXCEEDED'));
+});
+
+test('Action Trigger Test rejects a primary signal that does not change a decision or action', () => {
+  const manifest = make70();
+  manifest.metrics[0].changesDecision = false;
+  delete manifest.metrics[0].decisionImpact;
+  const result = validateMetricRouting(manifest, noScoreState());
+  assert.equal(result.valid, false);
+  assert.ok(result.errors.some((error) => error.code === 'ACTION_TRIGGER_REQUIRED'));
+});
+
+test('active exceptions cannot be hidden to make the dashboard look healthier', () => {
+  const manifest = make70();
+  manifest.metrics[10] = makeMetric('m11', 'exception', { active: true, visibility: 'on_demand' });
+  const result = validateMetricRouting(manifest, noScoreState());
+  assert.equal(result.valid, false);
+  assert.ok(result.errors.some((error) => error.code === 'ACTIVE_EXCEPTION_MUST_SURFACE'));
+});
+
+test('active exceptions must map to an actually rendered exception or event', () => {
+  const manifest = make70();
+  manifest.metrics[10] = makeMetric('m11', 'exception', { active: true, visibility: 'first_view' });
+  const result = validateMetricRouting(manifest, noScoreState());
+  assert.equal(result.valid, false);
+  assert.ok(result.errors.some((error) => error.code === 'ACTIVE_EXCEPTION_NOT_SURFACED'));
+});
+
+test('diagnostics must explain a routed primary signal or exception', () => {
+  const manifest = make70();
+  manifest.metrics[4].explains = 'm70';
+  const result = validateMetricRouting(manifest, noScoreState());
+  assert.equal(result.valid, false);
+  assert.ok(result.errors.some((error) => error.code === 'DIAGNOSTIC_TARGET_INVALID'));
+});
+
+test('preserve everything requires one routing entry per extracted metric', () => {
+  const manifest = make70();
+  manifest.metrics.pop();
+  const result = validateMetricRouting(manifest, noScoreState());
+  assert.equal(result.valid, false);
+  assert.ok(result.errors.some((error) => error.code === 'INVENTORY_COUNT_MISMATCH'));
+});
+
+test('rendered center metrics must exactly match the routed primary signals', () => {
+  const result = validateMetricRouting(make70(), noScoreState(['m1', 'm2', 'm3', 'm9']));
+  assert.equal(result.valid, false);
+  assert.ok(result.errors.some((error) => error.code === 'VISIBLE_PRIMARY_MISMATCH'));
+});
+
+test('composite components use the same primary routing contract', () => {
+  const manifest = make70();
+  const result = validateMetricRouting(manifest, {
+    mode: 'composite',
+    model: { components: ['m1', 'm2', 'm3', 'm4'].map((metric) => ({ metric })) }
+  });
+  assert.equal(result.valid, true);
+});

--- a/tests/compiler/metric-routing.test.js
+++ b/tests/compiler/metric-routing.test.js
@@ -121,3 +121,11 @@ test('composite components use the same primary routing contract', () => {
   });
   assert.equal(result.valid, true);
 });
+
+test('rejects unknown routing fields through the closed schema contract', () => {
+  const manifest = make70();
+  manifest.unexpected = 'not allowed';
+  const result = validateMetricRouting(manifest, noScoreState());
+  assert.equal(result.valid, false);
+  assert.ok(result.errors.some((error) => error.code === 'ROUTING_SCHEMA_INVALID'));
+});


### PR DESCRIPTION
## What changed

- Adds a machine-verifiable Metric Routing Manifest with a closed schema.
- Enforces `primary_signal / diagnostic / exception / drilldown / scorecard_only` semantics in code.
- Turns the Action Trigger Test into a compiler gate instead of documentation only.
- Enforces the 70-KPI overload pattern: preserve the full inventory while limiting first-view primary signals to 3–6.
- Prevents active exceptions from being cosmetically hidden; active exceptions must map to rendered exceptions/events.
- Requires rendered center metrics to exactly match routed primary signals.
- Adds `compile-dashboard.js`, which validates routing before the existing grounding compiler.
- Keeps `compile.js` as the lower-level grounding-only compiler for compatibility/tests.
- Requires radar dimensions to pass both Profile Test and Action Trigger Test.
- Extends GitHub Actions to compile routed no-score and composite fixtures.

## Verification

New routing behavior and production-gate tests were written first and observed failing before implementation. The PR adds coverage for 70-KPI compression, action triggers, exception surfacing, diagnostic relationships, closed routing schema, routing inventory completeness, primary/render agreement, and routed no-score/composite compilation.