### PR TITLE
Use a true radar profile as the README After showcase

### DIFF
--- a/.github/workflows/compiler-tests.yml
+++ b/.github/workflows/compiler-tests.yml
@@ -11,6 +11,7 @@ on:
     paths:
       - 'skills/decision-first-dashboard/**'
       - 'examples/saas/**'
+      - 'examples/radar-profile/**'
       - 'tests/compiler/**'
       - 'package.json'
       - '.github/workflows/compiler-tests.yml'
@@ -27,6 +28,8 @@ jobs:
       - run: npm test
       - run: npm run validate:saas
       - run: npm run render:saas
+      - run: npm run validate:radar-showcase
+      - run: npm run render:radar-showcase
       - name: Validate SaaSGrid real-world fixture
         run: node skills/decision-first-dashboard/scripts/validate.js examples/saas/real-world/saasgrid/input.no-score.json
       - name: Render SaaSGrid real-world fixture
@@ -47,6 +50,8 @@ jobs:
           path: |
             examples/saas/output.no-score.svg
             examples/saas/output.no-score.html
+            examples/radar-profile/output.no-score.svg
+            examples/radar-profile/output.no-score.html
             examples/saas/real-world/saasgrid/output.no-score.svg
             examples/saas/real-world/saasgrid/output.no-score.html
             tests/compiler/generated/v3-composite/output.composite.svg

--- a/README.md
+++ b/README.md
@@ -65,13 +65,15 @@ If it doesn't, show the real signals instead.
 <table>
   <tr>
     <th width="50%">Before</th>
-    <th width="50%">No-score mode — no unsupported score invented</th>
+    <th width="50%">No-score radar profile — no unsupported score invented</th>
   </tr>
   <tr>
     <td width="50%"><img src="examples/saas/before.png" width="100%"></td>
-    <td width="50%"><img src="examples/saas/output.no-score.svg" width="100%"></td>
+    <td width="50%"><img src="examples/radar-profile/output.no-score.svg" width="100%"></td>
   </tr>
 </table>
+
+The After showcase uses five source-backed percentage dimensions on one 0–100 scale, so the radar is real rather than decorative. Mixed-unit raw KPIs still use the non-radar fallback.
 
 ## How it works
 
@@ -99,7 +101,7 @@ Unrelated raw KPIs are not forced into a radar chart.
 
 ### Composite mode — when the evidence supports it
 
-If the source already provides a real score model — including the score, scale, normalized components, weights, aggregation rule, and score bands — the skill can render the score as the dominant decision signal.
+If the source already provides a real score model — including the score, scale, normalized components, weights, aggregation rule, and score bands — the skill can preserve and display that grounded score without forcing it into the radar center.
 
 <img src="examples/saas/composite-mode.png" width="760">
 
@@ -223,6 +225,8 @@ composite  → output.composite.svg / output.composite.html
 npm test
 npm run validate:saas
 npm run render:saas
