### PR TITLE
Make Dashboard Worthiness executable

### DIFF
--- a/.github/workflows/compiler-tests.yml
+++ b/.github/workflows/compiler-tests.yml
@@ -35,10 +35,12 @@ jobs:
         run: node skills/decision-first-dashboard/scripts/compile.js tests/compiler/fixtures/grounding/composite.grounded.json tests/compiler/generated/v3-composite
       - name: Compile grounded no-score fixture
         run: node skills/decision-first-dashboard/scripts/compile.js tests/compiler/fixtures/grounding/no-score.grounded.json tests/compiler/generated/v3-no-score
+      - name: Evaluate dashboard worthiness fixture
+        run: node skills/decision-first-dashboard/scripts/worthiness.js tests/compiler/fixtures/worthiness/dashboard.worthiness.json
       - name: Compile routed composite fixture
-        run: node skills/decision-first-dashboard/scripts/compile-dashboard.js tests/compiler/fixtures/routing/composite.routing.json tests/compiler/fixtures/grounding/composite.grounded.json tests/compiler/generated/routed-composite
+        run: node skills/decision-first-dashboard/scripts/compile-dashboard.js tests/compiler/fixtures/worthiness/dashboard.worthiness.json tests/compiler/fixtures/routing/composite.routing.json tests/compiler/fixtures/grounding/composite.grounded.json tests/compiler/generated/routed-composite
       - name: Compile routed no-score fixture
-        run: node skills/decision-first-dashboard/scripts/compile-dashboard.js tests/compiler/fixtures/routing/no-score.routing.json tests/compiler/fixtures/grounding/no-score.grounded.json tests/compiler/generated/routed-no-score
+        run: node skills/decision-first-dashboard/scripts/compile-dashboard.js tests/compiler/fixtures/worthiness/dashboard.worthiness.json tests/compiler/fixtures/routing/no-score.routing.json tests/compiler/fixtures/grounding/no-score.grounded.json tests/compiler/generated/routed-no-score
       - uses: actions/upload-artifact@v4
         with:
           name: saas-no-score-render

--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ Before redesigning anything, it asks:
 
 > **Does this need to be a dashboard at all?**
 
-A dashboard should support a **recurring decision**, have a clear owner, and change an action, priority, escalation, or intervention when an important signal changes.
+A dashboard should support a **recurring decision or monitoring loop**, have a clear **accountability path**, and change an action, priority, escalation, intervention, or coordination when an important signal changes.
+
+That accountability path can be one owner, an on-call team, or a recurring shared forum such as a board or cross-functional review. It does not have to be one named person.
 
 “Visibility” alone isn't enough.
 
@@ -122,9 +124,24 @@ The skill will first check whether a dashboard is the right format. If it is, it
 
 ### Dashboard Worthiness Test
 
-Before the Decision Brief, the skill checks for a recurring decision or monitoring loop, a clear owner, and an action/priority/escalation that changes when a signal changes. Any questions used here count toward the same five-question intake budget; this is not a second questionnaire.
+Before the Decision Brief, the agent produces a structured assessment matching `schemas/worthiness-assessment.schema.json`.
 
-If the request is only “visibility” or is better handled as a one-off analysis, scheduled summary, alert, report, or chat/query workflow, dashboard rendering stops by default. The user can explicitly override that recommendation, but the rest of the decision, routing, and grounding contracts still apply.
+It records whether there is a recurring decision or monitoring loop, an accountability path, and a response that changes. A shared decision forum is a valid accountability path; a single named owner is not required.
+
+The agent does **not** choose the next transition. The compiler validates the assessment and decides:
+
+```text
+BUILD_DECISION_BRIEF
+ASK_WORTHINESS_QUESTION
+REDIRECT_NON_DASHBOARD
+FIX_WORTHINESS_ASSESSMENT
+```
+
+If the request is only “visibility” or is better handled as a one-off analysis, scheduled summary, alert, report, or chat/query workflow, dashboard rendering stops by default. If the user explicitly chooses a dashboard after seeing that trade-off, `userOverride: true` can continue to the Decision Brief — but it still must pass routing and grounding.
+
+This machine gate checks schema and internal semantic consistency. **It does not prove the agent interpreted the user's natural-language intent correctly.** A separate end-to-end agent eval suite is still needed to measure model behavior on raw prompts.
+
+Any Worthiness questions count toward the same five-question intake budget as the Decision Brief; this is not a second questionnaire.
 
 ### Adaptive Decision Brief
 
@@ -136,14 +153,15 @@ The Action Trigger Test asks: **if this metric changes materially, what decision
 
 The routing manifest preserves the complete extracted inventory while keeping only the minimum sufficient first-view signals visible. Active exceptions cannot be hidden to make the dashboard look healthier.
 
-### Grounding
+### Three production gates
 
-The production compiler has two hard gates:
+The production compiler has three ordered gates:
 
-1. **Routing gate** — verifies metric-routing semantics.
-2. **Grounding gate** — verifies that rendered source claims resolve back to source evidence.
+1. **Worthiness gate** — validates the structured Worthiness Assessment and decides whether to continue, clarify, redirect, or repair the assessment.
+2. **Routing gate** — verifies metric-routing semantics.
+3. **Grounding gate** — verifies that rendered source claims resolve back to source evidence.
 
-Machine-readable transitions are:
+Downstream transitions remain:
 
 ```text
 PASS
@@ -168,7 +186,9 @@ Composite output is allowed only when all score-model facts are mechanically gro
 ### Production path
 
 ```text
-Dashboard Worthiness Test
+User context
+→ structured Worthiness Assessment
+→ worthiness validation
 → Decision Brief
 → evidence extraction
 → Metric Router
@@ -182,7 +202,8 @@ Dashboard Worthiness Test
 From the skill directory:
 
 ```bash
-node scripts/compile-dashboard.js path/to/routing-manifest.json path/to/grounded-bundle.json path/to/output-directory
+node scripts/worthiness.js path/to/worthiness-assessment.json
+node scripts/compile-dashboard.js path/to/worthiness-assessment.json path/to/routing-manifest.json path/to/grounded-bundle.json path/to/output-directory
 ```
 
 Mode-specific outputs:
