### PR TITLE
Add Dashboard Worthiness Test

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,21 @@ Most AI dashboard redesigns look cleaner.
 
 They don't necessarily get smarter.
 
-**Decision-First Dashboard makes AI figure out what the dashboard is actually for before redesigning it.**
+**Decision-First Dashboard first asks whether the dashboard deserves to exist — then figures out what decision it is actually for.**
 
 > **What matters → Why → What should I do?**
+
+## Sometimes the right dashboard is no dashboard
+
+Before redesigning anything, it asks:
+
+> **Does this need to be a dashboard at all?**
+
+A dashboard should support a **recurring decision**, have a clear owner, and change an action, priority, escalation, or intervention when an important signal changes.
+
+“Visibility” alone isn't enough.
+
+If the real job is one-off or passive, the skill can recommend a **one-off analysis**, **scheduled summary**, **alert**, report, or chat/query workflow instead of forcing another dashboard into existence.
 
 ## Less dashboard. More decision.
 
@@ -63,7 +75,7 @@ If it doesn't, show the real signals instead.
 
 You don't need to know the perfect KPI set or chart type first.
 
-The skill asks only enough questions to understand the decision and what action could change. Then it routes the available metrics by role instead of putting everything on the first screen.
+The skill first checks whether a persistent dashboard is warranted. If it is, it asks only enough questions to understand the decision and what action could change. Then it routes the available metrics by role instead of putting everything on the first screen.
 
 A source can contain 70 valid KPIs without becoming a 70-KPI dashboard.
 
@@ -103,14 +115,20 @@ Give your agent a dashboard screenshot, Figma frame, existing dashboard code, or
 
 > Redesign this dashboard using the `decision-first-dashboard` skill.
 
-The skill will clarify the decision if needed, route the metrics, verify source support, and render the decision-first output.
+The skill will first check whether a dashboard is the right format. If it is, it clarifies the decision if needed, routes the metrics, verifies source support, and renders the decision-first output.
 
 <details>
 <summary><strong>Under the hood</strong></summary>
 
+### Dashboard Worthiness Test
+
+Before the Decision Brief, the skill checks for a recurring decision or monitoring loop, a clear owner, and an action/priority/escalation that changes when a signal changes. Any questions used here count toward the same five-question intake budget; this is not a second questionnaire.
+
+If the request is only “visibility” or is better handled as a one-off analysis, scheduled summary, alert, report, or chat/query workflow, dashboard rendering stops by default. The user can explicitly override that recommendation, but the rest of the decision, routing, and grounding contracts still apply.
+
 ### Adaptive Decision Brief
 
-The skill asks one question at a time, no more than five, and stops as soon as it has enough confirmed context. Source facts can suggest intent, but they do not silently become business intent. Unless Decision + Action are already explicit, the skill asks for confirmation before routing or rendering.
+The skill asks one question at a time, no more than five total across Worthiness + Decision Brief intake, and stops as soon as it has enough confirmed context. Source facts can suggest intent, but they do not silently become business intent. Unless Decision + Action are already explicit, the skill asks for confirmation before routing or rendering.
 
 ### Metric Router
 
@@ -150,7 +168,8 @@ Composite output is allowed only when all score-model facts are mechanically gro
 ### Production path
 
 ```text
-Decision Brief
+Dashboard Worthiness Test
+→ Decision Brief
 → evidence extraction
 → Metric Router
 → no_score / composite decision
@@ -183,7 +202,7 @@ npm run validate:saas
 npm run render:saas
 ```
 
-GitHub Actions runs the compiler test suite, including Decision Brief intake, 70-KPI Metric Router behavior, routed production compilation, grounded composite/no-score compilation, radar rendering, and byte-level golden snapshots.
+GitHub Actions runs the compiler test suite, including Dashboard Worthiness and Decision Brief intake, 70-KPI Metric Router behavior, routed production compilation, grounded composite/no-score compilation, radar rendering, and byte-level golden snapshots.
 
 ## What this is not
 

