### PR TITLE
Add Anthropic plugin packaging

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,20 @@
+{
+  "name": "decision-first-dashboard",
+  "version": "1.0.0",
+  "description": "Turn KPI-heavy dashboards into grounded, decision-first views with dashboard-worthiness checks, metric routing, evidence validation, and deterministic rendering.",
+  "author": {
+    "name": "fourleaf13-hue",
+    "url": "https://github.com/fourleaf13-hue"
+  },
+  "homepage": "https://github.com/fourleaf13-hue/decision-first-dashboard",
+  "repository": "https://github.com/fourleaf13-hue/decision-first-dashboard",
+  "license": "MIT",
+  "keywords": [
+    "dashboard",
+    "analytics",
+    "data-visualization",
+    "decision-support",
+    "business-intelligence",
+    "agent-skill"
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ If those facts are missing, it falls back to `no_score` instead of guessing.
 npx skills add fourleaf13-hue/decision-first-dashboard
 ```
 
+The repository is also packaged as a standard Claude plugin via `.claude-plugin/plugin.json` for Anthropic Plugin Directory submission. Until directory approval, the skill install command above remains the public install path.
+
 ## Use
 
 Give your agent a dashboard screenshot, Figma frame, existing dashboard code, or verified metrics and ask:
@@ -223,7 +225,13 @@ npm run validate:saas
 npm run render:saas
 ```
 
-GitHub Actions runs the compiler suite, including executable Worthiness scenario fixtures, Decision Brief intake, 70-KPI Metric Router behavior, routed production compilation, grounded composite/no-score compilation, radar rendering, and byte-level golden snapshots.
+For Anthropic plugin packaging, validate the repository root with a current Claude Code CLI before submission:
+
+```bash
+claude plugin validate . --strict
+```
+
+GitHub Actions runs the compiler suite, including the plugin manifest contract, executable Worthiness scenario fixtures, Decision Brief intake, 70-KPI Metric Router behavior, routed production compilation, grounded composite/no-score compilation, radar rendering, and byte-level golden snapshots.
 
 ## What this is not
 

--- a/tests/compiler/plugin-manifest.test.js
+++ b/tests/compiler/plugin-manifest.test.js
@@ -1,0 +1,25 @@
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync } from 'node:fs';
+import test from 'node:test';
+
+const manifestPath = '.claude-plugin/plugin.json';
+const skillPath = 'skills/decision-first-dashboard/SKILL.md';
+
+test('Anthropic plugin manifest exposes the dashboard skill with stable metadata', () => {
+  assert.equal(existsSync(manifestPath), true, `${manifestPath} must exist`);
+  assert.equal(existsSync(skillPath), true, `${skillPath} must remain at plugin root`);
+
+  const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+
+  assert.equal(manifest.name, 'decision-first-dashboard');
+  assert.match(manifest.version, /^\d+\.\d+\.\d+$/);
+  assert.match(manifest.description, /dashboard/i);
+  assert.equal(manifest.author?.name, 'fourleaf13-hue');
+  assert.equal(manifest.author?.url, 'https://github.com/fourleaf13-hue');
+  assert.equal(manifest.homepage, 'https://github.com/fourleaf13-hue/decision-first-dashboard');
+  assert.equal(manifest.repository, 'https://github.com/fourleaf13-hue/decision-first-dashboard');
+  assert.equal(manifest.license, 'MIT');
+  assert.ok(Array.isArray(manifest.keywords));
+  assert.ok(manifest.keywords.includes('dashboard'));
+  assert.ok(manifest.keywords.includes('decision-support'));
+});


### PR DESCRIPTION
Prepare Decision-First Dashboard for Anthropic's plugin directory with a standard `.claude-plugin/plugin.json` manifest, README install guidance, and a contract test that keeps the plugin packaging valid.

This PR intentionally starts with a failing manifest contract test, then adds the manifest and documentation so CI demonstrates the RED → GREEN transition.