@@ -202,13 +223,13 @@ npm run validate:saas
 npm run render:saas
 ```
 
-GitHub Actions runs the compiler test suite, including Dashboard Worthiness and Decision Brief intake, 70-KPI Metric Router behavior, routed production compilation, grounded composite/no-score compilation, radar rendering, and byte-level golden snapshots.
+GitHub Actions runs the compiler suite, including executable Worthiness scenario fixtures, Decision Brief intake, 70-KPI Metric Router behavior, routed production compilation, grounded composite/no-score compilation, radar rendering, and byte-level golden snapshots.
 
 ## What this is not
 
 This is not a generic chart library and not a prompt that asks AI to freestyle a prettier admin dashboard.
 
-It is a decision-first workflow with routing, evidence checks, and deterministic rendering so the output is useful **and** auditable.
+It is a decision-first workflow with worthiness, routing, evidence checks, and deterministic rendering so the output is useful **and** auditable.
 
 ## License
 

--- a/skills/decision-first-dashboard/SKILL.md
+++ b/skills/decision-first-dashboard/SKILL.md
@@ -9,9 +9,9 @@ description: Use when redesigning KPI-heavy dashboards where users must scan mul
 
 Separate agent judgment from compiler judgment and deterministic rendering.
 
-**Source → Dashboard Worthiness Test → Decision Brief → Metric Routing Manifest → grounded evidence bundle → routed compiler gate → deterministic renderer → SVG / HTML**
+**Source / context → Worthiness Assessment → worthiness gate → Decision Brief → Metric Routing Manifest → grounded evidence bundle → routing + grounding gates → deterministic renderer → SVG / HTML**
 
-The agent may assess whether a dashboard is warranted, clarify decision intent, extract and classify evidence, and propose routing. It may not invent source support, bypass routing/grounding gates, or choose a free-form dashboard layout during ordinary compilation.
+The agent may assess whether a dashboard is warranted, clarify decision intent, extract and classify evidence, and propose routing. It may not invent source support, bypass worthiness/routing/grounding gates, or choose a free-form dashboard layout during ordinary compilation.
 
 A dashboard earns first-view screen space only when the information can change a decision, trigger an action, surface an exception, explain a primary signal, or support deliberate drill-down.
 
@@ -21,7 +21,7 @@ A dashboard earns first-view screen space only when the information can change a
 
 The agent may:
 
-- run the Dashboard Worthiness Test before committing to dashboard output;
+- produce a structured Worthiness Assessment from explicit user/context evidence;
 - build an adaptive Decision Brief from user context and source structure;
 - extract literal source facts;
 - classify every extracted metric with the Metric Router;
@@ -29,26 +29,34 @@ The agent may:
 - choose a proposed evidence mode;
 - create evidence anchors and claim references.
 
-The agent must not render UI or fabricate score-model evidence.
+The agent must not render UI, fabricate score-model evidence, or decide its own worthiness transition. **The agent does not choose or set the transition; the compiler owns the transition.**
 
 ### Layer 2 — Compiler contract
 
-Code decides whether routing and grounding can proceed.
+Code decides whether worthiness, routing, and grounding can proceed.
 
 The production compiler validates, in order:
 
-1. the Metric Routing Manifest and its semantic rules;
-2. exact agreement between routed `primary_signal` metrics and the visible center metrics/components;
-3. active-exception surfacing rules;
-4. the closed grounded-bundle contract;
-5. the closed `decision-state` contract;
-6. source file SHA-256;
-7. evidence reference integrity;
-8. exact JSON Pointer or text-span grounding;
-9. required claim coverage;
-10. composite score mathematics and score-band semantics.
+1. the Worthiness Assessment against `schemas/worthiness-assessment.schema.json` plus its semantic consistency rules;
+2. the Metric Routing Manifest and its semantic rules;
+3. exact agreement between routed `primary_signal` metrics and the visible center metrics/components;
+4. active-exception surfacing rules;
+5. the closed grounded-bundle contract;
+6. the closed `decision-state` contract;
+7. source file SHA-256;
+8. evidence reference integrity;
+9. exact JSON Pointer or text-span grounding;
+10. required claim coverage;
+11. composite score mathematics and score-band semantics.
 
-Machine-readable transitions are:
+Worthiness transitions are:
+
+- `BUILD_DECISION_BRIEF`;
+- `ASK_WORTHINESS_QUESTION`;
+- `REDIRECT_NON_DASHBOARD`;
+- `FIX_WORTHINESS_ASSESSMENT`.
+
+Downstream machine-readable transitions remain:
 
 - `PASS`;
 - `FIX_METRIC_ROUTING`;
@@ -68,19 +76,34 @@ Keeping hidden routing inventory out of the renderer is intentional: metrics ass
 
 Before starting the Decision Brief or committing to dashboard output, ask whether the request deserves to become a persistent dashboard at all. This is a lightweight preflight, not a separate questionnaire: reuse context already supplied, ask one question at a time only when needed, and count any worthiness questions toward the same **five-question total intake budget** used by the Decision Brief.
 
-A dashboard is justified when the workflow has a real recurring decision or recurring monitoring loop, a clear owner who is accountable for that decision or exception, and a meaningful action that changes when an important signal changes. A monitoring dashboard can qualify when a recurring exception changes attention, escalation, or intervention.
+A dashboard is justified when the workflow has a real recurring decision or recurring monitoring loop, a clear **accountability path**, and a meaningful response that changes when an important signal changes. An accountability path may be a single owner, an on-call team, a distributed responsible team, or a recurring shared decision forum such as a board or cross-functional review. A monitoring dashboard can qualify when a recurring exception changes attention, escalation, or intervention.
 
 Use three tests:
 
-1. **Recurring Decision Test** — is there a recurring decision, review, or exception-monitoring loop rather than a one-off question?
-2. **Owner Test** — is there a clear owner or accountable audience who acts on the result?
-3. **Action Change Test** — when a material signal changes, does a decision, priority, escalation, or action change?
+1. **Recurring Loop Test** — is there a recurring decision, review, or exception-monitoring loop rather than a one-off question?
+2. **Accountability Path Test** — is there an identifiable person, team, or shared forum accountable for responding to the result?
+3. **Response Change Test** — when a material signal changes, does an action, priority, escalation, intervention, or coordination change?
 
-**“Visibility” alone is not a decision and is not sufficient justification for a dashboard.** Wanting to feel informed, copy an old report, or fill a reporting slot does not automatically pass the test.
+**“Visibility” alone is not a decision and is not sufficient justification for a dashboard.** Wanting to feel informed, copy an old report, or fill a reporting slot does not automatically pass the test. Shared visibility can still be legitimate when it belongs to a recurring accountable forum and changes coordination or priorities.
+
+The agent must express the judgment as a structured assessment matching:
+
+`schemas/worthiness-assessment.schema.json`
+
+The assessment records `purpose`, `decisionLoop`, `accountability`, `responseChange`, `recommendedFormat`, and optional `userOverride`. Status fields distinguish `confirmed`, `inferred`, and `absent` instead of letting uncertainty silently become fact.
+
+The compiler, not the agent, determines the transition:
+
+- confirmed recurring loop + confirmed accountability path + confirmed response change → `BUILD_DECISION_BRIEF`;
+- inferred or unclear worthiness → `ASK_WORTHINESS_QUESTION`;
+- visibility-only, one-off, or otherwise non-recurring requests → `REDIRECT_NON_DASHBOARD` with a concrete non-dashboard `recommendedFormat`;
+- malformed or contradictory assessments → `FIX_WORTHINESS_ASSESSMENT`.
 
 If the request fails the Worthiness Test, **do not build or render a dashboard by default**. Explain the mismatch briefly and recommend the smallest format that fits the actual job, such as a **one-off analysis**, **scheduled summary**, **alert**, **report**, or **chat/query** workflow. Do not continue into Metric Routing or deterministic rendering merely because the user originally asked for a dashboard.
 
-If the user explicitly chooses a dashboard after seeing that trade-off, proceed as a user-requested exception, but still apply the Decision Brief, Metric Router, grounding, and rendering contracts. Worthiness judgment is design context, not source evidence.
+If the user explicitly chooses a dashboard after seeing that trade-off, record `userOverride: true` and `recommendedFormat: "dashboard"`. That explicit user override may enter the Decision Brief, but it does **not** bypass Metric Router, grounding, evidence, or rendering contracts. The agent may not set `userOverride` merely to avoid a redirect.
+
+Worthiness is design context, not source evidence. The machine gate verifies the assessment's schema and internal semantic consistency; it **does not prove the agent interpreted the user's natural-language intent correctly**. End-to-end model behavior therefore still requires a separate agent scenario/eval layer.
 
 ### 2. Build an adaptive Decision Brief
 
@@ -262,32 +285,36 @@ A missing radar-scale or normalized-score claim returns to evidence extraction. 
 
 Do not ground deterministic renderer synthesis or Metric Router role decisions as if they were source facts.
 
-### 8. Compile through both gates
+### 8. Compile through all gates
 
 Production execution is:
 
 ```bash