--- a/skills/decision-first-dashboard/SKILL.md
+++ b/skills/decision-first-dashboard/SKILL.md
@@ -305,7 +305,7 @@ For `composite`:
 - dominant center source-supported score and band;
 - 3–6 routed normalized weighted components form a true closed radar profile;
 - compact left score trend and score composition;
-- compact right account exceptions and events.
+- compact right exceptions/events.
 
 For both modes:
 

--- a/skills/decision-first-dashboard/SKILL.md
+++ b/skills/decision-first-dashboard/SKILL.md
@@ -9,9 +9,9 @@ description: Use when redesigning KPI-heavy dashboards where users must scan mul
 
 Separate agent judgment from compiler judgment and deterministic rendering.
 
-**Source → Decision Brief → Metric Routing Manifest → grounded evidence bundle → routed compiler gate → deterministic renderer → SVG / HTML**
+**Source → Dashboard Worthiness Test → Decision Brief → Metric Routing Manifest → grounded evidence bundle → routed compiler gate → deterministic renderer → SVG / HTML**
 
-The agent may clarify decision intent, extract and classify evidence, and propose routing. It may not invent source support, bypass routing/grounding gates, or choose a free-form dashboard layout during ordinary compilation.
+The agent may assess whether a dashboard is warranted, clarify decision intent, extract and classify evidence, and propose routing. It may not invent source support, bypass routing/grounding gates, or choose a free-form dashboard layout during ordinary compilation.
 
 A dashboard earns first-view screen space only when the information can change a decision, trigger an action, surface an exception, explain a primary signal, or support deliberate drill-down.
 
@@ -21,6 +21,7 @@ A dashboard earns first-view screen space only when the information can change a
 
 The agent may:
 
+- run the Dashboard Worthiness Test before committing to dashboard output;
 - build an adaptive Decision Brief from user context and source structure;
 - extract literal source facts;
 - classify every extracted metric with the Metric Router;
@@ -63,9 +64,27 @@ Keeping hidden routing inventory out of the renderer is intentional: metrics ass
 
 ## Workflow
 
-### 1. Build an adaptive Decision Brief
+### 1. Run the Dashboard Worthiness Test
 
-Before routing metrics or choosing a visual mode, establish the minimum decision context needed to design the dashboard. Tell the user briefly that better dashboard design requires a few questions. Ask **one question at a time**, ask **no more than five questions**, and **stop immediately once enough information** exists to route metrics and make a defensible design decision.
+Before starting the Decision Brief or committing to dashboard output, ask whether the request deserves to become a persistent dashboard at all. This is a lightweight preflight, not a separate questionnaire: reuse context already supplied, ask one question at a time only when needed, and count any worthiness questions toward the same **five-question total intake budget** used by the Decision Brief.
+
+A dashboard is justified when the workflow has a real recurring decision or recurring monitoring loop, a clear owner who is accountable for that decision or exception, and a meaningful action that changes when an important signal changes. A monitoring dashboard can qualify when a recurring exception changes attention, escalation, or intervention.
+
+Use three tests:
+
+1. **Recurring Decision Test** — is there a recurring decision, review, or exception-monitoring loop rather than a one-off question?
+2. **Owner Test** — is there a clear owner or accountable audience who acts on the result?
+3. **Action Change Test** — when a material signal changes, does a decision, priority, escalation, or action change?
+
+**“Visibility” alone is not a decision and is not sufficient justification for a dashboard.** Wanting to feel informed, copy an old report, or fill a reporting slot does not automatically pass the test.
+
+If the request fails the Worthiness Test, **do not build or render a dashboard by default**. Explain the mismatch briefly and recommend the smallest format that fits the actual job, such as a **one-off analysis**, **scheduled summary**, **alert**, **report**, or **chat/query** workflow. Do not continue into Metric Routing or deterministic rendering merely because the user originally asked for a dashboard.
+
+If the user explicitly chooses a dashboard after seeing that trade-off, proceed as a user-requested exception, but still apply the Decision Brief, Metric Router, grounding, and rendering contracts. Worthiness judgment is design context, not source evidence.
+
+### 2. Build an adaptive Decision Brief
+
+Before routing metrics or choosing a visual mode, establish the minimum decision context needed to design the dashboard. Tell the user briefly that better dashboard design requires a few questions. Ask **one question at a time**, ask **no more than five questions total across Worthiness + Decision Brief intake**, and **stop immediately once enough information** exists to route metrics and make a defensible design decision.
 
 **Intent-confirmation gate:** a screenshot, uploaded dataset, dashboard title, visible KPI mix, domain pattern, or source structure can establish data facts and suggest candidate intent, but a **screenshot alone cannot satisfy the Decision Brief**. Unless the user has **explicitly stated both the Decision and the Action** in the request or prior conversation, ask **at least one question** and obtain user confirmation before Metric Router classification or rendering.
 