+npm run validate:radar-showcase
+npm run render:radar-showcase
 ```
 
 For Anthropic plugin packaging, validate the repository root with a current Claude Code CLI before submission:

--- a/examples/radar-profile/input.no-score.json
+++ b/examples/radar-profile/input.no-score.json
@@ -1,0 +1,87 @@
+{
+  "mode": "no_score",
+  "radarScale": {
+    "min": 0,
+    "max": 100,
+    "provenance": "source"
+  },
+  "signals": [
+    {
+      "metric": "mrr",
+      "label": "Revenue attainment",
+      "value": "82%",
+      "delta": "+6pp",
+      "direction": "improving",
+      "normalizedScore": 82,
+      "previousNormalizedScore": 76,
+      "provenance": "source"
+    },
+    {
+      "metric": "active_customers",
+      "label": "Customer target",
+      "value": "78%",
+      "delta": "+5pp",
+      "direction": "improving",
+      "normalizedScore": 78,
+      "previousNormalizedScore": 73,
+      "provenance": "source"
+    },
+    {
+      "metric": "retention",
+      "label": "Retention",
+      "value": "91%",
+      "delta": "+3pp",
+      "direction": "improving",
+      "normalizedScore": 91,
+      "previousNormalizedScore": 88,
+      "provenance": "source"
+    },
+    {
+      "metric": "trial_conversion",
+      "label": "Trial conversion",
+      "value": "67%",
+      "delta": "-4pp",
+      "direction": "deteriorating",
+      "normalizedScore": 67,
+      "previousNormalizedScore": 71,
+      "provenance": "source"
+    },
+    {
+      "metric": "expansion",
+      "label": "Expansion",
+      "value": "74%",
+      "delta": "+2pp",
+      "direction": "improving",
+      "normalizedScore": 74,
+      "previousNormalizedScore": 72,
+      "provenance": "source"
+    }
+  ],
+  "context": {
+    "revenueSeries": [68, 72, 75, 79, 82],
+    "provenance": "source"
+  },
+  "exceptions": [
+    {
+      "name": "Dovetail",
+      "plan": "Basic",
+      "mrr": "$120",
+      "status": "At risk",
+      "provenance": "source"
+    }
+  ],
+  "events": [
+    {
+      "subject": "Dovetail",
+      "event": "Plan cancelled",
+      "time": "1 hr ago",
+      "provenance": "source"
+    },
+    {
+      "subject": "Orbit Systems",
+      "event": "Trial converted",
+      "time": "43 min ago",
+      "provenance": "source"
+    }
+  ]
+}

--- a/examples/radar-profile/output.no-score.html
+++ b/examples/radar-profile/output.no-score.html
@@ -1,0 +1,537 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Subscription health</title>
+  <style>:root {
+  color-scheme: light;
+  --bg-a: #f8faff;
+  --bg-b: #eef3fb;
+  --ink: #171733;
+  --muted: #747a9b;
+  --soft: #a5aac3;
+  --accent: #6555e8;
+  --accent-2: #8f7df2;
+  --accent-line: #d9d6f7;
+  --previous: #3b82f6;
+  --current: #f45fa5;
+  --positive: #238764;
+  --danger: #e25462;
+  --danger-bg: #fff0f3;
+  --panel-border: rgba(231, 233, 246, .9);
+  font-family: Inter, ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+* { box-sizing: border-box; }
+html, body { margin: 0; min-height: 100%; }
+body {
+  min-height: 100vh;
+  background:
+    radial-gradient(circle at 53% 42%, rgba(169, 155, 255, .16), rgba(255,255,255,0) 35%),
+    radial-gradient(circle at 25% 78%, rgba(109, 183, 255, .11), rgba(255,255,255,0) 31%),
+    linear-gradient(135deg, var(--bg-a), var(--bg-b));
+  color: var(--ink);
+}
+
+.dashboard-shell {
+  width: min(1376px, calc(100vw - 48px));
+  margin: 0 auto;
+  padding: 36px 0 52px;
+}
+
+.page-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: end;
+  margin-bottom: 22px;
+  padding: 0 4px;
+}
+
+.page-header h1 {
+  margin: 0;
+  font-size: 31px;
+  line-height: 1.06;
+  font-weight: 780;
+  letter-spacing: -0.035em;
+}
+
+.page-header p {
+  margin: 9px 0 0;
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.decision-layout {
+  display: grid;
+  grid-template-columns: 300px minmax(620px, 1fr) 320px;
+  gap: 24px;
+  align-items: stretch;
+  min-height: 640px;
+  position: relative;
+}
+
+.support-column {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  position: relative;
+  z-index: 5;
+  padding: 22px 0;
+}
+.support-column--left { transform: translateX(6px); }
+.support-column--right { transform: translateX(-6px); }
+
+.card {
+  background: transparent;
+  border: 0;
+  border-radius: 0;
+  box-shadow: none;
+}
+
+.support-card {
+  background: rgba(255, 255, 255, .82);
+  border: 1px solid var(--panel-border);
+  border-radius: 24px;
+  box-shadow: 0 20px 60px rgba(67, 62, 119, .09), 0 3px 14px rgba(67, 62, 119, .04);
+  backdrop-filter: blur(18px);
+  -webkit-backdrop-filter: blur(18px);
+}
+
+.eyebrow {
+  font-size: 14px;
+  font-weight: 720;
+  letter-spacing: -0.012em;
+}
+
+.revenue-card,
+.score-card {
+  padding: 24px 24px 20px;
+  min-height: 302px;
+}
+
+.metric-value {
+  margin-top: 20px;
+  font-size: 35px;
+  line-height: 1;
+  font-weight: 790;
+  letter-spacing: -0.045em;
+}
+
+.metric-delta {
+  margin-top: 8px;
+  font-size: 13px;
+  font-weight: 720;
+}
+.metric-delta span { color: var(--muted); font-weight: 500; margin-left: 6px; }
+.positive { color: var(--positive); }
+.danger { color: var(--danger); }
+.muted { color: var(--muted); }
+
+.sparkline {
+  width: 100%;
+  height: 86px;
+  margin: 22px 0 7px;
+  overflow: visible;
+  filter: drop-shadow(0 6px 8px rgba(101, 85, 232, .08));
+}
+.sparkline path {
+  fill: none;
+  stroke: var(--accent);
+  stroke-width: 4;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+.trend-unavailable {
+  height: 86px;
+  margin: 22px 0 7px;
+  display: flex;
+  align-items: center;
+  color: var(--muted);
+  font-size: 12px;
+}
+.card-divider {
+  height: 1px;
+  background: rgba(231, 232, 242, .9);
+  margin: 8px 0 16px;
+}
+.context-row {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  color: var(--muted);
+  font-size: 11px;
+}
+.context-row strong { color: var(--ink); font-size: 12px; font-weight: 720; }
+
+.context-card {
+  padding: 23px 24px 18px;
+  min-height: 190px;
+}
+.context-metric {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  grid-template-areas: "label delta" "value delta";
+  align-items: center;
+  gap: 4px 12px;
+  padding: 16px 0;
+}
+.context-metric + .context-metric { border-top: 1px solid rgba(235, 235, 244, .92); }
+.context-metric span { grid-area: label; color: var(--muted); font-size: 11px; }
+.context-metric strong { grid-area: value; font-size: 20px; letter-spacing: -0.02em; }
+.context-metric em { grid-area: delta; font-style: normal; font-size: 12px; font-weight: 720; }
+
+.synthesis-card {
+  min-height: 640px;
+  position: relative;
+  overflow: visible;
+  isolation: isolate;
+  z-index: 2;
+}
+.synthesis-card::before {
+  content: "";
+  position: absolute;
+  width: 680px;
+  height: 680px;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  border-radius: 50%;
+  border: 1px solid rgba(224, 221, 246, .82);
+  background:
+    radial-gradient(circle at 47% 43%, rgba(210, 202, 255, .42) 0%, rgba(235, 231, 255, .30) 25%, rgba(249, 249, 255, .66) 56%, rgba(255,255,255,.92) 76%, rgba(255,255,255,.98) 100%);
+  box-shadow: 0 34px 100px rgba(77, 69, 143, .09), inset 0 0 80px rgba(255,255,255,.75);
+  z-index: -1;
+}
+.synthesis-card::after {
+  content: "";
+  position: absolute;
+  width: 760px;
+  height: 760px;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  border-radius: 50%;
+  border: 1px solid rgba(199, 194, 240, .26);
+  background: radial-gradient(circle, rgba(153, 137, 244, .07) 0%, rgba(153,137,244,.02) 54%, rgba(255,255,255,0) 72%);
+  box-shadow: 0 0 0 26px rgba(255,255,255,.16), 0 0 0 58px rgba(199,194,240,.06);
+  z-index: -2;
+}
+
+.orbit {
+  position: absolute;
+  width: 620px;
+  height: 520px;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  pointer-events: none;
+  z-index: 2;
+  overflow: visible;
+}
+.orbit svg { position: absolute; inset: 0; width: 620px; height: 520px; overflow: visible; }
+.orbit .orbit-spokes { fill: none; stroke: var(--accent-line); stroke-width: 1.45; vector-effect: non-scaling-stroke; }
+.orbit .radar-scale-ring {
+  fill: none;
+  stroke: #d8d9eb;
+  stroke-width: 1;
+  stroke-opacity: .82;
+  vector-effect: non-scaling-stroke;
+}
+.orbit .radar-spokes { fill: none; stroke: #dedff0; stroke-width: 1; vector-effect: non-scaling-stroke; }
+.orbit .radar-shape--previous {
+  fill: rgba(59, 130, 246, .07);
+  stroke: #3b82f6;
+  stroke-width: 3;
+  stroke-linejoin: round;
+  vector-effect: non-scaling-stroke;
+}
+.orbit .radar-shape--current {
+  fill: rgba(244, 95, 165, .13);
+  stroke: #f45fa5;
+  stroke-width: 3;
+  stroke-linejoin: round;
+  marker-start: url(#radarVertex);
+  marker-mid: url(#radarVertex);
+  vector-effect: non-scaling-stroke;
+  filter: drop-shadow(0 8px 12px rgba(244, 95, 165, .11));
+}
+
+.signal {
+  position: absolute;
+  width: 146px;
+  text-align: center;
+  z-index: 3;
+  transform: translate(-50%, -50%);
+}
+.metric-orb {
+  padding: 12px 12px 11px;
+  border-radius: 18px;
+  border: 1px solid rgba(231,229,247,.92);
+  background: rgba(255,255,255,.84);
+  box-shadow: 0 12px 30px rgba(74, 66, 137, .09);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+}
+.signal strong {
+  display: block;
+  color: var(--accent);
+  font-size: 23px;
+  line-height: 1;
+  letter-spacing: -0.025em;
+}
+.signal span {
+  display: block;
+  margin-top: 7px;
+  font-weight: 700;
+  font-size: 12px;
+}
+.signal small { display: block; margin-top: 4px; color: var(--muted); font-size: 10px; }
+
+.radar-label {
+  position: absolute;
+  width: 132px;
+  z-index: 4;
+  line-height: 1.1;
+}
+.radar-label span {
+  display: block;
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 650;
+}
+.radar-label strong {
+  display: block;
+  margin-top: 5px;
+  color: var(--ink);
+  font-size: 16px;
+  line-height: 1;
+  font-weight: 780;
+  letter-spacing: -0.02em;
+}
+.radar-label small {
+  display: block;
+  margin-top: 6px;
+  font-size: 10px;
+  font-weight: 720;
+}
+.radar-label small.positive { color: var(--positive); }
+.radar-label small.danger { color: var(--danger); }
+.radar-label small.muted { color: var(--muted); }
+.radar-label--left { text-align: right; transform: translate(-100%, -50%); }
+.radar-label--right { text-align: left; transform: translate(0, -50%); }
+.radar-label--top,
+.radar-label--bottom { text-align: center; transform: translate(-50%, -50%); }
+
+.score-value-line {
+  display: flex;
+  align-items: baseline;
+  gap: 7px;
+  margin-top: 20px;
+}
+.score-value-line strong {
+  font-size: 36px;
+  line-height: 1;
+  font-weight: 800;
+  letter-spacing: -0.045em;
+}
+.score-value-line span { color: var(--muted); font-size: 13px; }
+.score-band { margin-top: 8px; color: var(--danger); font-size: 12px; font-weight: 720; }
+
+.composition-card {
+  padding: 22px 24px 18px;
+  min-height: 250px;
+}
+.composition-list { margin-top: 12px; }
+.composition-row {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 12px;
+  align-items: center;
+  padding: 10px 0;
+}
+.composition-row + .composition-row { border-top: 1px solid rgba(235,235,244,.82); }
+.composition-row span { font-size: 12px; font-weight: 660; }
+.composition-row small { color: var(--muted); font-size: 10px; }
+
+.compact-card {
+  padding: 23px 24px 18px;
+  min-height: 270px;
+}
+.risk-card { background: linear-gradient(155deg, rgba(255,255,255,.90), rgba(255,248,250,.86)); }
+.events-card { min-height: 294px; }
+.exception-list, .event-list { margin-top: 15px; }
+.exception-row, .event-row {
+  display: grid;
+  grid-template-columns: 10px 1fr auto;
+  gap: 9px;
+  align-items: start;
+  padding: 14px 0;
+}
+.exception-row + .exception-row,
+.event-row + .event-row { border-top: 1px solid rgba(232,232,242,.76); }
+.dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  margin-top: 5px;
+  background: #7869e4;
+  box-shadow: 0 0 0 4px rgba(120,105,228,.08);
+}
+.dot--risk { background: var(--danger); box-shadow: 0 0 0 4px rgba(226,84,98,.08); }
+.row-copy strong { display: block; font-size: 12px; }
+.row-copy span { display: block; color: var(--muted); font-size: 10px; margin-top: 5px; line-height: 1.4; }
+.badge {
+  align-self: start;
+  padding: 6px 9px;
+  border-radius: 999px;
+  background: var(--danger-bg);
+  color: var(--danger);
+  font-size: 9px;
+  font-weight: 720;
+  white-space: nowrap;
+}
+.event-time { color: var(--soft); font-size: 9px; white-space: nowrap; margin-top: 2px; }
+.empty-state { color: var(--muted); font-size: 11px; margin-top: 20px; }
+
+@media (max-width: 1320px) {
+  .dashboard-shell { width: min(1180px, calc(100vw - 40px)); }
+  .decision-layout {
+    grid-template-columns: 270px minmax(560px, 1fr) 286px;
+    gap: 18px;
+  }
+  .synthesis-card::before { width: 620px; height: 620px; }
+  .synthesis-card::after { width: 690px; height: 690px; }
+  .orbit { transform: translate(-50%, -50%) scale(.92); }
+}
+
+@media (max-width: 1080px) {
+  .dashboard-shell { width: min(920px, calc(100vw - 36px)); }
+  .decision-layout { grid-template-columns: 1fr; gap: 18px; }
+  .support-column { display: grid; grid-template-columns: 1fr 1fr; gap: 18px; padding: 0; transform: none; }
+  .synthesis-card { order: -1; min-height: 590px; }
+  .synthesis-card::before { width: 610px; height: 610px; }
+  .synthesis-card::after { width: 680px; height: 680px; }
+  .orbit { transform: translate(-50%, -50%) scale(.96); }
+}
+
+@media (max-width: 700px) {
+  .dashboard-shell { width: min(100% - 24px, 660px); padding-top: 26px; }
+  .page-header { margin-bottom: 18px; }
+  .page-header h1 { font-size: 26px; }
+  .support-column { grid-template-columns: 1fr; }
+  .synthesis-card { min-height: 520px; overflow: hidden; }
+  .synthesis-card::before { width: 520px; height: 520px; }
+  .synthesis-card::after { width: 590px; height: 590px; }
+  .orbit { transform: translate(-50%, -50%) scale(.82); }
+  .support-card { border-radius: 20px; }
+}
+</style>
+</head>
+<body>
+  <main class="dashboard-shell">
+    <header class="page-header">
+      <div>
+        <h1>Subscription health</h1>
+        <p>Movement, exceptions, and business context in one view</p>
+      </div>
+    </header>
+
+    <section class="decision-layout">
+      <aside class="support-column support-column--left">
+        <article class="card support-card revenue-card">
+          <div class="eyebrow">Revenue attainment context</div>
+          <div class="metric-value">82%</div>
+          <div class="metric-delta positive">+6pp</div>
+          <svg class="sparkline" viewBox="0 0 234 86" aria-label="Revenue trend"><path d="M0.0 80.0 L58.5 58.9 L117.0 43.0 L175.5 21.9 L234.0 6.0"></path></svg>
+          <div class="card-divider"></div>
+          <div class="context-row"><span>Current Revenue attainment</span><strong>82%</strong></div>
+        </article>
+
+        <article class="card support-card context-card">
+          <div class="eyebrow">Movement context</div>
+          <div class="context-metric">
+    <span>Trial conversion</span>
+    <strong>67%</strong>
+    <em class="danger">-4pp</em>
+  </div>
+<div class="context-metric">
+    <span>Customer target</span>
+    <strong>78%</strong>
+    <em class="positive">+5pp</em>
+  </div>
+        </article>
+      </aside>
+
+      <section class="card synthesis-card" aria-label="Subscription profile">
+        <div class="orbit" aria-hidden="true">
+          <svg viewBox="0 0 620 520" preserveAspectRatio="xMidYMid meet">
+            <defs>
+              <marker id="radarVertex" viewBox="0 0 14 14" refX="7" refY="7" markerWidth="14" markerHeight="14" markerUnits="userSpaceOnUse">
+                <circle cx="7" cy="7" r="5" fill="#f45fa5" stroke="#ffffff" stroke-width="2"></circle>
+              </marker>
+            </defs>
+            <circle class="radar-scale-ring" data-scale="40" r="75.2" cx="310" cy="260"/>
+<circle class="radar-scale-ring" data-scale="60" r="112.8" cx="310" cy="260"/>
+<circle class="radar-scale-ring" data-scale="80" r="150.4" cx="310" cy="260"/>
+<circle class="radar-scale-ring" data-scale="100" r="188" cx="310" cy="260"/>
+            <path class="radar-spokes" d="M310 260 L310.0 72.0 M310 260 L488.8 201.9 M310 260 L420.5 412.1 M310 260 L199.5 412.1 M310 260 L131.2 201.9"></path>
+            <path class="radar-shape radar-shape--previous" d="M310.0 117.1 L440.5 217.6 L407.2 393.8 L231.5 368.0 L181.3 218.2 Z"></path>
+            <path class="radar-shape radar-shape--current" d="M310.0 105.8 L449.5 214.7 L410.6 398.4 L236.0 361.9 L177.7 217.0 Z"></path>
+          </svg>
+          <div class="radar-dimension radar-label radar-label--top" data-outside-ring="true" style="left:50.00%;top:4.23%">
+    <span>Revenue attainment</span>
+    <strong>82%</strong>
+    <small class="positive">↑ 6pp</small>
+  </div>
+<div class="radar-dimension radar-label radar-label--right" data-outside-ring="true" style="left:86.51%;top:35.86%">
+    <span>Customer target</span>
+    <strong>78%</strong>
+    <small class="positive">↑ 5pp</small>
+  </div>
+<div class="radar-dimension radar-label radar-label--right" data-outside-ring="true" style="left:72.56%;top:87.03%">
+    <span>Retention</span>
+    <strong>91%</strong>
+    <small class="positive">↑ 3pp</small>
+  </div>
+<div class="radar-dimension radar-label radar-label--left" data-outside-ring="true" style="left:27.44%;top:87.03%">
+    <span>Trial conversion</span>
+    <strong>67%</strong>
+    <small class="danger">↓ 4pp</small>
+  </div>
+<div class="radar-dimension radar-label radar-label--left" data-outside-ring="true" style="left:13.49%;top:35.86%">
+    <span>Expansion</span>
+    <strong>74%</strong>
+    <small class="positive">↑ 2pp</small>
+  </div>
+        </div>
+      </section>
+
+      <aside class="support-column support-column--right">
+        <article class="card support-card compact-card risk-card">
+          <div class="eyebrow">Accounts to watch</div>
+          <div class="exception-list"><div class="exception-row">
+      <span class="dot dot--risk" aria-hidden="true"></span>
+      <div class="row-copy"><strong>Dovetail</strong><span>Basic · $120 MRR</span></div>
+      <span class="badge">At risk</span>
+    </div></div>
+        </article>
+
+        <article class="card support-card compact-card events-card">
+          <div class="eyebrow">Recent events</div>
+          <div class="event-list"><div class="event-row">
+    <span class="dot" aria-hidden="true"></span>
+    <div class="row-copy"><strong>Dovetail</strong><span>Plan cancelled</span></div>
+    <span class="event-time">1 hr ago</span>
+  </div>
+<div class="event-row">
+    <span class="dot" aria-hidden="true"></span>
+    <div class="row-copy"><strong>Orbit Systems</strong><span>Trial converted</span></div>
+    <span class="event-time">43 min ago</span>
+  </div></div>
+        </article>
+      </aside>
+    </section>
+  </main>
+</body>
+</html>

--- a/examples/radar-profile/output.no-score.svg
+++ b/examples/radar-profile/output.no-score.svg
@@ -1,0 +1,166 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1440 900" role="img" aria-labelledby="title desc">
+  <title id="title">Subscription health</title>
+  <desc id="desc">Subscription metrics, revenue context, account exceptions, and recent events.</desc>
+  <defs>
+    <linearGradient id="pageBg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#f5f8ff"/>
+      <stop offset="1" stop-color="#e9eff9"/>
+    </linearGradient>
+    <radialGradient id="ambientGlow" cx="52%" cy="43%" r="62%">
+      <stop offset="0" stop-color="#c9c0ff" stop-opacity="0.34"/>
+      <stop offset="0.46" stop-color="#e7e3ff" stop-opacity="0.18"/>
+      <stop offset="1" stop-color="#ffffff" stop-opacity="0"/>
+    </radialGradient>
+    <radialGradient id="centerField" cx="47%" cy="43%" r="58%">
+      <stop offset="0" stop-color="#e5dfff" stop-opacity="0.50"/>
+      <stop offset="0.35" stop-color="#efecff" stop-opacity="0.48"/>
+      <stop offset="0.72" stop-color="#f8f8ff" stop-opacity="0.82"/>
+      <stop offset="1" stop-color="#fbfcff" stop-opacity="0.94"/>
+    </radialGradient>
+    <linearGradient id="accentLine" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#6555e8"/>
+      <stop offset="1" stop-color="#9b8df4"/>
+    </linearGradient>
+    <filter id="panelShadow" x="-30%" y="-30%" width="160%" height="170%">
+      <feDropShadow dx="0" dy="18" stdDeviation="20" flood-color="#403875" flood-opacity="0.10"/>
+      <feDropShadow dx="0" dy="3" stdDeviation="5" flood-color="#403875" flood-opacity="0.05"/>
+    </filter>
+    <filter id="orbShadow" x="-40%" y="-50%" width="180%" height="210%">
+      <feDropShadow dx="0" dy="9" stdDeviation="10" flood-color="#51468d" flood-opacity="0.12"/>
+    </filter>
+    <marker id="radarVertex" viewBox="0 0 14 14" refX="7" refY="7" markerWidth="14" markerHeight="14" markerUnits="userSpaceOnUse">
+      <circle cx="7" cy="7" r="5" fill="#f45fa5" stroke="#ffffff" stroke-width="2"/>
+    </marker>
+    <style>
+      .sans { font-family: Inter, ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+      .ink { fill: #171733; }
+      .muted { fill: #747a9b; }
+      .soft { fill: #a5aac3; }
+      .accent { fill: #6555e8; }
+      .positive { fill: #238764; }
+      .danger { fill: #e25462; }
+      .support-shadow { fill: #655b8f; fill-opacity: .065; }
+      .support-panel { fill: #ffffff; fill-opacity: .97; stroke: #e1e4f1; stroke-width: 1; filter: url(#panelShadow); }
+      .center-halo { fill: none; }
+      .center-halo--outer { stroke: #b8afe9; stroke-opacity: .24; stroke-width: 1; }
+      .center-halo--inner { stroke: #c8c0f2; stroke-opacity: .11; stroke-width: 22; }
+      .center-field { fill: url(#centerField); stroke: #ddd9f5; stroke-width: 1; }
+      .radar-scale-ring { fill: none; stroke: #d8d9eb; stroke-width: 1; stroke-opacity: .82; }
+      .radar-spokes { fill: none; stroke: #dedff0; stroke-width: 1; }
+      .radar-shape--previous { fill: #3b82f6; fill-opacity: .07; stroke: #3b82f6; stroke-width: 3; stroke-linejoin: round; }
+      .radar-shape--current { fill: #f45fa5; fill-opacity: .13; stroke: #f45fa5; stroke-width: 3; stroke-linejoin: round; marker-start: url(#radarVertex); marker-mid: url(#radarVertex); }
+      .metric-orb { fill: #f8f7ff; fill-opacity: .98; stroke: #d8d3f4; stroke-width: 1; filter: url(#orbShadow); }
+    </style>
+  </defs>
+
+  <rect width="1440" height="900" fill="url(#pageBg)"/>
+  <rect width="1440" height="900" fill="url(#ambientGlow)"/>
+
+  <g class="sans">
+    <text x="72" y="76" class="ink" font-size="29" font-weight="760" letter-spacing="-0.8">Subscription health</text>
+    <text x="72" y="107" class="muted" font-size="14">A compact view of movement, exceptions, and business context</text>
+
+    <rect x="70" y="158" width="310" height="300" rx="26" class="support-shadow"/>
+    <rect x="70" y="482" width="310" height="220" rx="26" class="support-shadow"/>
+    <rect x="1040" y="158" width="334" height="286" rx="26" class="support-shadow"/>
+    <rect x="1040" y="472" width="334" height="306" rx="26" class="support-shadow"/>
+    <rect x="66" y="150" width="310" height="300" rx="26" class="support-panel"/>
+    <rect x="66" y="474" width="310" height="220" rx="26" class="support-panel"/>
+    <rect x="1036" y="150" width="334" height="286" rx="26" class="support-panel"/>
+    <rect x="1036" y="464" width="334" height="306" rx="26" class="support-panel"/>
+
+    <text x="98" y="194" class="ink" font-size="15" font-weight="700">Revenue attainment context</text>
+    <text x="98" y="236" class="ink" font-size="34" font-weight="780">82%</text>
+    <text x="98" y="252" class="positive" font-size="14" font-weight="650">+6pp</text>
+    <path d="M98.0 360.0 L156.5 338.9 L215.0 323.0 L273.5 301.9 L332.0 286.0" fill="none" stroke="url(#accentLine)" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+    <line x1="98" y1="392" x2="344" y2="392" stroke="#e8e8f2"/>
+    <text x="98" y="422" class="muted" font-size="12">Current Revenue attainment</text>
+    <text x="344" y="422" class="ink" font-size="13" font-weight="700" text-anchor="end">82%</text>
+
+    <text x="98" y="516" class="ink" font-size="15" font-weight="700">Movement context</text>
+    <g>
+      <text x="98" y="552" class="muted" font-size="12">Trial conversion</text>
+      <text x="98" y="579" class="ink" font-size="21" font-weight="700">67%</text>
+      <text x="332" y="579" class="danger" font-size="13" font-weight="650" text-anchor="end">-4pp</text>
+      <line x1="98" y1="600" x2="332" y2="600" stroke="#efedf6"/>
+    </g>
+<g>
+      <text x="98" y="624" class="muted" font-size="12">Customer target</text>
+      <text x="98" y="651" class="ink" font-size="21" font-weight="700">78%</text>
+      <text x="332" y="651" class="positive" font-size="13" font-weight="650" text-anchor="end">+5pp</text>
+      
+    </g>
+
+    <circle cx="740" cy="458" r="366" class="center-halo center-halo--outer"/>
+    <circle cx="740" cy="458" r="338" class="center-halo center-halo--inner"/>
+    <circle cx="740" cy="458" r="314" class="center-field"/>
+
+    <g transform="translate(42 -6)">
+      <circle class="radar-scale-ring" data-scale="40" r="75.2" cx="698" cy="464"/>
+<circle class="radar-scale-ring" data-scale="60" r="112.8" cx="698" cy="464"/>
+<circle class="radar-scale-ring" data-scale="80" r="150.4" cx="698" cy="464"/>
+<circle class="radar-scale-ring" data-scale="100" r="188" cx="698" cy="464"/>
+    <path class="radar-spokes" d="M698 464 L698.0 276.0 M698 464 L876.8 405.9 M698 464 L808.5 616.1 M698 464 L587.5 616.1 M698 464 L519.2 405.9"/>
+    <path class="radar-shape radar-shape--previous" d="M698.0 321.1 L828.5 421.6 L795.2 597.8 L619.5 572.0 L569.3 422.2 Z"/>
+    <path class="radar-shape radar-shape--current" d="M698.0 309.8 L837.5 418.7 L798.6 602.4 L624.0 565.9 L565.7 421.0 Z"/>
+      <g class="radar-dimension-node">
+      <text class="radar-label radar-label--top" data-outside-ring="true" text-anchor="middle" x="698.0" y="205.0">
+        <tspan x="698.0" class="muted" font-size="11" font-weight="650">Revenue attainment</tspan>
+        <tspan x="698.0" dy="20" class="ink" font-size="16" font-weight="760">82%</tspan>
+        <tspan x="698.0" dy="18" class="positive" font-size="11" font-weight="700">↑ 6pp</tspan>
+      </text>
+    </g>
+<g class="radar-dimension-node">
+      <text class="radar-label radar-label--right" data-outside-ring="true" text-anchor="start" x="924.4" y="370.5">
+        <tspan x="924.4" class="muted" font-size="11" font-weight="650">Customer target</tspan>
+        <tspan x="924.4" dy="20" class="ink" font-size="16" font-weight="760">78%</tspan>
+        <tspan x="924.4" dy="18" class="positive" font-size="11" font-weight="700">↑ 5pp</tspan>
+      </text>
+    </g>
+<g class="radar-dimension-node">
+      <text class="radar-label radar-label--right" data-outside-ring="true" text-anchor="start" x="837.9" y="636.5">
+        <tspan x="837.9" class="muted" font-size="11" font-weight="650">Retention</tspan>
+        <tspan x="837.9" dy="20" class="ink" font-size="16" font-weight="760">91%</tspan>
+        <tspan x="837.9" dy="18" class="positive" font-size="11" font-weight="700">↑ 3pp</tspan>
+      </text>
+    </g>
+<g class="radar-dimension-node">
+      <text class="radar-label radar-label--left" data-outside-ring="true" text-anchor="end" x="558.1" y="636.5">
+        <tspan x="558.1" class="muted" font-size="11" font-weight="650">Trial conversion</tspan>
+        <tspan x="558.1" dy="20" class="ink" font-size="16" font-weight="760">67%</tspan>
+        <tspan x="558.1" dy="18" class="danger" font-size="11" font-weight="700">↓ 4pp</tspan>
+      </text>
+    </g>
+<g class="radar-dimension-node">
+      <text class="radar-label radar-label--left" data-outside-ring="true" text-anchor="end" x="471.6" y="370.5">
+        <tspan x="471.6" class="muted" font-size="11" font-weight="650">Expansion</tspan>
+        <tspan x="471.6" dy="20" class="ink" font-size="16" font-weight="760">74%</tspan>
+        <tspan x="471.6" dy="18" class="positive" font-size="11" font-weight="700">↑ 2pp</tspan>
+      </text>
+    </g>
+    </g>
+
+    <text x="1066" y="194" class="ink" font-size="15" font-weight="700">Accounts to watch</text>
+    <g>
+      <circle cx="1072" cy="228" r="5" fill="#e25462"/>
+      <text x="1088" y="232" class="ink" font-size="14" font-weight="650">Dovetail</text>
+      <text x="1088" y="254" class="muted" font-size="12">Basic · $120 MRR</text>
+      <rect x="1268" y="213" width="74" height="26" rx="13" fill="#fff1f3"/>
+      <text x="1305" y="231" class="danger" font-size="11" font-weight="650" text-anchor="middle">At risk</text>
+    </g>
+
+    <text x="1066" y="506" class="ink" font-size="15" font-weight="700">Recent events</text>
+    <g>
+      <circle cx="1072" cy="530" r="4" fill="#6555e8"/>
+      <text x="1088" y="534" class="ink" font-size="13" font-weight="650">Dovetail</text>
+      <text x="1088" y="555" class="muted" font-size="12">Plan cancelled</text>
+      <text x="1342" y="555" class="soft" font-size="11" text-anchor="end">1 hr ago</text>
+    </g>
+<g>
+      <circle cx="1072" cy="598" r="4" fill="#6555e8"/>
+      <text x="1088" y="602" class="ink" font-size="13" font-weight="650">Orbit Systems</text>
+      <text x="1088" y="623" class="muted" font-size="12">Trial converted</text>
+      <text x="1342" y="623" class="soft" font-size="11" text-anchor="end">43 min ago</text>
+    </g>
+  </g>
+</svg>

--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
   "scripts": {
     "test": "node --test tests/compiler/*.test.js",
     "validate:saas": "node skills/decision-first-dashboard/scripts/validate.js examples/saas/input.no-score.json",
-    "render:saas": "node skills/decision-first-dashboard/scripts/render.js examples/saas/input.no-score.json examples/saas"
+    "render:saas": "node skills/decision-first-dashboard/scripts/render.js examples/saas/input.no-score.json examples/saas",
+    "validate:radar-showcase": "node skills/decision-first-dashboard/scripts/validate.js examples/radar-profile/input.no-score.json",
+    "render:radar-showcase": "node skills/decision-first-dashboard/scripts/render.js examples/radar-profile/input.no-score.json examples/radar-profile"
   }
 }

--- a/tests/compiler/metric-router-contract.test.js
+++ b/tests/compiler/metric-router-contract.test.js
@@ -38,7 +38,7 @@ test('skill documents the compiler-enforced routing manifest and production gate
 test('README distinguishes no-score and composite examples without overstating capability', () => {
   assert.match(readme, /No-score mode — no unsupported score invented/);
   assert.match(readme, /Composite mode — when the evidence supports it/);
-  assert.match(readme, /examples\/saas\/output\.no-score\.svg/);
+  assert.match(readme, /examples\/radar-profile\/output\.no-score\.svg/);
   assert.match(readme, /examples\/saas\/composite-mode\.png/);
   assert.equal(fs.existsSync(path.join(root, 'examples/saas/composite-mode.png')), true);
 });

--- a/tests/compiler/readme-radar-showcase.test.js
+++ b/tests/compiler/readme-radar-showcase.test.js
@@ -1,0 +1,30 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import { renderSvg } from '../../skills/decision-first-dashboard/scripts/render.js';
+
+const readme = fs.readFileSync(new URL('../../README.md', import.meta.url), 'utf8');
+const showcasePath = new URL('../../examples/radar-profile/input.no-score.json', import.meta.url);
+
+test('README primary After uses the radar-profile showcase instead of the mixed-unit fallback', () => {
+  assert.match(readme, /examples\/radar-profile\/output\.no-score\.svg/);
+  assert.doesNotMatch(readme, /<td width="50%"><img src="examples\/saas\/output\.no-score\.svg"/);
+});
+
+test('radar-profile showcase is a true comparable no-score profile with current and previous periods', () => {
+  const fixture = JSON.parse(fs.readFileSync(showcasePath, 'utf8'));
+  assert.equal(fixture.mode, 'no_score');
+  assert.deepEqual(fixture.radarScale, { min: 0, max: 100, provenance: 'source' });
+  assert.ok(fixture.signals.length >= 3 && fixture.signals.length <= 6);
+  for (const signal of fixture.signals) {
+    assert.equal(signal.provenance, 'source');
+    assert.equal(Number.isFinite(signal.normalizedScore), true);
+    assert.equal(Number.isFinite(signal.previousNormalizedScore), true);
+  }
+
+  const svg = renderSvg(fixture);
+  assert.equal((svg.match(/class="radar-scale-ring"/g) ?? []).length, 4);
+  assert.match(svg, /class="radar-shape radar-shape--previous"/);
+  assert.match(svg, /class="radar-shape radar-shape--current"/);
+  assert.doesNotMatch(svg, /IMPROVING|Target unknown|Health Score|score-core/);
+});


### PR DESCRIPTION
The current README hero After is still the mixed-unit no-score fallback, so it cannot exercise the newly approved radar grammar. This PR switches the main showcase to a real radar-eligible no-score profile while keeping the mixed-unit fallback intact for production logic. The first commit adds a failing contract test.