### PR TITLE
Refine radar into a proportional profile comparison

### DIFF
--- a/examples/saas/output.no-score.svg
+++ b/examples/saas/output.no-score.svg
@@ -12,10 +12,10 @@
       <stop offset="1" stop-color="#ffffff" stop-opacity="0"/>
     </radialGradient>
     <radialGradient id="centerField" cx="47%" cy="43%" r="58%">
-      <stop offset="0" stop-color="#e5dfff" stop-opacity="0.82"/>
-      <stop offset="0.35" stop-color="#efecff" stop-opacity="0.72"/>
-      <stop offset="0.72" stop-color="#f8f8ff" stop-opacity="0.94"/>
-      <stop offset="1" stop-color="#fbfcff" stop-opacity="0.98"/>
+      <stop offset="0" stop-color="#e5dfff" stop-opacity="0.50"/>
+      <stop offset="0.35" stop-color="#efecff" stop-opacity="0.48"/>
+      <stop offset="0.72" stop-color="#f8f8ff" stop-opacity="0.82"/>
+      <stop offset="1" stop-color="#fbfcff" stop-opacity="0.94"/>
     </radialGradient>
     <linearGradient id="accentLine" x1="0" y1="0" x2="1" y2="1">
       <stop offset="0" stop-color="#6555e8"/>
@@ -29,7 +29,7 @@
       <feDropShadow dx="0" dy="9" stdDeviation="10" flood-color="#51468d" flood-opacity="0.12"/>
     </filter>
     <marker id="radarVertex" viewBox="0 0 14 14" refX="7" refY="7" markerWidth="14" markerHeight="14" markerUnits="userSpaceOnUse">