@@ -86,7 +105,7 @@ An **inferred candidate requires confirmation**. It may make the next question e
 
 After every answer, run an information-sufficiency check. If the confirmed Decision, confirmed Action, and relevant Exception, Diagnosis, or Audience context provide enough information for routing, stop. Do not ask all five questions merely for completeness.
 
-The zero-question path is narrow: use it only when the user's request or already-established conversation context explicitly states both what the dashboard should help decide and what action/prioritization changes based on that decision. Source data by itself never qualifies.
+The zero-question path is narrow: use it only when the user's request or already-established conversation context explicitly states both what the dashboard should help decide and what action/prioritization changes based on that decision, and the Worthiness Test can also be resolved from already-established context. Source data by itself never qualifies.
 
 If the user is unsure:
 
@@ -104,13 +123,13 @@ Support both intake orders:
 
 The Decision Brief is internal design context. It may guide routing and information hierarchy, but it is not automatically source evidence.
 
-### 2. Extract verified facts only
+### 3. Extract verified facts only
 
 Identify the primary user and decision from the Decision Brief, then capture only source-supported metrics, deltas, account states, events, targets, thresholds, and score rules.
 
 Never invent scores, targets, thresholds, customer states, events, workflows, actions, or causal claims. Direction is not the same as health.
 
-### 3. Route every extracted metric
+### 4. Route every extracted metric
 
 Use the **Metric Router** whenever the source exposes more metrics than a user can reasonably scan at first view. The canonical stress case is **70-KPI overload**: a source may contain roughly 70 valid KPIs, but validity does not make every KPI a first-view peer.
 
@@ -154,7 +173,7 @@ Compiler-enforced routing rules:
 
 The routing manifest is a durable decision trace. It preserves what was considered, why it was promoted or demoted, and what would change the decision, so later analysis does not have to rediscover the same KPI-prioritization logic from scratch.
 
-### 4. Choose the evidence mode
+### 5. Choose the evidence mode
 
 The compiler supports two mutually exclusive decision-state modes.
 
@@ -193,7 +212,7 @@ A radar must pass two gates:
 
 If the Profile Test passes but the Action Trigger Test fails, keep those dimensions in diagnostic/drilldown/scorecard layers instead of using a decorative radar as the dominant visual.
 
-### 5. Build a grounded bundle
+### 6. Build a grounded bundle
 
 The grounded bundle remains separate from the routing inventory and contains only facts used by the rendered decision state:
 
@@ -221,7 +240,7 @@ The compiler verifies the source file hash before accepting source claims.
 
 Image-only coordinates are not strong composite grounding because this repository has no deterministic OCR/token extractor. For screenshot inputs, first produce a verifiable text/JSON sidecar.
 
-### 6. Required grounding coverage
+### 7. Required grounding coverage
 
 For `composite`, ground all source-dependent scoring facts:
 
@@ -243,7 +262,7 @@ A missing radar-scale or normalized-score claim returns to evidence extraction. 
 
 Do not ground deterministic renderer synthesis or Metric Router role decisions as if they were source facts.
 
-### 7. Compile through both gates
+### 8. Compile through both gates
 
 Production execution is:
 