-node scripts/compile-dashboard.js <routing-manifest.json> <grounded-bundle.json> <output-dir>
+node scripts/compile-dashboard.js <worthiness-assessment.json> <routing-manifest.json> <grounded-bundle.json> <output-dir>
 ```
 
-The production gate runs Metric Router validation first. On routing failure it returns `FIX_METRIC_ROUTING` and produces no SVG/HTML. Only after routing passes does it run the existing grounding compiler.
+The production path runs the Worthiness gate first. `FIX_WORTHINESS_ASSESSMENT`, `ASK_WORTHINESS_QUESTION`, or `REDIRECT_NON_DASHBOARD` produces no SVG/HTML. Only `BUILD_DECISION_BRIEF` may continue to Metric Router validation. On routing failure the compiler returns `FIX_METRIC_ROUTING`; only after routing passes does it run the grounding compiler.
 
 On final `PASS`, the CLI writes:
 
 - `no_score` → `output.no-score.svg` and `output.no-score.html`;
 - `composite` → `output.composite.svg` and `output.composite.html`.
 
-`compile.js` remains the lower-level grounding-only compiler for tests and internal compatibility. `validate.js` and `render.js` remain lower-level Layer 2 / Layer 3 tools. Do not use these lower-level entry points as a substitute for `compile-dashboard.js` in ordinary Decision-First production workflows.
+`worthiness.js` is the lower-level Worthiness evaluator. `compile.js` remains the lower-level grounding-only compiler for tests and internal compatibility. `validate.js` and `render.js` remain lower-level Layer 2 / Layer 3 tools. Do not use these lower-level entry points as a substitute for `compile-dashboard.js` in ordinary Decision-First production workflows.
 
 ### 9. Follow failure transitions literally
 
+- `FIX_WORTHINESS_ASSESSMENT` → repair malformed or contradictory structured worthiness fields; do not guess a transition.
+- `ASK_WORTHINESS_QUESTION` → ask only the minimum missing question and keep the same five-question total intake budget.
+- `REDIRECT_NON_DASHBOARD` → stop dashboard compilation and use the validated `recommendedFormat` unless the user explicitly overrides after the trade-off is explained.
+- `BUILD_DECISION_BRIEF` → continue into the existing Decision Brief; this is not final render permission.
 - `FIX_METRIC_ROUTING` → repair routing roles, action-trigger logic, first-view budget, primary/visible mismatch, or exception surfacing; do not bypass the gate.
 - `FIX_DECISION_STATE` → repair contract/schema errors only; do not weaken validation.
 - `RETURN_TO_EVIDENCE_EXTRACTION` → re-read source and repair evidence/claims.
 - `FALLBACK_TO_NO_SCORE` → abandon unsupported composite scoring and rebuild a grounded no-score state.
 - `PASS` → render deterministically.
 
-Do not turn a failed routing or grounding check into an invitation to guess.
+Do not turn a failed worthiness, routing, or grounding check into an invitation to guess.
 
 ## Visual contract
 
@@ -328,7 +355,10 @@ Safety, compliance, security, regulatory, contractual, or outage conditions over
 
 Before delivery, verify:
 
-- the Dashboard Worthiness Test passed, or the user explicitly chose a dashboard after the trade-off was explained;
+- `schemas/worthiness-assessment.schema.json` is respected and the compiler, not the agent, owned the Worthiness transition;
+- inferred or unclear worthiness did not silently pass; it produced `ASK_WORTHINESS_QUESTION` unless the user explicitly resolved it;
+- the accountability path may be a single owner, responsible team, or shared forum; do not require one named individual when a recurring accountable forum exists;
+- `REDIRECT_NON_DASHBOARD` stopped rendering unless the user explicitly chose the dashboard trade-off and `userOverride: true` was recorded;
 - any worthiness questions counted toward the same five-question intake budget rather than creating a second questionnaire;
 - the Decision Brief contains enough confirmed decision context to route metrics, and intake stopped as soon as that context was sufficient;
 - source facts were not mistaken for business intent; if Decision and Action were not explicitly stated beforehand, at least one user-confirmation question was asked;

--- a/skills/decision-first-dashboard/schemas/worthiness-assessment.schema.json
+++ b/skills/decision-first-dashboard/schemas/worthiness-assessment.schema.json
@@ -73,7 +73,8 @@
         "chat_query",
         "undetermined"
       ]
-    }
+    },
+    "userOverride": { "enum": [true, false] }
   },
   "$defs": {
     "statusDescription": {

--- a/skills/decision-first-dashboard/schemas/worthiness-assessment.schema.json
+++ b/skills/decision-first-dashboard/schemas/worthiness-assessment.schema.json
@@ -1,0 +1,89 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Dashboard Worthiness Assessment",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "version",
+    "purpose",
+    "decisionLoop",
+    "accountability",
+    "responseChange",
+    "recommendedFormat"
+  ],
+  "properties": {
+    "version": { "const": "1.0" },
+    "purpose": {
+      "enum": [
+        "recurring_decision",
+        "recurring_monitoring",
+        "shared_coordination",
+        "visibility_only",
+        "one_off_question",
+        "unclear"
+      ]
+    },
+    "decisionLoop": { "$ref": "#/$defs/statusDescription" },
+    "accountability": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "mode", "description"],
+      "properties": {
+        "status": { "enum": ["confirmed", "inferred", "absent"] },
+        "mode": {
+          "enum": [
+            "single_owner",
+            "shared_forum",
+            "on_call_team",
+            "distributed_team",
+            "absent",
+            "unclear"
+          ]
+        },
+        "description": { "type": "string", "minLength": 1, "maxLength": 500 }
+      }
+    },
+    "responseChange": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "kind", "description"],
+      "properties": {
+        "status": { "enum": ["confirmed", "inferred", "absent"] },
+        "kind": {
+          "enum": [
+            "action",
+            "priority",
+            "escalation",
+            "intervention",
+            "coordination",
+            "none",
+            "unclear"
+          ]
+        },
+        "description": { "type": "string", "minLength": 1, "maxLength": 500 }
+      }
+    },
+    "recommendedFormat": {
+      "enum": [
+        "dashboard",
+        "one_off_analysis",
+        "scheduled_summary",
+        "alert",
+        "report",
+        "chat_query",
+        "undetermined"
+      ]
+    }
+  },
+  "$defs": {
+    "statusDescription": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "description"],
+      "properties": {
+        "status": { "enum": ["confirmed", "inferred", "absent"] },
+        "description": { "type": "string", "minLength": 1, "maxLength": 500 }
+      }
+    }
+  }
+}

--- a/skills/decision-first-dashboard/scripts/compile-dashboard.js
+++ b/skills/decision-first-dashboard/scripts/compile-dashboard.js
@@ -3,10 +3,29 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { compileGroundedBundle } from './compile.js';
 import { validateMetricRouting } from './routing.js';
+import { evaluateWorthinessAssessment } from './worthiness.js';
 
 const currentFile = fileURLToPath(import.meta.url);
 
-export function compileDecisionDashboard(routingManifest, bundle, { baseDir = process.cwd() } = {}) {
+export function compileDecisionDashboard(worthinessAssessment, routingManifest, bundle, { baseDir = process.cwd() } = {}) {
+  const worthiness = evaluateWorthinessAssessment(worthinessAssessment);
+  if (!worthiness.valid || worthiness.transition !== 'BUILD_DECISION_BRIEF') {
+    return {
+      result: {
+        valid: false,
+        assessmentValid: worthiness.valid,
+        stage: 'worthiness',
+        transition: worthiness.transition,
+        errors: worthiness.errors,
+        recommendedFormat: worthiness.recommendedFormat,
+        worthinessSummary: worthiness.summary
+      },
+      svg: null,
+      html: null,
+      outputMode: null
+    };
+  }
+
   const routing = validateMetricRouting(routingManifest, bundle?.decisionState);
   if (!routing.valid) {
     return {
@@ -15,6 +34,7 @@ export function compileDecisionDashboard(routingManifest, bundle, { baseDir = pr
         stage: 'routing',
         transition: 'FIX_METRIC_ROUTING',
         errors: routing.errors,
+        worthinessSummary: worthiness.summary,
         routingSummary: routing.summary
       },
       svg: null,
@@ -28,33 +48,37 @@ export function compileDecisionDashboard(routingManifest, bundle, { baseDir = pr
     ...compiled,
     result: {
       ...compiled.result,
+      worthinessSummary: worthiness.summary,
       routingSummary: routing.summary
     }
   };
 }
 
 if (process.argv[1] === currentFile) {
-  const routingPath = process.argv[2];
-  const bundlePath = process.argv[3];
-  const outputDir = process.argv[4] ?? path.dirname(bundlePath ?? '.');
+  const worthinessPath = process.argv[2];
+  const routingPath = process.argv[3];
+  const bundlePath = process.argv[4];
+  const outputDir = process.argv[5] ?? path.dirname(bundlePath ?? '.');
 
-  if (!routingPath || !bundlePath) {
+  if (!worthinessPath || !routingPath || !bundlePath) {
     process.stderr.write(`${JSON.stringify({
       valid: false,
-      stage: 'routing',
-      transition: 'FIX_METRIC_ROUTING',
-      errors: [{ code: 'ROUTING_MANIFEST_INVALID', path: '', message: 'Usage: node compile-dashboard.js <routing-manifest.json> <grounded-bundle.json> [output-dir]' }]
+      stage: 'worthiness',
+      transition: 'FIX_WORTHINESS_ASSESSMENT',
+      errors: [{ code: 'WORTHINESS_ASSESSMENT_INVALID', path: '', message: 'Usage: node compile-dashboard.js <worthiness-assessment.json> <routing-manifest.json> <grounded-bundle.json> [output-dir]' }]
     })}\n`);
     process.exit(2);
   }
 
+  const absoluteWorthiness = path.resolve(worthinessPath);
   const absoluteRouting = path.resolve(routingPath);
   const absoluteBundle = path.resolve(bundlePath);
+  const worthinessAssessment = JSON.parse(fs.readFileSync(absoluteWorthiness, 'utf8'));
   const routingManifest = JSON.parse(fs.readFileSync(absoluteRouting, 'utf8'));
   const bundle = JSON.parse(fs.readFileSync(absoluteBundle, 'utf8'));
-  const compiled = compileDecisionDashboard(routingManifest, bundle, { baseDir: path.dirname(absoluteBundle) });
+  const compiled = compileDecisionDashboard(worthinessAssessment, routingManifest, bundle, { baseDir: path.dirname(absoluteBundle) });
 
-  if (!compiled.result.valid) {
+  if (!compiled.result.valid || compiled.result.transition !== 'PASS') {
     process.stderr.write(`${JSON.stringify(compiled.result)}\n`);
     process.exit(1);
   }

--- a/skills/decision-first-dashboard/scripts/worthiness.js
+++ b/skills/decision-first-dashboard/scripts/worthiness.js
@@ -18,13 +18,15 @@ function summaryOf(assessment) {
     accountabilityStatus: assessment.accountability.status,
     accountabilityMode: assessment.accountability.mode,
     responseChangeStatus: assessment.responseChange.status,
-    responseChangeKind: assessment.responseChange.kind
+    responseChangeKind: assessment.responseChange.kind,
+    userOverride: assessment.userOverride === true
   };
 }
 
 function validateSemantics(assessment) {
   const errors = [];
   const { accountability, responseChange, recommendedFormat, purpose } = assessment;
+  const userOverride = assessment.userOverride === true;
 
   if (accountability.status === 'absent' && accountability.mode !== 'absent') {
     add(errors, 'ACCOUNTABILITY_STATUS_CONFLICT', '/accountability/mode', 'absent accountability must use mode "absent"');
@@ -40,6 +42,13 @@ function validateSemantics(assessment) {
   }
   if (purpose === 'visibility_only' && responseChange.status === 'confirmed') {
     add(errors, 'VISIBILITY_PURPOSE_CONFLICT', '/purpose', 'visibility_only cannot simultaneously claim a confirmed action, priority, escalation, intervention, or coordination change');
+  }
+
+  if (userOverride) {
+    if (recommendedFormat !== 'dashboard') {
+      add(errors, 'FORMAT_TRANSITION_CONFLICT', '/recommendedFormat', 'an explicit user override must use recommendedFormat "dashboard"');
+    }
+    return errors;
   }
 
   const explicitRedirect = purpose === 'visibility_only' || purpose === 'one_off_question';
@@ -94,6 +103,17 @@ export function evaluateWorthinessAssessment(assessment) {
       transition: 'FIX_WORTHINESS_ASSESSMENT',
       errors: semanticErrors,
       recommendedFormat: null,
+      summary: summaryOf(assessment)
+    };
+  }
+
+  if (assessment.userOverride === true) {
+    return {
+      valid: true,
+      stage: 'worthiness',
+      transition: 'BUILD_DECISION_BRIEF',
+      errors: [],
+      recommendedFormat: 'dashboard',
       summary: summaryOf(assessment)
     };
   }

--- a/skills/decision-first-dashboard/scripts/worthiness.js
+++ b/skills/decision-first-dashboard/scripts/worthiness.js
@@ -1,0 +1,173 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { validateAgainstSchema } from './validate.js';
+
+const currentFile = fileURLToPath(import.meta.url);
+const currentDir = path.dirname(currentFile);
+const schema = JSON.parse(fs.readFileSync(path.resolve(currentDir, '../schemas/worthiness-assessment.schema.json'), 'utf8'));
+
+function add(errors, code, path, message) {
+  errors.push({ code, path, message });
+}
+
+function summaryOf(assessment) {
+  return {
+    purpose: assessment.purpose,
+    decisionLoopStatus: assessment.decisionLoop.status,
+    accountabilityStatus: assessment.accountability.status,
+    accountabilityMode: assessment.accountability.mode,
+    responseChangeStatus: assessment.responseChange.status,
+    responseChangeKind: assessment.responseChange.kind
+  };
+}
+
+function validateSemantics(assessment) {
+  const errors = [];
+  const { accountability, responseChange, recommendedFormat, purpose } = assessment;
+
+  if (accountability.status === 'absent' && accountability.mode !== 'absent') {
+    add(errors, 'ACCOUNTABILITY_STATUS_CONFLICT', '/accountability/mode', 'absent accountability must use mode "absent"');
+  }
+  if (accountability.status !== 'absent' && accountability.mode === 'absent') {
+    add(errors, 'ACCOUNTABILITY_STATUS_CONFLICT', '/accountability/mode', 'present or inferred accountability cannot use mode "absent"');
+  }
+  if (responseChange.status === 'absent' && responseChange.kind !== 'none') {
+    add(errors, 'RESPONSE_CHANGE_STATUS_CONFLICT', '/responseChange/kind', 'absent response change must use kind "none"');
+  }
+  if (responseChange.status !== 'absent' && responseChange.kind === 'none') {
+    add(errors, 'RESPONSE_CHANGE_STATUS_CONFLICT', '/responseChange/kind', 'present or inferred response change cannot use kind "none"');
+  }
+  if (purpose === 'visibility_only' && responseChange.status === 'confirmed') {
+    add(errors, 'VISIBILITY_PURPOSE_CONFLICT', '/purpose', 'visibility_only cannot simultaneously claim a confirmed action, priority, escalation, intervention, or coordination change');
+  }
+
+  const explicitRedirect = purpose === 'visibility_only' || purpose === 'one_off_question';
+  const needsQuestion = !explicitRedirect && (
+    purpose === 'unclear' ||
+    assessment.decisionLoop.status === 'inferred' ||
+    accountability.status === 'inferred' ||
+    responseChange.status === 'inferred' ||
+    accountability.mode === 'unclear' ||
+    responseChange.kind === 'unclear'
+  );
+  const qualifies = !explicitRedirect && !needsQuestion &&
+    assessment.decisionLoop.status === 'confirmed' &&
+    accountability.status === 'confirmed' &&
+    responseChange.status === 'confirmed';
+
+  if (qualifies && recommendedFormat !== 'dashboard') {
+    add(errors, 'FORMAT_TRANSITION_CONFLICT', '/recommendedFormat', 'a confirmed dashboard-worthy assessment must recommend "dashboard"');
+  }
+  if (needsQuestion && recommendedFormat !== 'undetermined') {
+    add(errors, 'FORMAT_TRANSITION_CONFLICT', '/recommendedFormat', 'an unresolved assessment must use recommendedFormat "undetermined"');
+  }
+  if (!qualifies && !needsQuestion && ['dashboard', 'undetermined'].includes(recommendedFormat)) {
+    add(errors, 'FORMAT_TRANSITION_CONFLICT', '/recommendedFormat', 'a non-dashboard redirect must recommend a concrete non-dashboard format');
+  }
+
+  return errors;
+}
+
+export function evaluateWorthinessAssessment(assessment) {
+  const schemaResult = validateAgainstSchema(assessment, schema);
+  if (!schemaResult.valid) {
+    return {
+      valid: false,
+      stage: 'worthiness',
+      transition: 'FIX_WORTHINESS_ASSESSMENT',
+      errors: schemaResult.errors.map((error) => ({
+        code: 'WORTHINESS_SCHEMA_INVALID',
+        path: error.instancePath,
+        message: `${error.keyword}: ${error.message}`
+      })),
+      recommendedFormat: null,
+      summary: null
+    };
+  }
+
+  const semanticErrors = validateSemantics(assessment);
+  if (semanticErrors.length > 0) {
+    return {
+      valid: false,
+      stage: 'worthiness',
+      transition: 'FIX_WORTHINESS_ASSESSMENT',
+      errors: semanticErrors,
+      recommendedFormat: null,
+      summary: summaryOf(assessment)
+    };
+  }
+
+  const explicitRedirect = assessment.purpose === 'visibility_only' || assessment.purpose === 'one_off_question';
+  if (explicitRedirect) {
+    return {
+      valid: true,
+      stage: 'worthiness',
+      transition: 'REDIRECT_NON_DASHBOARD',
+      errors: [],
+      recommendedFormat: assessment.recommendedFormat,
+      summary: summaryOf(assessment)
+    };
+  }
+
+  const needsQuestion = assessment.purpose === 'unclear' ||
+    assessment.decisionLoop.status === 'inferred' ||
+    assessment.accountability.status === 'inferred' ||
+    assessment.responseChange.status === 'inferred' ||
+    assessment.accountability.mode === 'unclear' ||
+    assessment.responseChange.kind === 'unclear';
+
+  if (needsQuestion) {
+    return {
+      valid: true,
+      stage: 'worthiness',
+      transition: 'ASK_WORTHINESS_QUESTION',
+      errors: [],
+      recommendedFormat: 'undetermined',
+      summary: summaryOf(assessment)
+    };
+  }
+
+  const qualifies = assessment.decisionLoop.status === 'confirmed' &&
+    assessment.accountability.status === 'confirmed' &&
+    assessment.responseChange.status === 'confirmed';
+
+  if (!qualifies) {
+    return {
+      valid: true,
+      stage: 'worthiness',
+      transition: 'REDIRECT_NON_DASHBOARD',
+      errors: [],
+      recommendedFormat: assessment.recommendedFormat,
+      summary: summaryOf(assessment)
+    };
+  }
+
+  return {
+    valid: true,
+    stage: 'worthiness',
+    transition: 'BUILD_DECISION_BRIEF',
+    errors: [],
+    recommendedFormat: 'dashboard',
+    summary: summaryOf(assessment)
+  };
+}
+
+if (process.argv[1] === currentFile) {
+  const inputPath = process.argv[2];
+  if (!inputPath) {
+    process.stderr.write(`${JSON.stringify({
+      valid: false,
+      stage: 'worthiness',
+      transition: 'FIX_WORTHINESS_ASSESSMENT',
+      errors: [{ code: 'WORTHINESS_ASSESSMENT_INVALID', path: '', message: 'Usage: node worthiness.js <worthiness-assessment.json>' }]
+    })}\n`);
+    process.exit(2);
+  }
+
+  const assessment = JSON.parse(fs.readFileSync(path.resolve(inputPath), 'utf8'));
+  const result = evaluateWorthinessAssessment(assessment);
+  const stream = result.valid ? process.stdout : process.stderr;
+  stream.write(`${JSON.stringify(result)}\n`);
+  process.exit(result.valid ? 0 : 1);
+}

--- a/tests/compiler/compile-dashboard.test.js
+++ b/tests/compiler/compile-dashboard.test.js
@@ -10,14 +10,17 @@ import { compileDecisionDashboard } from '../../skills/decision-first-dashboard/
 const root = path.resolve(fileURLToPath(new URL('../..', import.meta.url)));
 const groundingDir = fileURLToPath(new URL('./fixtures/grounding/', import.meta.url));
 const routingDir = fileURLToPath(new URL('./fixtures/routing/', import.meta.url));
+const worthinessDir = fileURLToPath(new URL('./fixtures/worthiness/', import.meta.url));
 const noScoreBundle = JSON.parse(fs.readFileSync(path.join(groundingDir, 'no-score.grounded.json'), 'utf8'));
 const noScoreRouting = JSON.parse(fs.readFileSync(path.join(routingDir, 'no-score.routing.json'), 'utf8'));
+const dashboardWorthiness = JSON.parse(fs.readFileSync(path.join(worthinessDir, 'dashboard.worthiness.json'), 'utf8'));
 
 function runCli(routingName, bundleName) {
   const outputDir = fs.mkdtempSync(path.join(os.tmpdir(), 'decision-first-routed-'));
   const script = path.join(root, 'skills/decision-first-dashboard/scripts/compile-dashboard.js');
   const result = spawnSync(process.execPath, [
     script,
+    path.join(worthinessDir, 'dashboard.worthiness.json'),
     path.join(routingDir, routingName),
     path.join(groundingDir, bundleName),
     outputDir
@@ -25,17 +28,18 @@ function runCli(routingName, bundleName) {
   return { result, outputDir };
 }
 
-test('routed production compile passes routing before grounding and rendering', () => {
-  const compiled = compileDecisionDashboard(noScoreRouting, noScoreBundle, { baseDir: groundingDir });
+test('production compile passes worthiness before routing, grounding, and rendering', () => {
+  const compiled = compileDecisionDashboard(dashboardWorthiness, noScoreRouting, noScoreBundle, { baseDir: groundingDir });
   assert.equal(compiled.result.valid, true);
   assert.equal(compiled.result.transition, 'PASS');
+  assert.equal(compiled.result.worthinessSummary.accountabilityMode, 'single_owner');
   assert.equal(compiled.result.routingSummary.inventoryCount, 5);
   assert.equal(compiled.result.routingSummary.primaryCount, 5);
   assert.match(compiled.svg, /Subscription health/);
   assert.match(compiled.html, /Subscription health/);
 });
 
-test('invalid Metric Router output blocks compilation before grounding', () => {
+test('invalid Metric Router output blocks compilation after worthiness and before grounding', () => {
   const routing = structuredClone(noScoreRouting);
   routing.metrics[0].changesDecision = false;
   delete routing.metrics[0].decisionImpact;
@@ -43,7 +47,7 @@ test('invalid Metric Router output blocks compilation before grounding', () => {
   const bundle = structuredClone(noScoreBundle);
   bundle.source.sha256 = '0'.repeat(64);
 
-  const compiled = compileDecisionDashboard(routing, bundle, { baseDir: groundingDir });
+  const compiled = compileDecisionDashboard(dashboardWorthiness, routing, bundle, { baseDir: groundingDir });
   assert.equal(compiled.result.valid, false);
   assert.equal(compiled.result.stage, 'routing');
   assert.equal(compiled.result.transition, 'FIX_METRIC_ROUTING');
@@ -52,14 +56,14 @@ test('invalid Metric Router output blocks compilation before grounding', () => {
   assert.equal(compiled.html, null);
 });
 
-test('routed CLI writes no-score output only after both gates pass', () => {
+test('production CLI writes no-score output only after all three gates pass', () => {
   const { result, outputDir } = runCli('no-score.routing.json', 'no-score.grounded.json');
   assert.equal(result.status, 0, result.stderr);
   assert.equal(fs.existsSync(path.join(outputDir, 'output.no-score.svg')), true);
   assert.equal(fs.existsSync(path.join(outputDir, 'output.no-score.html')), true);
 });
 
-test('routed CLI writes composite output only after both gates pass', () => {
+test('production CLI writes composite output only after all three gates pass', () => {
   const { result, outputDir } = runCli('composite.routing.json', 'composite.grounded.json');
   assert.equal(result.status, 0, result.stderr);
   assert.equal(fs.existsSync(path.join(outputDir, 'output.composite.svg')), true);

--- a/tests/compiler/dashboard-worthiness-contract.test.js
+++ b/tests/compiler/dashboard-worthiness-contract.test.js
@@ -16,11 +16,21 @@ test('skill evaluates dashboard worthiness before the Decision Brief', () => {
   assert.ok(worthinessIndex < briefIndex, 'worthiness must be evaluated before the Decision Brief');
 });
 
-test('worthiness requires a recurring decision owner and action path', () => {
-  assert.match(skill, /recurring decision/i);
-  assert.match(skill, /clear owner|accountable owner|decision owner/i);
-  assert.match(skill, /action[^\n]*changes|changes[^\n]*action/i);
+test('worthiness requires a recurring loop, accountability path, and response change', () => {
+  assert.match(skill, /recurring decision|recurring monitoring/i);
+  assert.match(skill, /accountability path/i);
+  assert.match(skill, /shared forum|shared decision forum/i);
+  assert.match(skill, /action[^\n]*changes|changes[^\n]*action|priority[^\n]*changes|coordination[^\n]*changes/i);
   assert.match(skill, /visibility[^\n]*not[^\n]*(decision|sufficient)|visibility alone[^\n]*insufficient/i);
+});
+
+test('skill documents the machine-readable worthiness gate', () => {
+  assert.match(skill, /worthiness-assessment\.schema\.json/i);
+  assert.match(skill, /BUILD_DECISION_BRIEF/);
+  assert.match(skill, /ASK_WORTHINESS_QUESTION/);
+  assert.match(skill, /REDIRECT_NON_DASHBOARD/);
+  assert.match(skill, /FIX_WORTHINESS_ASSESSMENT/);
+  assert.match(skill, /agent[^\n]*does not[^\n]*(choose|own|set)[^\n]*(transition|next)|compiler[^\n]*(owns|decides)[^\n]*(transition|next)/i);
 });
 
 test('an unworthy request is redirected instead of forced into a dashboard', () => {
@@ -31,8 +41,9 @@ test('an unworthy request is redirected instead of forced into a dashboard', () 
   }
 });
 
-test('README explains that the skill can refuse an unnecessary dashboard', () => {
+test('README explains both refusal and the executable gate boundary', () => {
   assert.match(readme, /does this need to be a dashboard at all|deserves to (exist|be a dashboard)/i);
-  assert.match(readme, /recurring decision/i);
-  assert.match(readme, /one-off analysis|scheduled summary|alert/i);
+  assert.match(readme, /accountability path/i);
+  assert.match(readme, /worthiness-assessment\.schema\.json/i);
+  assert.match(readme, /does not prove[^\n]*(agent|model)|cannot prove[^\n]*(agent|model)|semantic[^\n]*(still|remains)[^\n]*(agent|model)/i);
 });

--- a/tests/compiler/fixtures/worthiness/dashboard.worthiness.json
+++ b/tests/compiler/fixtures/worthiness/dashboard.worthiness.json
@@ -1,0 +1,19 @@
+{
+  "version": "1.0",
+  "purpose": "recurring_decision",
+  "decisionLoop": {
+    "status": "confirmed",
+    "description": "A recurring subscription-health review determines where retention attention should go."
+  },
+  "accountability": {
+    "status": "confirmed",
+    "mode": "single_owner",
+    "description": "The business owner for subscription health is accountable for the review."
+  },
+  "responseChange": {
+    "status": "confirmed",
+    "kind": "priority",
+    "description": "Material signal changes alter which retention risks are prioritized."
+  },
+  "recommendedFormat": "dashboard"
+}

--- a/tests/compiler/fixtures/worthiness/scenarios.json
+++ b/tests/compiler/fixtures/worthiness/scenarios.json
@@ -1,0 +1,62 @@
+[
+  {
+    "id": "visibility-only",
+    "assessment": {
+      "version": "1.0",
+      "purpose": "visibility_only",
+      "decisionLoop": { "status": "absent", "description": "The boss wants to glance at the numbers each week, with no recurring decision attached." },
+      "accountability": { "status": "absent", "mode": "absent", "description": "No person or recurring forum is accountable for acting on the view." },
+      "responseChange": { "status": "absent", "kind": "none", "description": "No action, priority, escalation, intervention, or coordination changes when the numbers move." },
+      "recommendedFormat": "scheduled_summary"
+    },
+    "expected": { "transition": "REDIRECT_NON_DASHBOARD", "recommendedFormat": "scheduled_summary" }
+  },
+  {
+    "id": "one-off-analysis",
+    "assessment": {
+      "version": "1.0",
+      "purpose": "one_off_question",
+      "decisionLoop": { "status": "absent", "description": "The request is a one-time investigation of last quarter." },
+      "accountability": { "status": "confirmed", "mode": "single_owner", "description": "The analyst owns the one-time answer." },
+      "responseChange": { "status": "absent", "kind": "none", "description": "There is no recurring response loop after the answer is delivered." },
+      "recommendedFormat": "one_off_analysis"
+    },
+    "expected": { "transition": "REDIRECT_NON_DASHBOARD", "recommendedFormat": "one_off_analysis" }
+  },
+  {
+    "id": "uncertain-shared-review",
+    "assessment": {
+      "version": "1.0",
+      "purpose": "unclear",
+      "decisionLoop": { "status": "inferred", "description": "A weekly review seems plausible but has not been confirmed." },
+      "accountability": { "status": "inferred", "mode": "shared_forum", "description": "A cross-functional review may own the decision." },
+      "responseChange": { "status": "inferred", "kind": "coordination", "description": "The review may change cross-functional priorities." },
+      "recommendedFormat": "undetermined"
+    },
+    "expected": { "transition": "ASK_WORTHINESS_QUESTION", "recommendedFormat": "undetermined" }
+  },
+  {
+    "id": "operational-monitoring",
+    "assessment": {
+      "version": "1.0",
+      "purpose": "recurring_monitoring",
+      "decisionLoop": { "status": "confirmed", "description": "The service is continuously monitored for operational exceptions." },
+      "accountability": { "status": "confirmed", "mode": "on_call_team", "description": "The on-call operations team owns escalation." },
+      "responseChange": { "status": "confirmed", "kind": "escalation", "description": "A breach changes escalation and intervention." },
+      "recommendedFormat": "dashboard"
+    },
+    "expected": { "transition": "PASS", "accountabilityMode": "on_call_team" }
+  },
+  {
+    "id": "board-shared-forum",
+    "assessment": {
+      "version": "1.0",
+      "purpose": "shared_coordination",
+      "decisionLoop": { "status": "confirmed", "description": "The board reviews the same operating signals every month." },
+      "accountability": { "status": "confirmed", "mode": "shared_forum", "description": "The board is the recurring accountable decision forum." },
+      "responseChange": { "status": "confirmed", "kind": "coordination", "description": "The review changes cross-functional priorities and coordination." },
+      "recommendedFormat": "dashboard"
+    },
+    "expected": { "transition": "PASS", "accountabilityMode": "shared_forum" }
+  }
+]

--- a/tests/compiler/worthiness-behavior.test.js
+++ b/tests/compiler/worthiness-behavior.test.js
@@ -7,108 +7,51 @@ import { compileDecisionDashboard } from '../../skills/decision-first-dashboard/
 
 const groundingDir = fileURLToPath(new URL('./fixtures/grounding/', import.meta.url));
 const routingDir = fileURLToPath(new URL('./fixtures/routing/', import.meta.url));
+const worthinessDir = fileURLToPath(new URL('./fixtures/worthiness/', import.meta.url));
 const noScoreBundle = JSON.parse(fs.readFileSync(path.join(groundingDir, 'no-score.grounded.json'), 'utf8'));
 const noScoreRouting = JSON.parse(fs.readFileSync(path.join(routingDir, 'no-score.routing.json'), 'utf8'));
-
-function assessment(overrides = {}) {
-  return {
-    version: '1.0',
-    purpose: 'recurring_decision',
-    decisionLoop: {
-      status: 'confirmed',
-      description: 'Weekly review changes which retention risk receives attention first.'
-    },
-    accountability: {
-      status: 'confirmed',
-      mode: 'single_owner',
-      description: 'Head of Customer Success owns the review.'
-    },
-    responseChange: {
-      status: 'confirmed',
-      kind: 'priority',
-      description: 'The review changes which accounts are prioritized for intervention.'
-    },
-    recommendedFormat: 'dashboard',
-    ...overrides
-  };
-}
+const dashboardWorthiness = JSON.parse(fs.readFileSync(path.join(worthinessDir, 'dashboard.worthiness.json'), 'utf8'));
+const scenarios = JSON.parse(fs.readFileSync(path.join(worthinessDir, 'scenarios.json'), 'utf8'));
 
 function compile(worthiness) {
   return compileDecisionDashboard(worthiness, noScoreRouting, noScoreBundle, { baseDir: groundingDir });
 }
 
-test('visibility-only requests are redirected before routing or rendering', () => {
-  const result = compile(assessment({
-    purpose: 'visibility_only',
-    decisionLoop: { status: 'absent', description: 'The request is only to glance at numbers each week.' },
-    accountability: { status: 'absent', mode: 'absent', description: 'No person or forum is accountable for acting on it.' },
-    responseChange: { status: 'absent', kind: 'none', description: 'No action, priority, escalation, intervention, or coordination changes.' },
-    recommendedFormat: 'scheduled_summary'
-  }));
+for (const scenario of scenarios) {
+  test(`worthiness scenario: ${scenario.id}`, () => {
+    const result = compile(scenario.assessment);
 
-  assert.equal(result.result.stage, 'worthiness');
-  assert.equal(result.result.transition, 'REDIRECT_NON_DASHBOARD');
-  assert.equal(result.result.recommendedFormat, 'scheduled_summary');
-  assert.equal(result.svg, null);
-  assert.equal(result.html, null);
-});
+    assert.equal(result.result.transition, scenario.expected.transition);
+    if (scenario.expected.recommendedFormat) {
+      assert.equal(result.result.recommendedFormat, scenario.expected.recommendedFormat);
+    }
+    if (scenario.expected.accountabilityMode) {
+      assert.equal(result.result.worthinessSummary.accountabilityMode, scenario.expected.accountabilityMode);
+    }
 
-test('one-off questions redirect to one-off analysis instead of a persistent dashboard', () => {
-  const result = compile(assessment({
-    purpose: 'one_off_question',
-    decisionLoop: { status: 'absent', description: 'This is a single investigation of last quarter.' },
-    accountability: { status: 'confirmed', mode: 'single_owner', description: 'The analyst owns the one-time answer.' },
-    responseChange: { status: 'absent', kind: 'none', description: 'There is no recurring response loop.' },
-    recommendedFormat: 'one_off_analysis'
-  }));
-
-  assert.equal(result.result.transition, 'REDIRECT_NON_DASHBOARD');
-  assert.equal(result.result.recommendedFormat, 'one_off_analysis');
-});
-
-test('inferred worthiness cannot silently pass and asks for confirmation', () => {
-  const result = compile(assessment({
-    purpose: 'unclear',
-    decisionLoop: { status: 'inferred', description: 'A weekly decision loop seems plausible but is not confirmed.' },
-    accountability: { status: 'inferred', mode: 'shared_forum', description: 'A cross-functional review may own the decision.' },
-    responseChange: { status: 'inferred', kind: 'coordination', description: 'The meeting may change coordination priorities.' },
-    recommendedFormat: 'undetermined'
-  }));
-
-  assert.equal(result.result.transition, 'ASK_WORTHINESS_QUESTION');
-  assert.equal(result.svg, null);
-});
-
-test('recurring exception monitoring with an on-call team can proceed', () => {
-  const result = compile(assessment({
-    purpose: 'recurring_monitoring',
-    decisionLoop: { status: 'confirmed', description: 'The service is monitored continuously for operational exceptions.' },
-    accountability: { status: 'confirmed', mode: 'on_call_team', description: 'The on-call operations team owns escalation.' },
-    responseChange: { status: 'confirmed', kind: 'escalation', description: 'A breach changes escalation and intervention.' }
-  }));
-
-  assert.equal(result.result.transition, 'PASS');
-  assert.equal(result.result.worthinessSummary.accountabilityMode, 'on_call_team');
-});
-
-test('a shared decision forum is a valid accountability path without a single owner', () => {
-  const result = compile(assessment({
-    purpose: 'shared_coordination',
-    decisionLoop: { status: 'confirmed', description: 'The board reviews the same operating signals every month.' },
-    accountability: { status: 'confirmed', mode: 'shared_forum', description: 'The board is the recurring accountable decision forum.' },
-    responseChange: { status: 'confirmed', kind: 'coordination', description: 'The review changes cross-functional priorities and coordination.' }
-  }));
-
-  assert.equal(result.result.transition, 'PASS');
-  assert.equal(result.result.worthinessSummary.accountabilityMode, 'shared_forum');
-});
+    if (scenario.expected.transition !== 'PASS') {
+      assert.equal(result.result.stage, 'worthiness');
+      assert.equal(result.svg, null);
+      assert.equal(result.html, null);
+    }
+  });
+}
 
 test('malformed worthiness assessments fail closed before Metric Router validation', () => {
-  const malformed = assessment({ surprise: 'not allowed' });
+  const malformed = { ...structuredClone(dashboardWorthiness), surprise: 'not allowed' };
   const result = compile(malformed);
 
   assert.equal(result.result.stage, 'worthiness');
   assert.equal(result.result.transition, 'FIX_WORTHINESS_ASSESSMENT');
   assert.ok(result.result.errors.some((error) => error.code === 'WORTHINESS_SCHEMA_INVALID'));
   assert.equal(result.svg, null);
+});
+
+test('a non-dashboard redirect cannot smuggle dashboard back in as the recommended format', () => {
+  const visibility = structuredClone(scenarios.find((scenario) => scenario.id === 'visibility-only').assessment);
+  visibility.recommendedFormat = 'dashboard';
+  const result = compile(visibility);
+
+  assert.equal(result.result.transition, 'FIX_WORTHINESS_ASSESSMENT');
+  assert.ok(result.result.errors.some((error) => error.code === 'FORMAT_TRANSITION_CONFLICT'));
 });

--- a/tests/compiler/worthiness-behavior.test.js
+++ b/tests/compiler/worthiness-behavior.test.js
@@ -1,0 +1,114 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { fileURLToPath } from 'node:url';
+import { compileDecisionDashboard } from '../../skills/decision-first-dashboard/scripts/compile-dashboard.js';
+
+const groundingDir = fileURLToPath(new URL('./fixtures/grounding/', import.meta.url));
+const routingDir = fileURLToPath(new URL('./fixtures/routing/', import.meta.url));
+const noScoreBundle = JSON.parse(fs.readFileSync(path.join(groundingDir, 'no-score.grounded.json'), 'utf8'));
+const noScoreRouting = JSON.parse(fs.readFileSync(path.join(routingDir, 'no-score.routing.json'), 'utf8'));
+
+function assessment(overrides = {}) {
+  return {
+    version: '1.0',
+    purpose: 'recurring_decision',
+    decisionLoop: {
+      status: 'confirmed',
+      description: 'Weekly review changes which retention risk receives attention first.'
+    },
+    accountability: {
+      status: 'confirmed',
+      mode: 'single_owner',
+      description: 'Head of Customer Success owns the review.'
+    },
+    responseChange: {
+      status: 'confirmed',
+      kind: 'priority',
+      description: 'The review changes which accounts are prioritized for intervention.'
+    },
+    recommendedFormat: 'dashboard',
+    ...overrides
+  };
+}
+
+function compile(worthiness) {
+  return compileDecisionDashboard(worthiness, noScoreRouting, noScoreBundle, { baseDir: groundingDir });
+}
+
+test('visibility-only requests are redirected before routing or rendering', () => {
+  const result = compile(assessment({
+    purpose: 'visibility_only',
+    decisionLoop: { status: 'absent', description: 'The request is only to glance at numbers each week.' },
+    accountability: { status: 'absent', mode: 'absent', description: 'No person or forum is accountable for acting on it.' },
+    responseChange: { status: 'absent', kind: 'none', description: 'No action, priority, escalation, intervention, or coordination changes.' },
+    recommendedFormat: 'scheduled_summary'
+  }));
+
+  assert.equal(result.result.stage, 'worthiness');
+  assert.equal(result.result.transition, 'REDIRECT_NON_DASHBOARD');
+  assert.equal(result.result.recommendedFormat, 'scheduled_summary');
+  assert.equal(result.svg, null);
+  assert.equal(result.html, null);
+});
+
+test('one-off questions redirect to one-off analysis instead of a persistent dashboard', () => {
+  const result = compile(assessment({
+    purpose: 'one_off_question',
+    decisionLoop: { status: 'absent', description: 'This is a single investigation of last quarter.' },
+    accountability: { status: 'confirmed', mode: 'single_owner', description: 'The analyst owns the one-time answer.' },
+    responseChange: { status: 'absent', kind: 'none', description: 'There is no recurring response loop.' },
+    recommendedFormat: 'one_off_analysis'
+  }));
+
+  assert.equal(result.result.transition, 'REDIRECT_NON_DASHBOARD');
+  assert.equal(result.result.recommendedFormat, 'one_off_analysis');
+});
+
+test('inferred worthiness cannot silently pass and asks for confirmation', () => {
+  const result = compile(assessment({
+    purpose: 'unclear',
+    decisionLoop: { status: 'inferred', description: 'A weekly decision loop seems plausible but is not confirmed.' },
+    accountability: { status: 'inferred', mode: 'shared_forum', description: 'A cross-functional review may own the decision.' },
+    responseChange: { status: 'inferred', kind: 'coordination', description: 'The meeting may change coordination priorities.' },
+    recommendedFormat: 'undetermined'
+  }));
+
+  assert.equal(result.result.transition, 'ASK_WORTHINESS_QUESTION');
+  assert.equal(result.svg, null);
+});
+
+test('recurring exception monitoring with an on-call team can proceed', () => {
+  const result = compile(assessment({
+    purpose: 'recurring_monitoring',
+    decisionLoop: { status: 'confirmed', description: 'The service is monitored continuously for operational exceptions.' },
+    accountability: { status: 'confirmed', mode: 'on_call_team', description: 'The on-call operations team owns escalation.' },
+    responseChange: { status: 'confirmed', kind: 'escalation', description: 'A breach changes escalation and intervention.' }
+  }));
+
+  assert.equal(result.result.transition, 'PASS');
+  assert.equal(result.result.worthinessSummary.accountabilityMode, 'on_call_team');
+});
+
+test('a shared decision forum is a valid accountability path without a single owner', () => {
+  const result = compile(assessment({
+    purpose: 'shared_coordination',
+    decisionLoop: { status: 'confirmed', description: 'The board reviews the same operating signals every month.' },
+    accountability: { status: 'confirmed', mode: 'shared_forum', description: 'The board is the recurring accountable decision forum.' },
+    responseChange: { status: 'confirmed', kind: 'coordination', description: 'The review changes cross-functional priorities and coordination.' }
+  }));
+
+  assert.equal(result.result.transition, 'PASS');
+  assert.equal(result.result.worthinessSummary.accountabilityMode, 'shared_forum');
+});
+
+test('malformed worthiness assessments fail closed before Metric Router validation', () => {
+  const malformed = assessment({ surprise: 'not allowed' });
+  const result = compile(malformed);
+
+  assert.equal(result.result.stage, 'worthiness');
+  assert.equal(result.result.transition, 'FIX_WORTHINESS_ASSESSMENT');
+  assert.ok(result.result.errors.some((error) => error.code === 'WORTHINESS_SCHEMA_INVALID'));
+  assert.equal(result.svg, null);
+});

--- a/tests/compiler/worthiness-behavior.test.js
+++ b/tests/compiler/worthiness-behavior.test.js
@@ -55,3 +55,14 @@ test('a non-dashboard redirect cannot smuggle dashboard back in as the recommend
   assert.equal(result.result.transition, 'FIX_WORTHINESS_ASSESSMENT');
   assert.ok(result.result.errors.some((error) => error.code === 'FORMAT_TRANSITION_CONFLICT'));
 });
+
+test('an explicit user override can proceed to Decision Brief while keeping downstream gates intact', () => {
+  const visibility = structuredClone(scenarios.find((scenario) => scenario.id === 'visibility-only').assessment);
+  visibility.userOverride = true;
+  visibility.recommendedFormat = 'dashboard';
+  const result = compile(visibility);
+
+  assert.equal(result.result.transition, 'PASS');
+  assert.equal(result.result.worthinessSummary.userOverride, true);
+  assert.equal(result.result.routingSummary.primaryCount, 5);
+});


### PR DESCRIPTION
Moves Dashboard Worthiness from prose-only guidance to an executable machine gate.

- adds a closed `worthiness-assessment` schema and validator-owned transitions
- gates production compilation before Metric Router / grounding
- adds behavior fixtures for visibility-only, one-off analysis, uncertain intent, operational monitoring, and board/shared-forum accountability
- treats accountability as a path, not necessarily a single owner
- preserves explicit user override without bypassing downstream gates
- documents the important boundary: structural/semantic validation does not prove the LLM interpreted raw natural-language intent correctly
- updates CI to execute the worthiness gate before routed compilation

TDD evidence: the initial behavior suite failed against the old routing-first path; the final head passes the full workflow, including a fresh rerun of the complete CI job.