-      <circle cx="7" cy="7" r="5" fill="#6555e8" stroke="#ffffff" stroke-width="2"/>
+      <circle cx="7" cy="7" r="5" fill="#f45fa5" stroke="#ffffff" stroke-width="2"/>
     </marker>
     <style>
       .sans { font-family: Inter, ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
@@ -42,13 +42,14 @@
       .support-shadow { fill: #655b8f; fill-opacity: .065; }
       .support-panel { fill: #ffffff; fill-opacity: .97; stroke: #e1e4f1; stroke-width: 1; filter: url(#panelShadow); }
       .center-halo { fill: none; }
-      .center-halo--outer { stroke: #b8afe9; stroke-opacity: .30; stroke-width: 1; }
-      .center-halo--inner { stroke: #c8c0f2; stroke-opacity: .16; stroke-width: 22; }
+      .center-halo--outer { stroke: #b8afe9; stroke-opacity: .24; stroke-width: 1; }
+      .center-halo--inner { stroke: #c8c0f2; stroke-opacity: .11; stroke-width: 22; }
       .center-field { fill: url(#centerField); stroke: #ddd9f5; stroke-width: 1; }
-      .radar-guide { fill: none; stroke: #d2cdf4; stroke-width: 1; stroke-dasharray: 6 9; }
-      .radar-shape { marker-start: url(#radarVertex); marker-mid: url(#radarVertex); }
+      .radar-scale-ring { fill: none; stroke: #d8d9eb; stroke-width: 1; stroke-opacity: .82; }
+      .radar-spokes { fill: none; stroke: #dedff0; stroke-width: 1; }
+      .radar-shape--previous { fill: #3b82f6; fill-opacity: .07; stroke: #3b82f6; stroke-width: 3; stroke-linejoin: round; }
+      .radar-shape--current { fill: #f45fa5; fill-opacity: .13; stroke: #f45fa5; stroke-width: 3; stroke-linejoin: round; marker-start: url(#radarVertex); marker-mid: url(#radarVertex); }
       .metric-orb { fill: #f8f7ff; fill-opacity: .98; stroke: #d8d3f4; stroke-width: 1; filter: url(#orbShadow); }
-      .direction-core { fill: #ffffff; stroke: #ffffff; stroke-width: 10; filter: url(#orbShadow); }
     </style>
   </defs>
 
@@ -93,11 +94,6 @@
     <circle cx="740" cy="458" r="366" class="center-halo center-halo--outer"/>
     <circle cx="740" cy="458" r="338" class="center-halo center-halo--inner"/>
     <circle cx="740" cy="458" r="314" class="center-field"/>
-    <text x="434" y="198" class="muted" font-size="10" font-weight="700" letter-spacing="1.8">OVERALL DIRECTION</text>
-
-    <circle cx="740" cy="458" r="214" class="radar-guide"/>
-    <circle cx="740" cy="458" r="158" class="radar-guide"/>
-    <circle cx="740" cy="458" r="104" class="radar-guide"/>
 
     <g transform="translate(42 -6)">
       <path class="orbit-spokes" d="M698 464 L548 330 M698 464 L848 330 M698 464 L548 590 M698 464 L848 590" fill="none" stroke="#d6d0ef" stroke-width="1.6"/>
@@ -130,11 +126,6 @@
       <text x="848" y="700" class="muted" font-size="10" text-anchor="middle">31.7%</text>
     </g>
     </g>
-
-    <circle cx="740" cy="458" r="82" class="direction-core"/>
-    <circle cx="740" cy="458" r="70" fill="#fbfaff"/>
-    <text x="740" y="451" class="accent" font-size="22" font-weight="790" text-anchor="middle">IMPROVING</text>
-    <text x="740" y="482" class="muted" font-size="12" text-anchor="middle">Target unknown</text>
 
     <text x="1066" y="194" class="ink" font-size="15" font-weight="700">Accounts to watch</text>
     <g>

--- a/skills/decision-first-dashboard/references/visual-pattern.md
+++ b/skills/decision-first-dashboard/references/visual-pattern.md
@@ -17,41 +17,113 @@ Preferred balance:
 The signature visual language is:
 
 - a large open circular center field as the first focal point;
-- layered halos / orbit geometry that creates depth without implying unsupported relationships;
-- compact floating metric orbs around the center rather than equal KPI cards across the top;
+- layered ambient halos that create depth without pretending to be quantitative scale;
+- a true profile radar only when 3–6 dimensions are comparable on one grounded scale;
 - elevated translucent support surfaces at the sides for context, diagnosis, exceptions, and events;
-- asymmetric information density: synthesis/profile in the center, explanation on the left, attention items on the right;
-- restrained violet/blue accents, soft cool background, generous whitespace, and strong typographic hierarchy;
+- asymmetric information density: profile in the center, explanation on the left, attention items on the right;
+- restrained cool background, generous whitespace, and strong typographic hierarchy;
 - source-backed mini trends where they genuinely explain movement.
 
 Supporting cards are allowed and encouraged when they make the output feel like a production dashboard. They must remain subordinate to the center and must not collapse back into a flat wall of equally weighted KPI cards.
 
-## No-score executive composition
+## No-score composition
+
+A no-score dashboard has two valid center behaviors.
+
+When the routed primary signals are heterogeneous raw KPIs, use the non-radar radial/orbit signal composition. Different units must never be encoded as polygon distance.
+
+When 3–6 routed primary dimensions pass radar eligibility, use a neutral profile radar:
 
 ```text
-┌────────────────┬──────────────────────────────────┬──────────────────┐
-│ Revenue        │          open center field       │ Accounts to watch│
-│ context        │                                  │                  │
-│ + real trend   │     MRR              Customers   │ confirmed source │
-│                │        ╲            ╱             │ exceptions       │
-│ Movement       │          IMPROVING               │                  │
-│ context        │          target unknown          │ Recent events    │
-│                │        ╱            ╲             │                  │
-│                │     Churn          Conversion    │                  │
-└────────────────┴──────────────────────────────────┴──────────────────┘
+                         Dimension
+                      value  ↑/↓ delta
+
+                    ┌── 100% ──┐
+                 ┌───── 80% ─────┐
+              ┌──────── 60% ────────┐
+           ┌─────────── 40% ───────────┐
+ left label  ←   previous/current profile   →  right label
+ right aligned                               left aligned
+           └───────────────────────────────┘
+
+                         Dimension
+                      value  ↑/↓ delta
 ```
 
-The center is a synthesis cluster, not a large prose card. Ordinary raw signals may use radial/orbit placement, but their different units must never be encoded as polygon distance.
+The radar center is intentionally empty. Do not place an overall score, health badge, `IMPROVING`, `At risk`, or other synthetic verdict in the middle. The profile shape itself communicates expansion, contraction, imbalance, and relative weakness.
+
+## Radar profile eligibility
+
+Radar is a profile visualization, **not a score visualization**. It may represent percentages, achievement rates, normalized values, maturity levels, or other peer dimensions when they share one meaningful source-backed scale.
+
+Use a radar only when all of these conditions hold:
+
+- 3–6 peer dimensions describe the same object or condition;
+- every vertex uses the same source-backed numeric scale;
+- the dimensions are meaningfully comparable;
+- every displayed dimension is grounded and passes the Action Trigger Test;
+- mixed-unit raw KPIs are not being normalized merely to make a radar possible.
+
+Three dimensions form a triangle. Four to six dimensions use one vertex per dimension. Fewer than three dimensions are not radar-eligible.
+
+A radar does **not** require an overall score. `no_score` may render a radar whenever the comparable dimensions and shared scale are grounded.
+
+## Quantitative radar geometry
+
+The quantitative grid is fixed and must not be improvised for visual effect.
+
+- Render exactly **four concentric scale rings** at **40%, 60%, 80%, and 100%** of the radar radius.
+- All four rings share exactly one center.
+- Ring radii are proportional: `0.4R`, `0.6R`, `0.8R`, `1.0R`.
+- The scale rings are thin and quiet. They are measurement guides, not decorative halos.
+- Decorative ambient halos may sit behind the radar, but they must remain visually distinct from the four quantitative rings.
+- All polygon vertices stay inside the 100% ring.
+
+## Current versus previous profile
+
+A simple period comparison is allowed only when both periods use identical dimensions and scale.
+
+- Previous period: blue profile, rendered first/below the current profile.
+- Current period: pink/red profile, rendered above the previous profile.
+- Current vertices use small visible circular markers.
+- Previous vertices do not need markers.
+- A previous-period profile must be complete across every displayed dimension; partial comparison profiles are rejected.
+- Every previous-period normalized value must be source-backed and remain inside the same declared scale.
+
+Do not create multi-series spider webs. One current profile plus at most one comparison profile is the intended pattern.
+
+## Dimension labels and deltas
+
+Every radar dimension keeps its concrete business value visible. The polygon shape is not a replacement for the actual number.
+
+All dimension copy belongs **outside the 100% ring**:
+
+1. dimension name;
+2. current concrete value;
+3. optional period delta.
+
+Alignment follows physical position around the circle:
+
+- left-side labels and values: **right-aligned**;
+- right-side labels and values: **left-aligned**;
+- exact top and bottom labels: centered.
+
+Delta arrows communicate numeric movement:
+
+- positive numeric change → `↑`;
+- negative numeric change → `↓`;
+- flat change → `→`.
+
+Delta **color** communicates business favorability and must use the grounded signal direction, not the arithmetic sign. For example, churn falling from 6.8% to 4.2% may correctly render a green downward arrow.
 
 ## Evidence rules that affect rendering
 
-- Overall direction is derived by the renderer from signal directions.
-- `Improving` does not mean `Healthy`.
 - Numeric trend series render only when the contract marks them as source-supported.
 - If an exact trend series is unavailable, the renderer states that the trend data is unavailable instead of drawing an invented chart.
 - Account exceptions and events render only with source provenance.
-- No-score mode never renders a 0–100 score or unsupported health band.
-- Visual depth, halos, cards, and connection lines are presentation only. They do not create evidence or business semantics.
+- No-score mode never renders a 0–100 overall score or unsupported health band.
+- Radar scale, current normalized values, and any previous-period normalized values must be grounded.
+- Visual depth, ambient halos, cards, and connection lines are presentation only. They do not create evidence or business semantics.
 
 ## Product language
 
@@ -67,31 +139,21 @@ The templates intentionally omit:
 - full-width customer tables;
 - health banners without source support;
 - workflow/action buttons without source support;
-- arbitrary free-text insight panels.
+- arbitrary free-text insight panels;
+- score-like text in the middle of a radar merely to fill empty space.
 
 The center should remain visually dominant even when the side support surfaces contain more literal information. Do not solve overload by shrinking type or squeezing more peers into the center.
 
 If a user wants a different visual system, modify the deterministic templates deliberately; do not let the LLM improvise a replacement layout during ordinary dashboard compilation.
+
+## Composite mode
+
+A genuine source-supported composite score may still exist. Keep that real score and its band in a support card rather than using it as the radar's center label. Its 3–6 comparable normalized components may form the profile radar using the same neutral center and 40/60/80/100 visual grammar.
+
+Never invent a composite score, normalized component, weight, band, previous-period value, or radar scale merely to obtain the signature visual.
 
 ## Visualization tool routing
 
 Do not confuse a chart library with a visual-design skill. Recharts, visx, Bokeh, Cube, Nivo, Vue-ECharts, and Scrollama are primarily implementation libraries or infrastructure; ApexCharts currently provides a dedicated official AI skill.
 
 The default production path in this repository remains deterministic SVG/HTML. If a user explicitly asks for a framework implementation, choose the tool according to `visual-stack-routing.md`. In particular, prefer **visx** for bespoke React geometry that must closely reproduce the signature layout, and **Recharts** for conventional supporting charts. Never import a library merely to obtain its default demo aesthetic.
-
-## Radar profile eligibility
-
-Use a radar only to show the profile of one object or condition across **3–6 peer dimensions** on one shared, source-backed numeric scale.
-
-- 3 dimensions render as a triangle; fewer than 3 are invalid for radar.
-- 4–6 dimensions render with one vertex per dimension.
-- Each radar vertex must use a source-backed normalized score on the same scale.
-- A radar does not require an overall score: `no_score` may still use a radar when the comparable dimension scores and shared scale are grounded.
-- Do not connect mixed-unit KPIs such as dollars, counts, rates, durations, and ratios into a polygon. Use the ordinary radial signal composition instead.
-- Prefer one profile, or at most a simple before/after comparison when both series use identical dimensions and scale. Do not create a multi-series spider web.
-
-## Composite mode
-
-When a composite model is genuinely grounded, the center score remains dominant and its 3–6 normalized components form a closed radar profile. The same floating-orb and side-support visual language applies.
-
-Never invent a composite score, normalized component, weight, band, or radar scale merely to obtain the signature visual.

--- a/skills/decision-first-dashboard/schemas/decision-state.schema.json
+++ b/skills/decision-first-dashboard/schemas/decision-state.schema.json
@@ -63,6 +63,7 @@
         "delta": { "type": "string", "minLength": 1, "maxLength": 20 },
         "direction": { "enum": ["improving", "deteriorating", "flat", "unknown"] },
         "normalizedScore": { "type": "number" },
+        "previousNormalizedScore": { "type": "number" },
         "provenance": { "enum": ["source", "derived"] }
       }
     },

--- a/skills/decision-first-dashboard/scripts/grounding.js
+++ b/skills/decision-first-dashboard/scripts/grounding.js
@@ -139,7 +139,7 @@ function requiredNoScorePaths(data) {
     paths.push('/radarScale/min', '/radarScale/max');
   }
   data.signals.forEach((signal, index) => {
-    for (const field of ['label', 'value', 'delta', 'direction', 'normalizedScore']) {
+    for (const field of ['label', 'value', 'delta', 'direction', 'normalizedScore', 'previousNormalizedScore']) {
       if (Object.hasOwn(signal, field)) paths.push(`/signals/${index}/${field}`);
     }
   });

--- a/skills/decision-first-dashboard/scripts/render.js
+++ b/skills/decision-first-dashboard/scripts/render.js
@@ -44,22 +44,19 @@ export function deriveOverallDirection(signals = []) {
   return 'unknown';
 }
 
-function synthesisCopy(signals) {
-  const direction = {
-    improving: 'IMPROVING',
-    deteriorating: 'DETERIORATING',
-    mixed: 'MIXED',
-    flat: 'FLAT',
-    unknown: 'UNKNOWN'
-  }[deriveOverallDirection(signals)];
-
-  return { direction, target: 'Target unknown' };
-}
-
 function directionClass(direction) {
   if (direction === 'improving') return 'positive';
   if (direction === 'deteriorating') return 'danger';
   return 'muted';
+}
+
+function deltaWithArrow(delta) {
+  if (!delta) return null;
+  const text = String(delta).trim();
+  if (text.startsWith('+')) return `↑ ${text.slice(1)}`;
+  if (text.startsWith('-')) return `↓ ${text.slice(1)}`;
+  if (/^0(?:\D|$)/.test(text)) return `→ ${text.replace(/^[-+]/, '')}`;
+  return text;
 }
 
 function signalDisplay(signal) {
@@ -167,6 +164,7 @@ function htmlRowXs(count) {
 
 const SVG_RADAR_LAYOUT = { cx: 698, cy: 464, radarRadius: 188, labelRadius: 238 };
 const HTML_RADAR_LAYOUT = { cx: 310, cy: 260, radarRadius: 188, labelRadius: 238 };
+const RADAR_SCALE_STEPS = [40, 60, 80, 100];
 
 function radialPoint(cx, cy, radius, angle) {
   return {
@@ -182,48 +180,103 @@ function pointPath(points, close = false) {
   return close ? `${path} Z` : path;
 }
 
-function radarGeometry(dimensions, min, max, layout) {
+function radarGeometry(dimensions, min, max, layout, valueKey = 'normalizedScore') {
   const span = max - min;
   const count = dimensions.length;
   const axes = [];
   const shape = [];
   const labels = [];
+  const angles = [];
 
   dimensions.forEach((dimension, index) => {
     const angle = -Math.PI / 2 + (Math.PI * 2 * index) / count;
-    const ratio = Math.min(1, Math.max(0, (dimension.normalizedScore - min) / span));
+    const value = dimension[valueKey];
+    const ratio = Math.min(1, Math.max(0, (value - min) / span));
     axes.push(radialPoint(layout.cx, layout.cy, layout.radarRadius, angle));
     shape.push(radialPoint(layout.cx, layout.cy, layout.radarRadius * ratio, angle));
     labels.push(radialPoint(layout.cx, layout.cy, layout.labelRadius, angle));
+    angles.push(angle);
   });
 
   return {
     shape: pointPath(shape, true),
     spokes: axes.map((point) => `M${layout.cx} ${layout.cy} L${point.x.toFixed(1)} ${point.y.toFixed(1)}`).join(' '),
-    labels
+    labels,
+    angles
   };
 }
 
+function radarScaleRings(layout) {
+  return RADAR_SCALE_STEPS.map((scale) => {
+    const radius = Number((layout.radarRadius * scale / 100).toFixed(1));
+    return `<circle class="radar-scale-ring" data-scale="${scale}" r="${radius}" cx="${layout.cx}" cy="${layout.cy}"/>`;
+  }).join('\n');
+}
+
+function hasCompletePreviousProfile(dimensions) {
+  return dimensions.length > 0 && dimensions.every((dimension) => Number.isFinite(dimension.previousNormalizedScore));
+}
+
+function radarSide(angle) {
+  const x = Math.cos(angle);
+  const y = Math.sin(angle);
+  if (Math.abs(x) < 0.15) return y < 0 ? 'top' : 'bottom';
+  return x < 0 ? 'left' : 'right';
+}
+
+function radarAnchor(side) {
+  if (side === 'left') return 'end';
+  if (side === 'right') return 'start';
+  return 'middle';
+}
+
 function svgRadarVisual(dimensions, min, max) {
-  const geometry = radarGeometry(dimensions, min, max, SVG_RADAR_LAYOUT);
-  return `<path class="radar-spokes" d="${geometry.spokes}"/>
-    <path class="radar-shape" d="${geometry.shape}" fill="#6555e8" fill-opacity="0.16" stroke="#6555e8" stroke-width="3" stroke-linejoin="round"/>`;
+  const current = radarGeometry(dimensions, min, max, SVG_RADAR_LAYOUT);
+  const previous = hasCompletePreviousProfile(dimensions)
+    ? radarGeometry(dimensions, min, max, SVG_RADAR_LAYOUT, 'previousNormalizedScore')
+    : null;
+  const previousPath = previous
+    ? `<path class="radar-shape radar-shape--previous" d="${previous.shape}"/>`
+    : '';
+
+  return `${radarScaleRings(SVG_RADAR_LAYOUT)}
+    <path class="radar-spokes" d="${current.spokes}"/>
+    ${previousPath}
+    <path class="radar-shape radar-shape--current" d="${current.shape}"/>`;
 }
 
 function htmlRadarVisual(dimensions, min, max) {
-  const geometry = radarGeometry(dimensions, min, max, HTML_RADAR_LAYOUT);
-  return `<path class="radar-spokes" d="${geometry.spokes}"></path>
-            <path class="radar-shape" d="${geometry.shape}"></path>`;
+  const current = radarGeometry(dimensions, min, max, HTML_RADAR_LAYOUT);
+  const previous = hasCompletePreviousProfile(dimensions)
+    ? radarGeometry(dimensions, min, max, HTML_RADAR_LAYOUT, 'previousNormalizedScore')
+    : null;
+  const previousPath = previous
+    ? `<path class="radar-shape radar-shape--previous" d="${previous.shape}"></path>`
+    : '';
+
+  return `${radarScaleRings(HTML_RADAR_LAYOUT)}
+            <path class="radar-spokes" d="${current.spokes}"></path>
+            ${previousPath}
+            <path class="radar-shape radar-shape--current" d="${current.shape}"></path>`;
 }
 
 function svgRadarNodes(dimensions, min, max, nodeClass) {
   const geometry = radarGeometry(dimensions, min, max, SVG_RADAR_LAYOUT);
   return dimensions.map((dimension, index) => {
     const point = geometry.labels[index];
+    const side = radarSide(geometry.angles[index]);
+    const anchor = radarAnchor(side);
+    const startY = side === 'top' ? point.y - 21 : side === 'bottom' ? point.y - 3 : point.y - 20;
+    const delta = deltaWithArrow(dimension.delta);
+    const deltaNode = delta
+      ? `<tspan x="${point.x.toFixed(1)}" dy="18" class="${directionClass(dimension.direction)}" font-size="11" font-weight="700">${escapeMarkup(delta)}</tspan>`
+      : '';
     return `<g class="${nodeClass}">
-      <rect x="${(point.x - 68).toFixed(1)}" y="${(point.y - 42).toFixed(1)}" width="136" height="68" rx="19" class="metric-orb"/>
-      <text x="${point.x.toFixed(1)}" y="${(point.y - 10).toFixed(1)}" class="accent" font-size="22" font-weight="760" text-anchor="middle">${escapeMarkup(formatScore(dimension.normalizedScore))}</text>
-      <text x="${point.x.toFixed(1)}" y="${(point.y + 13).toFixed(1)}" class="ink" font-size="12" font-weight="670" text-anchor="middle">${escapeMarkup(dimension.label)}</text>
+      <text class="radar-label radar-label--${side}" data-outside-ring="true" text-anchor="${anchor}" x="${point.x.toFixed(1)}" y="${startY.toFixed(1)}">
+        <tspan x="${point.x.toFixed(1)}" class="muted" font-size="11" font-weight="650">${escapeMarkup(dimension.label)}</tspan>
+        <tspan x="${point.x.toFixed(1)}" dy="20" class="ink" font-size="16" font-weight="760">${escapeMarkup(dimension.value)}</tspan>
+        ${deltaNode}
+      </text>
     </g>`;
   }).join('\n');
 }
@@ -232,9 +285,15 @@ function htmlRadarNodes(dimensions, min, max, className) {
   const geometry = radarGeometry(dimensions, min, max, HTML_RADAR_LAYOUT);
   return dimensions.map((dimension, index) => {
     const point = geometry.labels[index];
-    return `<div class="${className}" style="left:${(point.x / 620 * 100).toFixed(2)}%;top:${(point.y / 520 * 100).toFixed(2)}%">
-    <strong>${escapeMarkup(formatScore(dimension.normalizedScore))}</strong>
+    const side = radarSide(geometry.angles[index]);
+    const delta = deltaWithArrow(dimension.delta);
+    const deltaNode = delta
+      ? `<small class="${directionClass(dimension.direction)}">${escapeMarkup(delta)}</small>`
+      : '';
+    return `<div class="${className} radar-label radar-label--${side}" data-outside-ring="true" style="left:${(point.x / 620 * 100).toFixed(2)}%;top:${(point.y / 520 * 100).toFixed(2)}%">
     <span>${escapeMarkup(dimension.label)}</span>
+    <strong>${escapeMarkup(dimension.value)}</strong>
+    ${deltaNode}
   </div>`;
   }).join('\n');
 }
@@ -322,7 +381,7 @@ function svgComponentCluster(components, min, max) {
 function htmlComponentCluster(components, min, max) {
   return {
     visual: htmlRadarVisual(components, min, max),
-    nodes: htmlRadarNodes(components, min, max, 'signal score-component metric-orb')
+    nodes: htmlRadarNodes(components, min, max, 'score-component')
   };
 }
 
@@ -465,15 +524,14 @@ function fillTemplate(template, replacements) {
 
 function noScoreViewModel(data) {
   const revenue = selectRevenueSignal(data.signals);
-  const synthesis = synthesisCopy(data.signals);
   const revenueSeries = data.context?.provenance === 'source' ? data.context.revenueSeries : null;
   const movement = movementSignals(data.signals, revenue?.metric ?? null);
-  return { revenue, synthesis, revenueSeries, movement };
+  return { revenue, revenueSeries, movement };
 }
 
 function renderNoScoreSvg(data) {
   const template = fs.readFileSync(noScoreSvgTemplatePath, 'utf8');
-  const { revenue, synthesis, revenueSeries, movement } = noScoreViewModel(data);
+  const { revenue, revenueSeries, movement } = noScoreViewModel(data);
   const radar = data.radarScale
     ? {
         visual: svgRadarVisual(data.signals, data.radarScale.min, data.radarScale.max),
@@ -492,7 +550,6 @@ function renderNoScoreSvg(data) {
     CURRENT_REVENUE_LABEL: escapeMarkup(currentRevenueLabel(revenue)),
     REVENUE_VISUAL: svgRevenueVisual(revenueSeries),
     MOVEMENT_ROWS: svgMovementRows(movement),
-    SYNTHESIS: synthesis.direction,
     SVG_ORBIT_VISUAL: orbitVisual,
     SVG_SIGNAL_NODES: signalCluster.nodes,
     EXCEPTION_ROWS: svgExceptionRows(data.exceptions),
@@ -503,11 +560,11 @@ function renderNoScoreSvg(data) {
 function renderNoScoreHtml(data) {
   const template = fs.readFileSync(noScoreHtmlTemplatePath, 'utf8');
   const css = fs.readFileSync(cssTemplatePath, 'utf8');
-  const { revenue, synthesis, revenueSeries, movement } = noScoreViewModel(data);
+  const { revenue, revenueSeries, movement } = noScoreViewModel(data);
   const radar = data.radarScale
     ? {
         visual: htmlRadarVisual(data.signals, data.radarScale.min, data.radarScale.max),
-        nodes: htmlRadarNodes(data.signals, data.radarScale.min, data.radarScale.max, 'signal radar-dimension metric-orb')
+        nodes: htmlRadarNodes(data.signals, data.radarScale.min, data.radarScale.max, 'radar-dimension')
       }
     : null;
   const signalCluster = radar ?? htmlSignalCluster(data.signals);
@@ -523,7 +580,6 @@ function renderNoScoreHtml(data) {
     CURRENT_REVENUE_LABEL: escapeMarkup(currentRevenueLabel(revenue)),
     HTML_REVENUE_VISUAL: htmlRevenueVisual(revenueSeries),
     HTML_MOVEMENT_ROWS: htmlMovementRows(movement),
-    SYNTHESIS: synthesis.direction,
     HTML_ORBIT_VISUAL: orbitVisual,
     HTML_SIGNAL_NODES: signalCluster.nodes,
     HTML_EXCEPTION_ROWS: htmlExceptionRows(data.exceptions),

--- a/skills/decision-first-dashboard/scripts/validate.js
+++ b/skills/decision-first-dashboard/scripts/validate.js
@@ -253,7 +253,7 @@ function validateCompositeSemantics(data, errors) {
   }
 
   if (!nearlyEqual(bands[bands.length - 1].max, score.max, 1e-9)) {
-    pushError(errors, `/model/bands/${bands.length - 1]/max`, 'bandCoverage', 'last band must end at the score maximum');
+    pushError(errors, `/model/bands/${bands.length - 1}/max`, 'bandCoverage', 'last band must end at the score maximum');
   }
 
   const selectedBand = bands.find((band, index) => {

--- a/skills/decision-first-dashboard/scripts/validate.js
+++ b/skills/decision-first-dashboard/scripts/validate.js
@@ -135,15 +135,16 @@ function nearlyEqual(a, b, tolerance) {
 function validateNoScoreSemantics(data, errors) {
   const hasRadarScale = Object.hasOwn(data, 'radarScale');
   const scoredSignals = data.signals.filter((signal) => Object.hasOwn(signal, 'normalizedScore'));
+  const previousSignals = data.signals.filter((signal) => Object.hasOwn(signal, 'previousNormalizedScore'));
 
-  if (!hasRadarScale && scoredSignals.length === 0) return;
+  if (!hasRadarScale && scoredSignals.length === 0 && previousSignals.length === 0) return;
 
   if (!hasRadarScale) {
     pushError(
       errors,
       '/radarScale',
       'radarScale',
-      'source-backed radar scale is required when no-score signals contain normalized scores'
+      'source-backed radar scale is required when no-score signals contain normalized radar values'
     );
     return;
   }
@@ -159,7 +160,16 @@ function validateNoScoreSemantics(data, errors) {
       errors,
       '/signals',
       'radarEligibility',
-      'every no-score radar dimension must provide a source-backed normalized score on the shared radar scale'
+      'every no-score radar dimension must provide a source-backed normalized value on the shared radar scale'
+    );
+  }
+
+  if (previousSignals.length > 0 && previousSignals.length !== data.signals.length) {
+    pushError(
+      errors,
+      '/signals',
+      'radarComparison',
+      'previous-period radar comparison must provide a value for every displayed dimension'
     );
   }
 
@@ -173,13 +183,20 @@ function validateNoScoreSemantics(data, errors) {
   }
 
   for (const [index, signal] of data.signals.entries()) {
-    if (!Object.hasOwn(signal, 'normalizedScore')) continue;
-    if (signal.normalizedScore < min || signal.normalizedScore > max) {
+    if (Object.hasOwn(signal, 'normalizedScore') && (signal.normalizedScore < min || signal.normalizedScore > max)) {
       pushError(
         errors,
         `/signals/${index}/normalizedScore`,
         'radarScale',
-        'normalized score must lie within the declared no-score radar scale'
+        'normalized value must lie within the declared no-score radar scale'
+      );
+    }
+    if (Object.hasOwn(signal, 'previousNormalizedScore') && (signal.previousNormalizedScore < min || signal.previousNormalizedScore > max)) {
+      pushError(
+        errors,
+        `/signals/${index}/previousNormalizedScore`,
+        'radarScale',
+        'previous normalized value must lie within the declared no-score radar scale'
       );
     }
   }
@@ -236,7 +253,7 @@ function validateCompositeSemantics(data, errors) {
   }
 
   if (!nearlyEqual(bands[bands.length - 1].max, score.max, 1e-9)) {
-    pushError(errors, `/model/bands/${bands.length - 1}/max`, 'bandCoverage', 'last band must end at the score maximum');
+    pushError(errors, `/model/bands/${bands.length - 1]/max`, 'bandCoverage', 'last band must end at the score maximum');
   }
 
   const selectedBand = bands.find((band, index) => {

--- a/skills/decision-first-dashboard/templates/composite.html
+++ b/skills/decision-first-dashboard/templates/composite.html
@@ -5,7 +5,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>{{SCORE_LABEL}}</title>
   <style>{{CSS}}</style>
-  <style>.orbit .radar-shape { marker-start: url(#radarVertex); marker-mid: url(#radarVertex); }</style>
 </head>
 <body>
   <main class="dashboard-shell">
@@ -36,26 +35,17 @@
         </article>
       </aside>
 
-      <section class="card synthesis-card score-center" aria-label="{{SCORE_LABEL}} score">
+      <section class="card synthesis-card score-center" aria-label="{{SCORE_LABEL}} profile">
         <div class="orbit" aria-hidden="true">
-          <div class="orbit-ring orbit-ring--outer"></div>
-          <div class="orbit-ring orbit-ring--middle"></div>
-          <div class="orbit-ring orbit-ring--inner"></div>
-          <svg viewBox="0 0 620 520" preserveAspectRatio="none">
+          <svg viewBox="0 0 620 520" preserveAspectRatio="xMidYMid meet">
             <defs>
               <marker id="radarVertex" viewBox="0 0 14 14" refX="7" refY="7" markerWidth="14" markerHeight="14" markerUnits="userSpaceOnUse">
-                <circle cx="7" cy="7" r="5" fill="#6555e8" stroke="#ffffff" stroke-width="2"></circle>
+                <circle cx="7" cy="7" r="5" fill="#f45fa5" stroke="#ffffff" stroke-width="2"></circle>
               </marker>
             </defs>
             {{HTML_COMPONENT_RADAR}}
           </svg>
           {{HTML_COMPONENT_NODES}}
-        </div>
-
-        <div class="synthesis-core">
-          <strong>{{SCORE_VALUE}}</strong>
-          <span>/ {{SCORE_MAX}}</span>
-          <em>{{SCORE_BAND}}</em>
         </div>
       </section>
 

--- a/skills/decision-first-dashboard/templates/composite.svg
+++ b/skills/decision-first-dashboard/templates/composite.svg
@@ -12,10 +12,10 @@
       <stop offset="1" stop-color="#ffffff" stop-opacity="0"/>
     </radialGradient>
     <radialGradient id="centerField" cx="47%" cy="43%" r="58%">
-      <stop offset="0" stop-color="#e5dfff" stop-opacity="0.82"/>
-      <stop offset="0.35" stop-color="#efecff" stop-opacity="0.72"/>
-      <stop offset="0.72" stop-color="#f8f8ff" stop-opacity="0.94"/>
-      <stop offset="1" stop-color="#fbfcff" stop-opacity="0.98"/>
+      <stop offset="0" stop-color="#e5dfff" stop-opacity="0.50"/>
+      <stop offset="0.35" stop-color="#efecff" stop-opacity="0.48"/>
+      <stop offset="0.72" stop-color="#f8f8ff" stop-opacity="0.82"/>
+      <stop offset="1" stop-color="#fbfcff" stop-opacity="0.94"/>
     </radialGradient>
     <linearGradient id="accentLine" x1="0" y1="0" x2="1" y2="1">
       <stop offset="0" stop-color="#6555e8"/>
@@ -25,11 +25,8 @@
       <feDropShadow dx="0" dy="18" stdDeviation="20" flood-color="#403875" flood-opacity="0.10"/>
       <feDropShadow dx="0" dy="3" stdDeviation="5" flood-color="#403875" flood-opacity="0.05"/>
     </filter>
-    <filter id="orbShadow" x="-40%" y="-50%" width="180%" height="210%">
-      <feDropShadow dx="0" dy="9" stdDeviation="10" flood-color="#51468d" flood-opacity="0.12"/>
-    </filter>
     <marker id="radarVertex" viewBox="0 0 14 14" refX="7" refY="7" markerWidth="14" markerHeight="14" markerUnits="userSpaceOnUse">
-      <circle cx="7" cy="7" r="5" fill="#6555e8" stroke="#ffffff" stroke-width="2"/>
+      <circle cx="7" cy="7" r="5" fill="#f45fa5" stroke="#ffffff" stroke-width="2"/>
     </marker>
     <style>
       .sans { font-family: Inter, ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
@@ -37,17 +34,18 @@
       .muted { fill: #747a9b; }
       .soft { fill: #a5aac3; }
       .accent { fill: #6555e8; }
+      .positive { fill: #238764; }
       .danger { fill: #e25462; }
       .support-shadow { fill: #655b8f; fill-opacity: .065; }
       .support-panel { fill: #ffffff; fill-opacity: .97; stroke: #e1e4f1; stroke-width: 1; filter: url(#panelShadow); }
       .center-halo { fill: none; }
-      .center-halo--outer { stroke: #b8afe9; stroke-opacity: .30; stroke-width: 1; }
-      .center-halo--inner { stroke: #c8c0f2; stroke-opacity: .16; stroke-width: 22; }
+      .center-halo--outer { stroke: #b8afe9; stroke-opacity: .24; stroke-width: 1; }
+      .center-halo--inner { stroke: #c8c0f2; stroke-opacity: .11; stroke-width: 22; }
       .center-field { fill: url(#centerField); stroke: #ddd9f5; stroke-width: 1; }
-      .radar-guide { fill: none; stroke: #d2cdf4; stroke-width: 1; stroke-dasharray: 6 9; }
-      .radar-shape { marker-start: url(#radarVertex); marker-mid: url(#radarVertex); }
-      .metric-orb { fill: #f8f7ff; fill-opacity: .98; stroke: #d8d3f4; stroke-width: 1; filter: url(#orbShadow); }
-      .score-core { fill: #ffffff; stroke: #ffffff; stroke-width: 10; filter: url(#orbShadow); }
+      .radar-scale-ring { fill: none; stroke: #d8d9eb; stroke-width: 1; stroke-opacity: .82; }
+      .radar-spokes { fill: none; stroke: #dedff0; stroke-width: 1; }
+      .radar-shape--previous { fill: #3b82f6; fill-opacity: .07; stroke: #3b82f6; stroke-width: 3; stroke-linejoin: round; }
+      .radar-shape--current { fill: #f45fa5; fill-opacity: .13; stroke: #f45fa5; stroke-width: 3; stroke-linejoin: round; marker-start: url(#radarVertex); marker-mid: url(#radarVertex); }
     </style>
   </defs>
 
@@ -83,20 +81,10 @@
     <circle cx="740" cy="458" r="338" class="center-halo center-halo--inner"/>
     <circle cx="740" cy="458" r="314" class="center-field"/>
 
-    <circle cx="740" cy="458" r="214" class="radar-guide"/>
-    <circle cx="740" cy="458" r="158" class="radar-guide"/>
-    <circle cx="740" cy="458" r="104" class="radar-guide"/>
-
     <g transform="translate(42 -6)">
       {{SVG_COMPONENT_RADAR}}
       {{SVG_COMPONENT_NODES}}
     </g>
-
-    <circle cx="740" cy="458" r="68" class="score-core"/>
-    <circle cx="740" cy="458" r="57" fill="#fbfaff"/>
-    <text x="740" y="452" class="accent" font-size="46" font-weight="800" text-anchor="middle">{{SCORE_VALUE}}</text>
-    <text x="740" y="480" class="muted" font-size="13" text-anchor="middle">/ {{SCORE_MAX}}</text>
-    <text x="740" y="506" class="danger" font-size="12" font-weight="700" text-anchor="middle">{{SCORE_BAND}}</text>
 
     <text x="1066" y="194" class="ink" font-size="15" font-weight="700">Accounts to watch</text>
     {{EXCEPTION_ROWS}}

--- a/skills/decision-first-dashboard/templates/dashboard.css
+++ b/skills/decision-first-dashboard/templates/dashboard.css
@@ -8,6 +8,8 @@
   --accent: #6555e8;
   --accent-2: #8f7df2;
   --accent-line: #d9d6f7;
+  --previous: #3b82f6;
+  --current: #f45fa5;
   --positive: #238764;
   --danger: #e25462;
   --danger-bg: #fff0f3;
@@ -191,7 +193,7 @@ body {
   border-radius: 50%;
   border: 1px solid rgba(224, 221, 246, .82);
   background:
-    radial-gradient(circle at 47% 43%, rgba(210, 202, 255, .50) 0%, rgba(235, 231, 255, .38) 25%, rgba(249, 249, 255, .70) 56%, rgba(255,255,255,.94) 76%, rgba(255,255,255,.98) 100%);
+    radial-gradient(circle at 47% 43%, rgba(210, 202, 255, .42) 0%, rgba(235, 231, 255, .30) 25%, rgba(249, 249, 255, .66) 56%, rgba(255,255,255,.92) 76%, rgba(255,255,255,.98) 100%);
   box-shadow: 0 34px 100px rgba(77, 69, 143, .09), inset 0 0 80px rgba(255,255,255,.75);
   z-index: -1;
 }
@@ -205,78 +207,49 @@ body {
   transform: translate(-50%, -50%);
   border-radius: 50%;
   border: 1px solid rgba(199, 194, 240, .26);
-  background: radial-gradient(circle, rgba(153, 137, 244, .08) 0%, rgba(153,137,244,.025) 54%, rgba(255,255,255,0) 72%);
+  background: radial-gradient(circle, rgba(153, 137, 244, .07) 0%, rgba(153,137,244,.02) 54%, rgba(255,255,255,0) 72%);
   box-shadow: 0 0 0 26px rgba(255,255,255,.16), 0 0 0 58px rgba(199,194,240,.06);
   z-index: -2;
 }
 
-.synthesis-eyebrow {
-  position: absolute;
-  top: 18px;
-  left: 28px;
-  color: var(--muted);
-  text-transform: uppercase;
-  letter-spacing: .16em;
-  font-size: 10px;
-  z-index: 4;
-}
-
 .orbit {
   position: absolute;
-  left: 8px;
-  right: 8px;
-  top: 54px;
-  height: 532px;
+  width: 620px;
+  height: 520px;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
   pointer-events: none;
   z-index: 2;
+  overflow: visible;
 }
-.orbit-ring {
-  position: absolute;
-  left: 50%;
-  top: 50%;
-  border: 1px dashed var(--accent-line);
-  border-radius: 50%;
-  transform: translate(-50%, -50%);
+.orbit svg { position: absolute; inset: 0; width: 620px; height: 520px; overflow: visible; }
+.orbit .orbit-spokes { fill: none; stroke: var(--accent-line); stroke-width: 1.45; vector-effect: non-scaling-stroke; }
+.orbit .radar-scale-ring {
+  fill: none;
+  stroke: #d8d9eb;
+  stroke-width: 1;
+  stroke-opacity: .82;
+  vector-effect: non-scaling-stroke;
 }
-.orbit-ring--outer { width: 448px; height: 448px; opacity: .76; }
-.orbit-ring--middle { width: 336px; height: 336px; opacity: .56; }
-.orbit-ring--inner { width: 222px; height: 222px; opacity: .42; }
-.orbit svg { position: absolute; inset: 0; width: 100%; height: 100%; overflow: visible; }
-.orbit path { fill: none; stroke: var(--accent-line); stroke-width: 1.45; vector-effect: non-scaling-stroke; }
-.orbit .radar-spokes { fill: none; stroke: #dcd8f6; stroke-width: 1.05; }
-.orbit .radar-shape {
-  fill: rgba(101, 85, 232, .16);
-  stroke: var(--accent);
-  stroke-width: 2.8;
+.orbit .radar-spokes { fill: none; stroke: #dedff0; stroke-width: 1; vector-effect: non-scaling-stroke; }
+.orbit .radar-shape--previous {
+  fill: rgba(59, 130, 246, .07);
+  stroke: #3b82f6;
+  stroke-width: 3;
   stroke-linejoin: round;
-  filter: drop-shadow(0 10px 16px rgba(101, 85, 232, .12));
+  vector-effect: non-scaling-stroke;
 }
-
-.synthesis-core {
-  position: absolute;
-  left: 50%;
-  top: 50%;
-  width: 166px;
-  height: 166px;
-  transform: translate(-50%, -50%);
-  border-radius: 50%;
-  border: 11px solid rgba(255,255,255,.96);
-  background: radial-gradient(circle at 45% 38%, #ffffff 0%, #fbfaff 75%);
-  box-shadow: 0 20px 44px rgba(79, 67, 157, .14), 0 0 0 1px rgba(219,216,244,.7);
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  text-align: center;
-  z-index: 5;
+.orbit .radar-shape--current {
+  fill: rgba(244, 95, 165, .13);
+  stroke: #f45fa5;
+  stroke-width: 3;
+  stroke-linejoin: round;
+  marker-start: url(#radarVertex);
+  marker-mid: url(#radarVertex);
+  vector-effect: non-scaling-stroke;
+  filter: drop-shadow(0 8px 12px rgba(244, 95, 165, .11));
 }
-.synthesis-core strong {
-  color: var(--accent);
-  font-size: 22px;
-  line-height: 1.06;
-  letter-spacing: .01em;
-}
-.synthesis-core span { color: var(--muted); margin-top: 9px; font-size: 12px; }
 
 .signal {
   position: absolute;
@@ -309,6 +282,41 @@ body {
 }
 .signal small { display: block; margin-top: 4px; color: var(--muted); font-size: 10px; }
 
+.radar-label {
+  position: absolute;
+  width: 132px;
+  z-index: 4;
+  line-height: 1.1;
+}
+.radar-label span {
+  display: block;
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 650;
+}
+.radar-label strong {
+  display: block;
+  margin-top: 5px;
+  color: var(--ink);
+  font-size: 16px;
+  line-height: 1;
+  font-weight: 780;
+  letter-spacing: -0.02em;
+}
+.radar-label small {
+  display: block;
+  margin-top: 6px;
+  font-size: 10px;
+  font-weight: 720;
+}
+.radar-label small.positive { color: var(--positive); }
+.radar-label small.danger { color: var(--danger); }
+.radar-label small.muted { color: var(--muted); }
+.radar-label--left { text-align: right; transform: translate(-100%, -50%); }
+.radar-label--right { text-align: left; transform: translate(0, -50%); }
+.radar-label--top,
+.radar-label--bottom { text-align: center; transform: translate(-50%, -50%); }
+
 .score-value-line {
   display: flex;
   align-items: baseline;
@@ -339,26 +347,6 @@ body {
 .composition-row + .composition-row { border-top: 1px solid rgba(235,235,244,.82); }
 .composition-row span { font-size: 12px; font-weight: 660; }
 .composition-row small { color: var(--muted); font-size: 10px; }
-
-.score-center .synthesis-core {
-  width: 142px;
-  height: 142px;
-  border-width: 10px;
-}
-.score-center .synthesis-core strong {
-  font-size: 48px;
-  line-height: 1;
-  letter-spacing: -0.045em;
-}
-.score-center .synthesis-core span { margin-top: 4px; }
-.score-center .synthesis-core em {
-  margin-top: 8px;
-  color: var(--danger);
-  font-size: 12px;
-  font-style: normal;
-  font-weight: 720;
-}
-.score-component strong { font-size: 23px; }
 
 .compact-card {
   padding: 23px 24px 18px;
@@ -408,7 +396,7 @@ body {
   }
   .synthesis-card::before { width: 620px; height: 620px; }
   .synthesis-card::after { width: 690px; height: 690px; }
-  .orbit { left: -12px; right: -12px; }
+  .orbit { transform: translate(-50%, -50%) scale(.92); }
 }
 
 @media (max-width: 1080px) {
@@ -418,7 +406,7 @@ body {
   .synthesis-card { order: -1; min-height: 590px; }
   .synthesis-card::before { width: 610px; height: 610px; }
   .synthesis-card::after { width: 680px; height: 680px; }
-  .orbit { top: 30px; left: 50%; right: auto; width: 640px; height: 532px; transform: translateX(-50%); }
+  .orbit { transform: translate(-50%, -50%) scale(.96); }
 }
 
 @media (max-width: 700px) {
@@ -429,6 +417,6 @@ body {
   .synthesis-card { min-height: 520px; overflow: hidden; }
   .synthesis-card::before { width: 520px; height: 520px; }
   .synthesis-card::after { width: 590px; height: 590px; }
-  .orbit { width: 570px; transform: translateX(-50%) scale(.84); transform-origin: center; }
+  .orbit { transform: translate(-50%, -50%) scale(.82); }
   .support-card { border-radius: 20px; }
 }

--- a/skills/decision-first-dashboard/templates/no-score.html
+++ b/skills/decision-first-dashboard/templates/no-score.html
@@ -5,7 +5,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Subscription health</title>
   <style>{{CSS}}</style>
-  <style>.orbit .radar-shape { marker-start: url(#radarVertex); marker-mid: url(#radarVertex); }</style>
 </head>
 <body>
   <main class="dashboard-shell">
@@ -33,26 +32,17 @@
         </article>
       </aside>
 
-      <section class="card synthesis-card" aria-label="Overall subscription direction">
-        <div class="eyebrow synthesis-eyebrow">Overall direction</div>
+      <section class="card synthesis-card" aria-label="Subscription profile">
         <div class="orbit" aria-hidden="true">
-          <div class="orbit-ring orbit-ring--outer"></div>
-          <div class="orbit-ring orbit-ring--middle"></div>
-          <div class="orbit-ring orbit-ring--inner"></div>
-          <svg viewBox="0 0 620 520" preserveAspectRatio="none">
+          <svg viewBox="0 0 620 520" preserveAspectRatio="xMidYMid meet">
             <defs>
               <marker id="radarVertex" viewBox="0 0 14 14" refX="7" refY="7" markerWidth="14" markerHeight="14" markerUnits="userSpaceOnUse">
-                <circle cx="7" cy="7" r="5" fill="#6555e8" stroke="#ffffff" stroke-width="2"></circle>
+                <circle cx="7" cy="7" r="5" fill="#f45fa5" stroke="#ffffff" stroke-width="2"></circle>
               </marker>
             </defs>
             {{HTML_ORBIT_VISUAL}}
           </svg>
           {{HTML_SIGNAL_NODES}}
-        </div>
-
-        <div class="synthesis-core">
-          <strong>{{SYNTHESIS}}</strong>
-          <span>Target unknown</span>
         </div>
       </section>
 

--- a/skills/decision-first-dashboard/templates/no-score.svg
+++ b/skills/decision-first-dashboard/templates/no-score.svg
@@ -12,10 +12,10 @@
       <stop offset="1" stop-color="#ffffff" stop-opacity="0"/>
     </radialGradient>
     <radialGradient id="centerField" cx="47%" cy="43%" r="58%">
-      <stop offset="0" stop-color="#e5dfff" stop-opacity="0.82"/>
-      <stop offset="0.35" stop-color="#efecff" stop-opacity="0.72"/>
-      <stop offset="0.72" stop-color="#f8f8ff" stop-opacity="0.94"/>
-      <stop offset="1" stop-color="#fbfcff" stop-opacity="0.98"/>
+      <stop offset="0" stop-color="#e5dfff" stop-opacity="0.50"/>
+      <stop offset="0.35" stop-color="#efecff" stop-opacity="0.48"/>
+      <stop offset="0.72" stop-color="#f8f8ff" stop-opacity="0.82"/>
+      <stop offset="1" stop-color="#fbfcff" stop-opacity="0.94"/>
     </radialGradient>
     <linearGradient id="accentLine" x1="0" y1="0" x2="1" y2="1">
       <stop offset="0" stop-color="#6555e8"/>
@@ -29,7 +29,7 @@
       <feDropShadow dx="0" dy="9" stdDeviation="10" flood-color="#51468d" flood-opacity="0.12"/>
     </filter>
     <marker id="radarVertex" viewBox="0 0 14 14" refX="7" refY="7" markerWidth="14" markerHeight="14" markerUnits="userSpaceOnUse">
-      <circle cx="7" cy="7" r="5" fill="#6555e8" stroke="#ffffff" stroke-width="2"/>
+      <circle cx="7" cy="7" r="5" fill="#f45fa5" stroke="#ffffff" stroke-width="2"/>
     </marker>
     <style>
       .sans { font-family: Inter, ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
@@ -42,13 +42,14 @@
       .support-shadow { fill: #655b8f; fill-opacity: .065; }
       .support-panel { fill: #ffffff; fill-opacity: .97; stroke: #e1e4f1; stroke-width: 1; filter: url(#panelShadow); }
       .center-halo { fill: none; }
-      .center-halo--outer { stroke: #b8afe9; stroke-opacity: .30; stroke-width: 1; }
-      .center-halo--inner { stroke: #c8c0f2; stroke-opacity: .16; stroke-width: 22; }
+      .center-halo--outer { stroke: #b8afe9; stroke-opacity: .24; stroke-width: 1; }
+      .center-halo--inner { stroke: #c8c0f2; stroke-opacity: .11; stroke-width: 22; }
       .center-field { fill: url(#centerField); stroke: #ddd9f5; stroke-width: 1; }
-      .radar-guide { fill: none; stroke: #d2cdf4; stroke-width: 1; stroke-dasharray: 6 9; }
-      .radar-shape { marker-start: url(#radarVertex); marker-mid: url(#radarVertex); }
+      .radar-scale-ring { fill: none; stroke: #d8d9eb; stroke-width: 1; stroke-opacity: .82; }
+      .radar-spokes { fill: none; stroke: #dedff0; stroke-width: 1; }
+      .radar-shape--previous { fill: #3b82f6; fill-opacity: .07; stroke: #3b82f6; stroke-width: 3; stroke-linejoin: round; }
+      .radar-shape--current { fill: #f45fa5; fill-opacity: .13; stroke: #f45fa5; stroke-width: 3; stroke-linejoin: round; marker-start: url(#radarVertex); marker-mid: url(#radarVertex); }
       .metric-orb { fill: #f8f7ff; fill-opacity: .98; stroke: #d8d3f4; stroke-width: 1; filter: url(#orbShadow); }
-      .direction-core { fill: #ffffff; stroke: #ffffff; stroke-width: 10; filter: url(#orbShadow); }
     </style>
   </defs>
 
@@ -82,21 +83,11 @@
     <circle cx="740" cy="458" r="366" class="center-halo center-halo--outer"/>
     <circle cx="740" cy="458" r="338" class="center-halo center-halo--inner"/>
     <circle cx="740" cy="458" r="314" class="center-field"/>
-    <text x="434" y="198" class="muted" font-size="10" font-weight="700" letter-spacing="1.8">OVERALL DIRECTION</text>
-
-    <circle cx="740" cy="458" r="214" class="radar-guide"/>
-    <circle cx="740" cy="458" r="158" class="radar-guide"/>
-    <circle cx="740" cy="458" r="104" class="radar-guide"/>
 
     <g transform="translate(42 -6)">
       {{SVG_ORBIT_VISUAL}}
       {{SVG_SIGNAL_NODES}}
     </g>
-
-    <circle cx="740" cy="458" r="82" class="direction-core"/>
-    <circle cx="740" cy="458" r="70" fill="#fbfaff"/>
-    <text x="740" y="451" class="accent" font-size="22" font-weight="790" text-anchor="middle">{{SYNTHESIS}}</text>
-    <text x="740" y="482" class="muted" font-size="12" text-anchor="middle">Target unknown</text>
 
     <text x="1066" y="194" class="ink" font-size="15" font-weight="700">Accounts to watch</text>
     {{EXCEPTION_ROWS}}

--- a/tests/compiler/golden/hashes.json
+++ b/tests/compiler/golden/hashes.json
@@ -1,6 +1,6 @@
 {
-  "no-score.svg": "d55f9467a1aec3d3e91dc18a754094ccd5126d1caaf3db50cc26833ba3c3762f",
-  "no-score.html": "673f29a866f76439cdc1552e112fec007d82b9a05b4fc687fa2f74c665ee4e2b",
-  "composite.svg": "36b489daf95a1c482e0cafa24315d3e93ff265f457f28404f49b3543e8ecaf29",
-  "composite.html": "a625f68ee9be78e8d4058b4623a20d40907dd1b94c339ce694d91f26ed762e67"
+  "no-score.svg": "cdea1f9ec3902cc22f688fea65e6fa3dcce767521d2c709335bae3a3f7a8bfc3",
+  "no-score.html": "7c271da50f991e93eb6f03191de608776ab02d47fcb434dc9a7244135bf0db16",
+  "composite.svg": "d011a57cefec18a54671a6ad988df72e67d1bab46cf50d5e20f62c9a363bcd57",
+  "composite.html": "d1d91af9d152de83e09266f21377ff95d3ce5af8d8b84e4b1441e4e1b606458e"
 }

--- a/tests/compiler/radar-render.test.js
+++ b/tests/compiler/radar-render.test.js
@@ -34,10 +34,10 @@ const composite = {
 };
 
 function radarPath(markup) {
-  return markup.match(/class="radar-shape"[^>]*d="([^"]+)"/)?.[1] ?? null;
+  return markup.match(/class="radar-shape radar-shape--current"[^>]*d="([^"]+)"/)?.[1] ?? null;
 }
 
-test('accepts 3 to 6 source-backed comparable dimension scores without requiring an overall score', () => {
+test('accepts 3 to 6 source-backed comparable dimensions without requiring an overall score', () => {
   assert.equal(validateDecisionState(scoredNoScore).valid, true);
 
   const six = structuredClone(scoredNoScore);
@@ -49,7 +49,7 @@ test('accepts 3 to 6 source-backed comparable dimension scores without requiring
   assert.equal(validateDecisionState(six).valid, true);
 });
 
-test('renders three scored dimensions as a closed triangular radar in SVG and HTML', () => {
+test('renders three comparable dimensions as a closed triangular radar in SVG and HTML', () => {
   const svg = renderSvg(scoredNoScore);
   const html = renderHtml(scoredNoScore);
 
@@ -92,6 +92,28 @@ test('does not turn heterogeneous raw no-score KPIs into a radar polygon', () =>
   assert.equal(validateDecisionState(raw).valid, true);
   assert.equal(radarPath(renderSvg(raw)), null);
   assert.equal(radarPath(renderHtml(raw)), null);
+});
+
+test('accepts a complete source-backed previous-period profile', () => {
+  const compared = structuredClone(scoredNoScore);
+  compared.signals[0].previousNormalizedScore = 64;
+  compared.signals[1].previousNormalizedScore = 76;
+  compared.signals[2].previousNormalizedScore = 70;
+  assert.equal(validateDecisionState(compared).valid, true);
+  const svg = renderSvg(compared);
+  assert.match(svg, /class="radar-shape radar-shape--previous"/);
+  assert.ok(svg.indexOf('radar-shape radar-shape--previous') < svg.indexOf('radar-shape radar-shape--current'));
+});
+
+test('rejects partial or out-of-range previous-period profile values', () => {
+  const partial = structuredClone(scoredNoScore);
+  partial.signals[0].previousNormalizedScore = 64;
+  assert.equal(validateDecisionState(partial).valid, false);
+
+  const outOfRange = structuredClone(scoredNoScore);
+  for (const signal of outOfRange.signals) signal.previousNormalizedScore = 60;
+  outOfRange.signals[1].previousNormalizedScore = 120;
+  assert.equal(validateDecisionState(outOfRange).valid, false);
 });
 
 test('rejects a derived signal inside an otherwise source-backed radar', () => {

--- a/tests/compiler/radar-scale-layout.test.js
+++ b/tests/compiler/radar-scale-layout.test.js
@@ -46,8 +46,10 @@ test('radar center stays empty and all dimension copy sits outside the 100% ring
   assert.match(svg, /class="radar-label radar-label--right"[^>]*data-outside-ring="true"/);
   assert.match(svg, /class="radar-label radar-label--bottom"[^>]*data-outside-ring="true"/);
   assert.match(svg, /class="radar-label radar-label--left"[^>]*data-outside-ring="true"/);
-  assert.match(svg, />Retail<[^]*?>80%<[^]*?>\+8pp</);
-  assert.match(svg, />To B<[^]*?>64%<[^]*?>-6pp</);
+  assert.match(svg, />Retail<[^]*?>80%<[^]*?>↑ 8pp</);
+  assert.match(svg, />To B<[^]*?>64%<[^]*?>↓ 6pp</);
+  assert.match(svg, /class="positive"[^>]*>↑ 8pp</);
+  assert.match(svg, /class="danger"[^>]*>↓ 6pp</);
 });
 
 test('left labels are right-aligned and right labels are left-aligned', () => {

--- a/tests/compiler/radar-scale-layout.test.js
+++ b/tests/compiler/radar-scale-layout.test.js
@@ -1,0 +1,60 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { renderSvg, renderHtml } from '../../skills/decision-first-dashboard/scripts/render.js';
+
+const comparisonRadar = {
+  mode: 'no_score',
+  radarScale: { min: 0, max: 100, provenance: 'source' },
+  signals: [
+    { metric: 'retail', label: 'Retail', value: '80%', delta: '+8pp', direction: 'improving', normalizedScore: 80, previousNormalizedScore: 72, provenance: 'source' },
+    { metric: 'to_b', label: 'To B', value: '64%', delta: '-6pp', direction: 'deteriorating', normalizedScore: 64, previousNormalizedScore: 70, provenance: 'source' },
+    { metric: 'retention', label: 'Retention', value: '92%', delta: '+4pp', direction: 'improving', normalizedScore: 92, previousNormalizedScore: 88, provenance: 'source' },
+    { metric: 'conversion', label: 'Conversion', value: '55%', delta: '-10pp', direction: 'deteriorating', normalizedScore: 55, previousNormalizedScore: 65, provenance: 'source' }
+  ]
+};
+
+function scaleRadii(markup) {
+  return [...markup.matchAll(/class="radar-scale-ring"[^>]*data-scale="(40|60|80|100)"[^>]*r="([0-9.]+)"/g)]
+    .map((match) => [Number(match[1]), Number(match[2])]);
+}
+
+test('profile radar uses exactly four proportional 40/60/80/100 scale rings', () => {
+  const svg = renderSvg(comparisonRadar);
+  const html = renderHtml(comparisonRadar);
+
+  assert.deepEqual(scaleRadii(svg), [[40, 75.2], [60, 112.8], [80, 150.4], [100, 188]]);
+  assert.deepEqual(scaleRadii(html), [[40, 75.2], [60, 112.8], [80, 150.4], [100, 188]]);
+});
+
+test('previous month is blue below the current pink profile and current vertices stay visible', () => {
+  const svg = renderSvg(comparisonRadar);
+  const previousIndex = svg.indexOf('radar-shape radar-shape--previous');
+  const currentIndex = svg.indexOf('radar-shape radar-shape--current');
+
+  assert.ok(previousIndex >= 0, 'previous profile should render');
+  assert.ok(currentIndex > previousIndex, 'current profile must render above previous profile');
+  assert.match(svg, /\.radar-shape--previous\s*\{[^}]*stroke:\s*#3b82f6/i);
+  assert.match(svg, /\.radar-shape--current\s*\{[^}]*stroke:\s*#f45fa5/i);
+  assert.match(svg, /\.radar-shape--current\s*\{[^}]*marker-start:/i);
+});
+
+test('radar center stays empty and all dimension copy sits outside the 100% ring', () => {
+  const svg = renderSvg(comparisonRadar);
+
+  assert.doesNotMatch(svg, /OVERALL DIRECTION|Target unknown|class="direction-core"|>IMPROVING<|>DETERIORATING</);
+  assert.match(svg, /class="radar-label radar-label--top"[^>]*data-outside-ring="true"/);
+  assert.match(svg, /class="radar-label radar-label--right"[^>]*data-outside-ring="true"/);
+  assert.match(svg, /class="radar-label radar-label--bottom"[^>]*data-outside-ring="true"/);
+  assert.match(svg, /class="radar-label radar-label--left"[^>]*data-outside-ring="true"/);
+  assert.match(svg, />Retail<[^]*?>80%<[^]*?>\+8pp</);
+  assert.match(svg, />To B<[^]*?>64%<[^]*?>-6pp</);
+});
+
+test('left labels are right-aligned and right labels are left-aligned', () => {
+  const svg = renderSvg(comparisonRadar);
+
+  assert.match(svg, /class="radar-label radar-label--left"[^>]*text-anchor="end"/);
+  assert.match(svg, /class="radar-label radar-label--right"[^>]*text-anchor="start"/);
+  assert.match(svg, /class="radar-label radar-label--top"[^>]*text-anchor="middle"/);
+  assert.match(svg, /class="radar-label radar-label--bottom"[^>]*text-anchor="middle"/);
+});

--- a/tests/compiler/render-html.test.js
+++ b/tests/compiler/render-html.test.js
@@ -27,11 +27,10 @@ function pointInTimeFixture() {
   };
 }
 
-test('renders the same canonical decision state into a fixed HTML composition', () => {
+test('renders the same canonical decision state into a fixed HTML composition without a center verdict', () => {
   const html = renderHtml(fixture);
   assert.match(html, /Subscription health/);
-  assert.match(html, /IMPROVING/);
-  assert.match(html, /Target unknown/);
+  assert.doesNotMatch(html, />IMPROVING<|Target unknown|OVERALL DIRECTION/);
   assert.match(html, /\$184,320/);
   assert.match(html, /Dovetail/);
   assert.match(html, /Plan cancelled/);
@@ -67,13 +66,13 @@ test('renders a trend line only when an exact source-supported series is supplie
   assert.doesNotMatch(html, /Trend data unavailable/);
 });
 
-test('does not expose layout freedom as KPI grids, tables, or action controls', () => {
+test('does not expose layout freedom as KPI grids, tables, action controls, or synthetic center verdicts', () => {
   const html = renderHtml(fixture);
   assert.doesNotMatch(html, /<table\b/i);
   assert.doesNotMatch(html, /<button\b/i);
   assert.doesNotMatch(
     html,
-    /kpi-grid|grid-cols-4|Executive Decision Dashboard|Primary Decision|Diagnostic Context|Required Interventions|HEALTH GOOD|Healthy|Marginal|Decision-first view|No composite score/
+    /kpi-grid|grid-cols-4|Executive Decision Dashboard|Primary Decision|Diagnostic Context|Required Interventions|HEALTH GOOD|Healthy|Marginal|Decision-first view|No composite score|OVERALL DIRECTION|Target unknown/
   );
 });
 

--- a/tests/compiler/render-svg.test.js
+++ b/tests/compiler/render-svg.test.js
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
-import { renderSvg } from '../../skills/decision-first-dashboard/scripts/render.js';
+import { renderSvg, deriveOverallDirection } from '../../skills/decision-first-dashboard/scripts/render.js';
 
 const fixture = JSON.parse(
   fs.readFileSync(new URL('../../examples/saas/input.no-score.json', import.meta.url), 'utf8')
@@ -27,23 +27,22 @@ function pointInTimeFixture() {
   };
 }
 
-test('renders a dominant no-score synthesis cluster from validated data', () => {
+test('renders a dominant no-score signal cluster without a synthetic center verdict', () => {
   const svg = renderSvg(fixture);
   assert.match(svg, /Subscription health/);
-  assert.match(svg, /IMPROVING/);
-  assert.match(svg, /Target unknown/);
+  assert.doesNotMatch(svg, />IMPROVING<|Target unknown|OVERALL DIRECTION/);
   assert.match(svg, /\+12\.4%/);
   assert.match(svg, /\+8\.1%/);
   assert.match(svg, /-0\.6pp/);
   assert.match(svg, /\+3\.2%/);
 });
 
-test('derives mixed overall direction from conflicting signal directions', () => {
+test('keeps direction derivation available without rendering it as a verdict', () => {
   const mixed = structuredClone(fixture);
   mixed.signals[2].direction = 'deteriorating';
+  assert.equal(deriveOverallDirection(mixed.signals), 'mixed');
   const svg = renderSvg(mixed);
-  assert.match(svg, />MIXED</);
-  assert.doesNotMatch(svg, />IMPROVING</);
+  assert.doesNotMatch(svg, />MIXED<|>IMPROVING</);
 });
 
 test('renders exactly three signals without inventing a fourth slot', () => {
@@ -78,7 +77,7 @@ test('does not leak framework, compiler, or fabricated verdict copy', () => {
   const svg = renderSvg(fixture);
   assert.doesNotMatch(
     svg,
-    /Executive Decision Dashboard|Primary Decision|Diagnostic Context|Required Interventions|HEALTH GOOD|Healthy|Marginal|No composite score|Decision-first view|Directional evidence is improving/
+    /Executive Decision Dashboard|Primary Decision|Diagnostic Context|Required Interventions|HEALTH GOOD|Healthy|Marginal|No composite score|Decision-first view|Directional evidence is improving|OVERALL DIRECTION|Target unknown/
   );
 });
 
@@ -100,7 +99,7 @@ test('renders point-in-time KPI values prominently without blank movement labels
   for (const value of ['$4.98M', '80.7%', '88.9%', '9.4 mo', '1.5x']) {
     assert.match(svg, new RegExp(value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
   }
-  assert.match(svg, />UNKNOWN</);
+  assert.doesNotMatch(svg, />UNKNOWN</);
   assert.doesNotMatch(svg, />\s*<\/text>/);
   assert.doesNotMatch(svg, /undefined/);
 });

--- a/tests/compiler/visual-fidelity-contract.test.js
+++ b/tests/compiler/visual-fidelity-contract.test.js
@@ -7,35 +7,41 @@ const composite = JSON.parse(
   fs.readFileSync(new URL('./fixtures/composite.valid.json', import.meta.url), 'utf8')
 );
 
-test('composite SVG uses a dominant premium center field with layered halo depth', () => {
+test('composite SVG keeps premium ambient depth while using four quantitative radar rings', () => {
   const svg = renderSvg(composite);
 
   assert.match(svg, /class="center-halo center-halo--outer"/);
   assert.match(svg, /class="center-halo center-halo--inner"/);
   assert.match(svg, /<circle cx="740" cy="458" r="314" class="center-field"\/>/);
-  assert.equal((svg.match(/class="radar-guide"/g) ?? []).length, 3);
-  assert.match(svg, /<circle cx="740" cy="458" r="68" class="score-core"\/>/);
+  assert.equal((svg.match(/class="radar-scale-ring"/g) ?? []).length, 4);
+  assert.doesNotMatch(svg, /class="score-core"|class="direction-core"/);
   assert.doesNotMatch(svg, /class="kpi-grid"|class="dashboard-table"/);
 });
 
-test('reference radar renders visible vertex markers and floating metric orbs', () => {
+test('reference radar renders current vertices and outside labels without floating metric cards', () => {
   const svg = renderSvg(composite);
   const html = renderHtml(composite);
 
   assert.match(svg, /<marker id="radarVertex"/);
-  assert.match(svg, /class="metric-orb"/);
-  assert.match(svg, /\.radar-shape \{ marker-start: url\(#radarVertex\); marker-mid: url\(#radarVertex\); \}/);
+  assert.match(svg, /class="radar-label radar-label--/);
+  assert.match(svg, /\.radar-shape--current\s*\{[^}]*marker-start:\s*url\(#radarVertex\);[^}]*marker-mid:\s*url\(#radarVertex\);/);
+  assert.doesNotMatch(svg, /class="metric-orb"/);
+
   assert.match(html, /<marker id="radarVertex"/);
-  assert.match(html, /class="signal score-component metric-orb"/);
-  assert.match(html, /\.orbit \.radar-shape \{ marker-start: url\(#radarVertex\); marker-mid: url\(#radarVertex\); \}/);
+  assert.match(html, /class="score-component radar-label radar-label--/);
+  assert.match(html, /\.orbit \.radar-shape--current\s*\{[\s\S]*?marker-start:\s*url\(#radarVertex\);[\s\S]*?marker-mid:\s*url\(#radarVertex\);/);
+  assert.doesNotMatch(html, /score-component metric-orb/);
 });
 
-test('reference composition does not add a floating current-score method label', () => {
+test('composite score remains in the support card instead of occupying the radar center', () => {
   const svg = renderSvg(composite);
   const html = renderHtml(composite);
 
-  assert.doesNotMatch(svg, />CURRENT SCORE</);
-  assert.doesNotMatch(html, />Current score<\/div>/);
+  assert.match(svg, /Score trend/);
+  assert.match(svg, />68</);
+  assert.doesNotMatch(svg, /class="score-core"/);
+  assert.match(html, /class="card support-card score-card"/);
+  assert.doesNotMatch(html, /class="score-core"/);
 });
 
 test('HTML uses a signature open center plus elevated support surfaces', () => {


### PR DESCRIPTION
This PR turns the central radar into a true profile visualization instead of a score-centric ornament. It will use exact 40/60/80/100 concentric scale rings, keep the center empty, place all dimension labels and values outside the 100% ring, right-align left-side labels and left-align right-side labels, and support a source-backed previous-period blue profile beneath the current pink profile. The first commit is the failing visual contract for TDD.