@@ -260,7 +279,7 @@ On final `PASS`, the CLI writes:
 
 `compile.js` remains the lower-level grounding-only compiler for tests and internal compatibility. `validate.js` and `render.js` remain lower-level Layer 2 / Layer 3 tools. Do not use these lower-level entry points as a substitute for `compile-dashboard.js` in ordinary Decision-First production workflows.
 
-### 8. Follow failure transitions literally
+### 9. Follow failure transitions literally
 
 - `FIX_METRIC_ROUTING` → repair routing roles, action-trigger logic, first-view budget, primary/visible mismatch, or exception surfacing; do not bypass the gate.
 - `FIX_DECISION_STATE` → repair contract/schema errors only; do not weaken validation.
@@ -286,7 +305,7 @@ For `composite`:
 - dominant center source-supported score and band;
 - 3–6 routed normalized weighted components form a true closed radar profile;
 - compact left score trend and score composition;
-- compact right exceptions/events.
+- compact right account exceptions and events.
 
 For both modes:
 
@@ -309,6 +328,8 @@ Safety, compliance, security, regulatory, contractual, or outage conditions over
 
 Before delivery, verify:
 
+- the Dashboard Worthiness Test passed, or the user explicitly chose a dashboard after the trade-off was explained;
+- any worthiness questions counted toward the same five-question intake budget rather than creating a second questionnaire;
 - the Decision Brief contains enough confirmed decision context to route metrics, and intake stopped as soon as that context was sufficient;
 - source facts were not mistaken for business intent; if Decision and Action were not explicitly stated beforehand, at least one user-confirmation question was asked;
 - no more than five questions were asked, one at a time, with no redundant request for source information already known;

--- a/tests/compiler/dashboard-worthiness-contract.test.js
+++ b/tests/compiler/dashboard-worthiness-contract.test.js
@@ -1,0 +1,38 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const root = process.cwd();
+const skill = fs.readFileSync(path.join(root, 'skills/decision-first-dashboard/SKILL.md'), 'utf8');
+const readme = fs.readFileSync(path.join(root, 'README.md'), 'utf8');
+
+test('skill evaluates dashboard worthiness before the Decision Brief', () => {
+  const worthinessIndex = skill.indexOf('Dashboard Worthiness Test');
+  const briefIndex = skill.indexOf('Build an adaptive Decision Brief');
+
+  assert.ok(worthinessIndex >= 0, 'missing Dashboard Worthiness Test');
+  assert.ok(briefIndex >= 0, 'missing Decision Brief workflow step');
+  assert.ok(worthinessIndex < briefIndex, 'worthiness must be evaluated before the Decision Brief');
+});
+
+test('worthiness requires a recurring decision owner and action path', () => {
+  assert.match(skill, /recurring decision/i);
+  assert.match(skill, /clear owner|accountable owner|decision owner/i);
+  assert.match(skill, /action[^\n]*changes|changes[^\n]*action/i);
+  assert.match(skill, /visibility[^\n]*not[^\n]*(decision|sufficient)|visibility alone[^\n]*insufficient/i);
+});
+
+test('an unworthy request is redirected instead of forced into a dashboard', () => {
+  assert.match(skill, /do not (build|force|render)[^\n]*dashboard/i);
+
+  for (const alternative of ['one-off analysis', 'scheduled summary', 'alert', 'report', 'chat']) {
+    assert.match(skill, new RegExp(alternative, 'i'), `missing ${alternative} alternative`);
+  }
+});
+
+test('README explains that the skill can refuse an unnecessary dashboard', () => {
+  assert.match(readme, /does this need to be a dashboard at all|deserves to (exist|be a dashboard)/i);
+  assert.match(readme, /recurring decision/i);
+  assert.match(readme, /one-off analysis|scheduled summary|alert/i);
+});


### PR DESCRIPTION
Adds a contract for evaluating whether a request deserves to become a dashboard before the Decision Brief and Metric Router run. This PR is being implemented test-first: the initial commit intentionally adds only the failing contract test; the skill and README changes follow in the next commit.