### PR TITLE
Refine radar ambient field layering

### DIFF
--- a/examples/radar-profile/output.no-score.html
+++ b/examples/radar-profile/output.no-score.html
@@ -191,31 +191,18 @@ body {
 .synthesis-card::before {
   content: "";
   position: absolute;
-  width: 680px;
-  height: 680px;
+  width: 700px;
+  height: 700px;
   left: 50%;
-  top: 50%;
+  top: 52%;
   transform: translate(-50%, -50%);
   border-radius: 50%;
-  border: 1px solid rgba(224, 221, 246, .82);
-  background:
-    radial-gradient(circle at 47% 43%, rgba(210, 202, 255, .42) 0%, rgba(235, 231, 255, .30) 25%, rgba(249, 249, 255, .66) 56%, rgba(255,255,255,.92) 76%, rgba(255,255,255,.98) 100%);
-  box-shadow: 0 34px 100px rgba(77, 69, 143, .09), inset 0 0 80px rgba(255,255,255,.75);
-  z-index: -1;
-}
-.synthesis-card::after {
-  content: "";
-  position: absolute;
-  width: 760px;
-  height: 760px;
-  left: 50%;
-  top: 50%;
-  transform: translate(-50%, -50%);
-  border-radius: 50%;
-  border: 1px solid rgba(199, 194, 240, .26);
-  background: radial-gradient(circle, rgba(153, 137, 244, .07) 0%, rgba(153,137,244,.02) 54%, rgba(255,255,255,0) 72%);
-  box-shadow: 0 0 0 26px rgba(255,255,255,.16), 0 0 0 58px rgba(199,194,240,.06);
-  z-index: -2;
+  border: 0;
+  background: radial-gradient(circle at 50% 58%, rgba(202, 192, 255, .24) 0%, rgba(216, 207, 255, .17) 44%, rgba(191, 179, 238, .07) 70%, rgba(180, 166, 232, 0) 86%);
+  box-shadow: 0 42px 92px rgba(88, 75, 152, .08);
+  filter: blur(14px);
+  pointer-events: none;
+  z-index: 0;
 }
 
 .orbit {
@@ -226,7 +213,7 @@ body {
   top: 50%;
   transform: translate(-50%, -50%);
   pointer-events: none;
-  z-index: 2;
+  z-index: 1;
   overflow: visible;
 }
 .orbit svg { position: absolute; inset: 0; width: 620px; height: 520px; overflow: visible; }
@@ -235,8 +222,13 @@ body {
   fill: none;
   stroke: #d8d9eb;
   stroke-width: 1;
-  stroke-opacity: .82;
+  stroke-opacity: .76;
   vector-effect: non-scaling-stroke;
+}
+.orbit .radar-scale-ring[data-scale="100"] {
+  stroke: #b7b3d4;
+  stroke-width: 1.5;
+  stroke-opacity: .98;
 }
 .orbit .radar-spokes { fill: none; stroke: #dedff0; stroke-width: 1; vector-effect: non-scaling-stroke; }
 .orbit .radar-shape--previous {
@@ -400,8 +392,7 @@ body {
     grid-template-columns: 270px minmax(560px, 1fr) 286px;
     gap: 18px;
   }
-  .synthesis-card::before { width: 620px; height: 620px; }
-  .synthesis-card::after { width: 690px; height: 690px; }
+  .synthesis-card::before { width: 640px; height: 640px; }
   .orbit { transform: translate(-50%, -50%) scale(.92); }
 }
 
@@ -410,8 +401,7 @@ body {
   .decision-layout { grid-template-columns: 1fr; gap: 18px; }
   .support-column { display: grid; grid-template-columns: 1fr 1fr; gap: 18px; padding: 0; transform: none; }
   .synthesis-card { order: -1; min-height: 590px; }
-  .synthesis-card::before { width: 610px; height: 610px; }
-  .synthesis-card::after { width: 680px; height: 680px; }
+  .synthesis-card::before { width: 630px; height: 630px; }
   .orbit { transform: translate(-50%, -50%) scale(.96); }
 }
 
@@ -421,12 +411,10 @@ body {
   .page-header h1 { font-size: 26px; }
   .support-column { grid-template-columns: 1fr; }
   .synthesis-card { min-height: 520px; overflow: hidden; }
-  .synthesis-card::before { width: 520px; height: 520px; }
-  .synthesis-card::after { width: 590px; height: 590px; }
+  .synthesis-card::before { width: 540px; height: 540px; }
   .orbit { transform: translate(-50%, -50%) scale(.82); }
   .support-card { border-radius: 20px; }
-}
-</style>
+}</style>
 </head>
 <body>
   <main class="dashboard-shell">

--- a/examples/radar-profile/output.no-score.svg
+++ b/examples/radar-profile/output.no-score.svg
@@ -11,16 +11,19 @@
       <stop offset="0.46" stop-color="#e7e3ff" stop-opacity="0.18"/>
       <stop offset="1" stop-color="#ffffff" stop-opacity="0"/>
     </radialGradient>
-    <radialGradient id="centerField" cx="47%" cy="43%" r="58%">
-      <stop offset="0" stop-color="#e5dfff" stop-opacity="0.50"/>
-      <stop offset="0.35" stop-color="#efecff" stop-opacity="0.48"/>
-      <stop offset="0.72" stop-color="#f8f8ff" stop-opacity="0.82"/>
-      <stop offset="1" stop-color="#fbfcff" stop-opacity="0.94"/>
+    <radialGradient id="radarAmbient" cx="50%" cy="58%" r="56%">
+      <stop offset="0" stop-color="#cfc6ff" stop-opacity="0.26"/>
+      <stop offset="0.46" stop-color="#dcd5ff" stop-opacity="0.18"/>
+      <stop offset="0.74" stop-color="#c7bdf2" stop-opacity="0.08"/>
+      <stop offset="1" stop-color="#b9adee" stop-opacity="0"/>
     </radialGradient>
     <linearGradient id="accentLine" x1="0" y1="0" x2="1" y2="1">
       <stop offset="0" stop-color="#6555e8"/>
       <stop offset="1" stop-color="#9b8df4"/>
     </linearGradient>
+    <filter id="ambientFieldBlur" x="-30%" y="-30%" width="160%" height="170%">
+      <feGaussianBlur stdDeviation="16"/>
+    </filter>
     <filter id="panelShadow" x="-30%" y="-30%" width="160%" height="170%">
       <feDropShadow dx="0" dy="18" stdDeviation="20" flood-color="#403875" flood-opacity="0.10"/>
       <feDropShadow dx="0" dy="3" stdDeviation="5" flood-color="#403875" flood-opacity="0.05"/>
@@ -41,11 +44,9 @@
       .danger { fill: #e25462; }
       .support-shadow { fill: #655b8f; fill-opacity: .065; }
       .support-panel { fill: #ffffff; fill-opacity: .97; stroke: #e1e4f1; stroke-width: 1; filter: url(#panelShadow); }
-      .center-halo { fill: none; }
-      .center-halo--outer { stroke: #b8afe9; stroke-opacity: .24; stroke-width: 1; }
-      .center-halo--inner { stroke: #c8c0f2; stroke-opacity: .11; stroke-width: 22; }
-      .center-field { fill: url(#centerField); stroke: #ddd9f5; stroke-width: 1; }
-      .radar-scale-ring { fill: none; stroke: #d8d9eb; stroke-width: 1; stroke-opacity: .82; }
+      .radar-ambient-field { fill: url(#radarAmbient); stroke: none; filter: url(#ambientFieldBlur); }
+      .radar-scale-ring { fill: none; stroke: #d8d9eb; stroke-width: 1; stroke-opacity: .76; }
+      .radar-scale-ring[data-scale="100"] { stroke: #b7b3d4; stroke-width: 1.5; stroke-opacity: .98; }
       .radar-spokes { fill: none; stroke: #dedff0; stroke-width: 1; }
       .radar-shape--previous { fill: #3b82f6; fill-opacity: .07; stroke: #3b82f6; stroke-width: 3; stroke-linejoin: round; }
       .radar-shape--current { fill: #f45fa5; fill-opacity: .13; stroke: #f45fa5; stroke-width: 3; stroke-linejoin: round; marker-start: url(#radarVertex); marker-mid: url(#radarVertex); }
@@ -55,6 +56,7 @@
 
   <rect width="1440" height="900" fill="url(#pageBg)"/>
   <rect width="1440" height="900" fill="url(#ambientGlow)"/>
+  <circle cx="740" cy="482" r="318" class="radar-ambient-field"/>
 
   <g class="sans">
     <text x="72" y="76" class="ink" font-size="29" font-weight="760" letter-spacing="-0.8">Subscription health</text>
@@ -90,10 +92,6 @@
       <text x="332" y="651" class="positive" font-size="13" font-weight="650" text-anchor="end">+5pp</text>
       
     </g>
-
-    <circle cx="740" cy="458" r="366" class="center-halo center-halo--outer"/>
-    <circle cx="740" cy="458" r="338" class="center-halo center-halo--inner"/>
-    <circle cx="740" cy="458" r="314" class="center-field"/>
 
     <g transform="translate(42 -6)">
       <circle class="radar-scale-ring" data-scale="40" r="75.2" cx="698" cy="464"/>

--- a/skills/decision-first-dashboard/references/visual-pattern.md
+++ b/skills/decision-first-dashboard/references/visual-pattern.md
@@ -17,7 +17,7 @@ Preferred balance:
 The signature visual language is:
 
 - a large open circular center field as the first focal point;
-- layered ambient halos that create depth without pretending to be quantitative scale;
+- one soft ambient field beneath the center visualization and its surrounding labels, creating depth without pretending to be quantitative scale;
 - a true profile radar only when 3–6 dimensions are comparable on one grounded scale;
 - elevated translucent support surfaces at the sides for context, diagnosis, exceptions, and events;
 - asymmetric information density: profile in the center, explanation on the left, attention items on the right;
@@ -76,8 +76,22 @@ The quantitative grid is fixed and must not be improvised for visual effect.
 - All four rings share exactly one center.
 - Ring radii are proportional: `0.4R`, `0.6R`, `0.8R`, `1.0R`.
 - The scale rings are thin and quiet. They are measurement guides, not decorative halos.
-- Decorative ambient halos may sit behind the radar, but they must remain visually distinct from the four quantitative rings.
+- The **100% ring is the outer quantitative boundary** and should be slightly more legible than the inner 40/60/80 guides.
 - All polygon vertices stay inside the 100% ring.
+
+## Ambient field layer
+
+The ambient field is presentation only. It exists to give the 100% boundary and the center profile more depth, not to add another ring.
+
+- Use **one soft colored ambient field**, not multiple crisp halos.
+- The ambient field sits at the **lowest visual layer** beneath the radar grid, polygons, vertices, dimension labels, values, and deltas.
+- It may extend beyond the 100% ring and behind the surrounding labels.
+- It should feel closer to a soft environmental shadow or glow than a circle that can be read as `120%`.
+- Do not give it a hard outline or a white filled disc.
+- Use a low-contrast cool environmental color with a soft edge; a slight downward emphasis is allowed to create a floating effect.
+- The ambient field never receives a scale label, data attribute, business meaning, or interaction.
+
+The key separation is: **40/60/80/100 are data; the ambient field is atmosphere.**
 
 ## Current versus previous profile
 
@@ -108,6 +122,8 @@ Alignment follows physical position around the circle:
 - right-side labels and values: **left-aligned**;
 - exact top and bottom labels: centered.
 
+The ambient field may sit visually behind this copy. It does not change the positioning rule: the 100% ring remains the only boundary used to decide whether a label is inside or outside the radar.
+
 Delta arrows communicate numeric movement:
 
 - positive numeric change → `↑`;
@@ -123,7 +139,7 @@ Delta **color** communicates business favorability and must use the grounded sig
 - Account exceptions and events render only with source provenance.
 - No-score mode never renders a 0–100 overall score or unsupported health band.
 - Radar scale, current normalized values, and any previous-period normalized values must be grounded.
-- Visual depth, ambient halos, cards, and connection lines are presentation only. They do not create evidence or business semantics.
+- Visual depth, ambient fields, cards, and connection lines are presentation only. They do not create evidence or business semantics.
 
 ## Product language
 

--- a/skills/decision-first-dashboard/templates/composite.svg
+++ b/skills/decision-first-dashboard/templates/composite.svg
@@ -11,16 +11,19 @@
       <stop offset="0.46" stop-color="#e7e3ff" stop-opacity="0.18"/>
       <stop offset="1" stop-color="#ffffff" stop-opacity="0"/>
     </radialGradient>
-    <radialGradient id="centerField" cx="47%" cy="43%" r="58%">
-      <stop offset="0" stop-color="#e5dfff" stop-opacity="0.50"/>
-      <stop offset="0.35" stop-color="#efecff" stop-opacity="0.48"/>
-      <stop offset="0.72" stop-color="#f8f8ff" stop-opacity="0.82"/>
-      <stop offset="1" stop-color="#fbfcff" stop-opacity="0.94"/>
+    <radialGradient id="radarAmbient" cx="50%" cy="58%" r="56%">
+      <stop offset="0" stop-color="#cfc6ff" stop-opacity="0.26"/>
+      <stop offset="0.46" stop-color="#dcd5ff" stop-opacity="0.18"/>
+      <stop offset="0.74" stop-color="#c7bdf2" stop-opacity="0.08"/>
+      <stop offset="1" stop-color="#b9adee" stop-opacity="0"/>
     </radialGradient>
     <linearGradient id="accentLine" x1="0" y1="0" x2="1" y2="1">
       <stop offset="0" stop-color="#6555e8"/>
       <stop offset="1" stop-color="#9b8df4"/>
     </linearGradient>
+    <filter id="ambientFieldBlur" x="-30%" y="-30%" width="160%" height="170%">
+      <feGaussianBlur stdDeviation="16"/>
+    </filter>
     <filter id="panelShadow" x="-30%" y="-30%" width="160%" height="170%">
       <feDropShadow dx="0" dy="18" stdDeviation="20" flood-color="#403875" flood-opacity="0.10"/>
       <feDropShadow dx="0" dy="3" stdDeviation="5" flood-color="#403875" flood-opacity="0.05"/>
@@ -38,11 +41,9 @@
       .danger { fill: #e25462; }
       .support-shadow { fill: #655b8f; fill-opacity: .065; }
       .support-panel { fill: #ffffff; fill-opacity: .97; stroke: #e1e4f1; stroke-width: 1; filter: url(#panelShadow); }
-      .center-halo { fill: none; }
-      .center-halo--outer { stroke: #b8afe9; stroke-opacity: .24; stroke-width: 1; }
-      .center-halo--inner { stroke: #c8c0f2; stroke-opacity: .11; stroke-width: 22; }
-      .center-field { fill: url(#centerField); stroke: #ddd9f5; stroke-width: 1; }
-      .radar-scale-ring { fill: none; stroke: #d8d9eb; stroke-width: 1; stroke-opacity: .82; }
+      .radar-ambient-field { fill: url(#radarAmbient); stroke: none; filter: url(#ambientFieldBlur); }
+      .radar-scale-ring { fill: none; stroke: #d8d9eb; stroke-width: 1; stroke-opacity: .76; }
+      .radar-scale-ring[data-scale="100"] { stroke: #b7b3d4; stroke-width: 1.5; stroke-opacity: .98; }
       .radar-spokes { fill: none; stroke: #dedff0; stroke-width: 1; }
       .radar-shape--previous { fill: #3b82f6; fill-opacity: .07; stroke: #3b82f6; stroke-width: 3; stroke-linejoin: round; }
       .radar-shape--current { fill: #f45fa5; fill-opacity: .13; stroke: #f45fa5; stroke-width: 3; stroke-linejoin: round; marker-start: url(#radarVertex); marker-mid: url(#radarVertex); }
@@ -51,6 +52,7 @@
 
   <rect width="1440" height="900" fill="url(#pageBg)"/>
   <rect width="1440" height="900" fill="url(#ambientGlow)"/>
+  <circle cx="740" cy="482" r="318" class="radar-ambient-field"/>
 
   <g class="sans">
     <text x="72" y="76" class="ink" font-size="29" font-weight="760" letter-spacing="-0.8">{{SCORE_LABEL}}</text>
@@ -76,10 +78,6 @@
 
     <text x="98" y="516" class="ink" font-size="15" font-weight="700">Score composition</text>
     {{SVG_COMPOSITION_ROWS}}
-
-    <circle cx="740" cy="458" r="366" class="center-halo center-halo--outer"/>
-    <circle cx="740" cy="458" r="338" class="center-halo center-halo--inner"/>
-    <circle cx="740" cy="458" r="314" class="center-field"/>
 
     <g transform="translate(42 -6)">
       {{SVG_COMPONENT_RADAR}}

--- a/skills/decision-first-dashboard/templates/dashboard.css
+++ b/skills/decision-first-dashboard/templates/dashboard.css
@@ -185,31 +185,18 @@ body {
 .synthesis-card::before {
   content: "";
   position: absolute;
-  width: 680px;
-  height: 680px;
+  width: 700px;
+  height: 700px;
   left: 50%;
-  top: 50%;
+  top: 52%;
   transform: translate(-50%, -50%);
   border-radius: 50%;
-  border: 1px solid rgba(224, 221, 246, .82);
-  background:
-    radial-gradient(circle at 47% 43%, rgba(210, 202, 255, .42) 0%, rgba(235, 231, 255, .30) 25%, rgba(249, 249, 255, .66) 56%, rgba(255,255,255,.92) 76%, rgba(255,255,255,.98) 100%);
-  box-shadow: 0 34px 100px rgba(77, 69, 143, .09), inset 0 0 80px rgba(255,255,255,.75);
-  z-index: -1;
-}
-.synthesis-card::after {
-  content: "";
-  position: absolute;
-  width: 760px;
-  height: 760px;
-  left: 50%;
-  top: 50%;
-  transform: translate(-50%, -50%);
-  border-radius: 50%;
-  border: 1px solid rgba(199, 194, 240, .26);
-  background: radial-gradient(circle, rgba(153, 137, 244, .07) 0%, rgba(153,137,244,.02) 54%, rgba(255,255,255,0) 72%);
-  box-shadow: 0 0 0 26px rgba(255,255,255,.16), 0 0 0 58px rgba(199,194,240,.06);
-  z-index: -2;
+  border: 0;
+  background: radial-gradient(circle at 50% 58%, rgba(202, 192, 255, .24) 0%, rgba(216, 207, 255, .17) 44%, rgba(191, 179, 238, .07) 70%, rgba(180, 166, 232, 0) 86%);
+  box-shadow: 0 42px 92px rgba(88, 75, 152, .08);
+  filter: blur(14px);
+  pointer-events: none;
+  z-index: 0;
 }
 
 .orbit {
@@ -220,7 +207,7 @@ body {
   top: 50%;
   transform: translate(-50%, -50%);
   pointer-events: none;
-  z-index: 2;
+  z-index: 1;
   overflow: visible;
 }
 .orbit svg { position: absolute; inset: 0; width: 620px; height: 520px; overflow: visible; }
@@ -229,8 +216,13 @@ body {
   fill: none;
   stroke: #d8d9eb;
   stroke-width: 1;
-  stroke-opacity: .82;
+  stroke-opacity: .76;
   vector-effect: non-scaling-stroke;
+}
+.orbit .radar-scale-ring[data-scale="100"] {
+  stroke: #b7b3d4;
+  stroke-width: 1.5;
+  stroke-opacity: .98;
 }
 .orbit .radar-spokes { fill: none; stroke: #dedff0; stroke-width: 1; vector-effect: non-scaling-stroke; }
 .orbit .radar-shape--previous {
@@ -394,8 +386,7 @@ body {
     grid-template-columns: 270px minmax(560px, 1fr) 286px;
     gap: 18px;
   }
-  .synthesis-card::before { width: 620px; height: 620px; }
-  .synthesis-card::after { width: 690px; height: 690px; }
+  .synthesis-card::before { width: 640px; height: 640px; }
   .orbit { transform: translate(-50%, -50%) scale(.92); }
 }
 
@@ -404,8 +395,7 @@ body {
   .decision-layout { grid-template-columns: 1fr; gap: 18px; }
   .support-column { display: grid; grid-template-columns: 1fr 1fr; gap: 18px; padding: 0; transform: none; }
   .synthesis-card { order: -1; min-height: 590px; }
-  .synthesis-card::before { width: 610px; height: 610px; }
-  .synthesis-card::after { width: 680px; height: 680px; }
+  .synthesis-card::before { width: 630px; height: 630px; }
   .orbit { transform: translate(-50%, -50%) scale(.96); }
 }
 
@@ -415,8 +405,7 @@ body {
   .page-header h1 { font-size: 26px; }
   .support-column { grid-template-columns: 1fr; }
   .synthesis-card { min-height: 520px; overflow: hidden; }
-  .synthesis-card::before { width: 520px; height: 520px; }
-  .synthesis-card::after { width: 590px; height: 590px; }
+  .synthesis-card::before { width: 540px; height: 540px; }
   .orbit { transform: translate(-50%, -50%) scale(.82); }
   .support-card { border-radius: 20px; }
 }

--- a/skills/decision-first-dashboard/templates/no-score.svg
+++ b/skills/decision-first-dashboard/templates/no-score.svg
@@ -11,16 +11,19 @@
       <stop offset="0.46" stop-color="#e7e3ff" stop-opacity="0.18"/>
       <stop offset="1" stop-color="#ffffff" stop-opacity="0"/>
     </radialGradient>
-    <radialGradient id="centerField" cx="47%" cy="43%" r="58%">
-      <stop offset="0" stop-color="#e5dfff" stop-opacity="0.50"/>
-      <stop offset="0.35" stop-color="#efecff" stop-opacity="0.48"/>
-      <stop offset="0.72" stop-color="#f8f8ff" stop-opacity="0.82"/>
-      <stop offset="1" stop-color="#fbfcff" stop-opacity="0.94"/>
+    <radialGradient id="radarAmbient" cx="50%" cy="58%" r="56%">
+      <stop offset="0" stop-color="#cfc6ff" stop-opacity="0.26"/>
+      <stop offset="0.46" stop-color="#dcd5ff" stop-opacity="0.18"/>
+      <stop offset="0.74" stop-color="#c7bdf2" stop-opacity="0.08"/>
+      <stop offset="1" stop-color="#b9adee" stop-opacity="0"/>
     </radialGradient>
     <linearGradient id="accentLine" x1="0" y1="0" x2="1" y2="1">
       <stop offset="0" stop-color="#6555e8"/>
       <stop offset="1" stop-color="#9b8df4"/>
     </linearGradient>
+    <filter id="ambientFieldBlur" x="-30%" y="-30%" width="160%" height="170%">
+      <feGaussianBlur stdDeviation="16"/>
+    </filter>
     <filter id="panelShadow" x="-30%" y="-30%" width="160%" height="170%">
       <feDropShadow dx="0" dy="18" stdDeviation="20" flood-color="#403875" flood-opacity="0.10"/>
       <feDropShadow dx="0" dy="3" stdDeviation="5" flood-color="#403875" flood-opacity="0.05"/>
@@ -41,11 +44,9 @@
       .danger { fill: #e25462; }
       .support-shadow { fill: #655b8f; fill-opacity: .065; }
       .support-panel { fill: #ffffff; fill-opacity: .97; stroke: #e1e4f1; stroke-width: 1; filter: url(#panelShadow); }
-      .center-halo { fill: none; }
-      .center-halo--outer { stroke: #b8afe9; stroke-opacity: .24; stroke-width: 1; }
-      .center-halo--inner { stroke: #c8c0f2; stroke-opacity: .11; stroke-width: 22; }
-      .center-field { fill: url(#centerField); stroke: #ddd9f5; stroke-width: 1; }
-      .radar-scale-ring { fill: none; stroke: #d8d9eb; stroke-width: 1; stroke-opacity: .82; }
+      .radar-ambient-field { fill: url(#radarAmbient); stroke: none; filter: url(#ambientFieldBlur); }
+      .radar-scale-ring { fill: none; stroke: #d8d9eb; stroke-width: 1; stroke-opacity: .76; }
+      .radar-scale-ring[data-scale="100"] { stroke: #b7b3d4; stroke-width: 1.5; stroke-opacity: .98; }
       .radar-spokes { fill: none; stroke: #dedff0; stroke-width: 1; }
       .radar-shape--previous { fill: #3b82f6; fill-opacity: .07; stroke: #3b82f6; stroke-width: 3; stroke-linejoin: round; }
       .radar-shape--current { fill: #f45fa5; fill-opacity: .13; stroke: #f45fa5; stroke-width: 3; stroke-linejoin: round; marker-start: url(#radarVertex); marker-mid: url(#radarVertex); }
@@ -55,6 +56,7 @@
 
   <rect width="1440" height="900" fill="url(#pageBg)"/>
   <rect width="1440" height="900" fill="url(#ambientGlow)"/>
+  <circle cx="740" cy="482" r="318" class="radar-ambient-field"/>
 
   <g class="sans">
     <text x="72" y="76" class="ink" font-size="29" font-weight="760" letter-spacing="-0.8">Subscription health</text>
@@ -79,10 +81,6 @@
 
     <text x="98" y="516" class="ink" font-size="15" font-weight="700">Movement context</text>
     {{MOVEMENT_ROWS}}
-
-    <circle cx="740" cy="458" r="366" class="center-halo center-halo--outer"/>
-    <circle cx="740" cy="458" r="338" class="center-halo center-halo--inner"/>
-    <circle cx="740" cy="458" r="314" class="center-field"/>
 
     <g transform="translate(42 -6)">
       {{SVG_ORBIT_VISUAL}}

--- a/tests/compiler/golden/hashes.json
+++ b/tests/compiler/golden/hashes.json
@@ -1,6 +1,6 @@
 {
-  "no-score.svg": "cdea1f9ec3902cc22f688fea65e6fa3dcce767521d2c709335bae3a3f7a8bfc3",
-  "no-score.html": "7c271da50f991e93eb6f03191de608776ab02d47fcb434dc9a7244135bf0db16",
-  "composite.svg": "d011a57cefec18a54671a6ad988df72e67d1bab46cf50d5e20f62c9a363bcd57",
-  "composite.html": "d1d91af9d152de83e09266f21377ff95d3ce5af8d8b84e4b1441e4e1b606458e"
+  "no-score.svg": "42a19508abf38c48b2452a1111cf1dbe28b8c8dc25ac4e3f0abeff48c66e8d37",
+  "no-score.html": "3aed07fc55af50223fbcc4f869c0be0ab4942dd8af4d2b21bcd77ae6aa07a4c5",
+  "composite.svg": "c70a062ce76442523035353f529b611ed915ae314cd3849de00860af3f8d8b19",
+  "composite.html": "658bcc666749903bf7a3a03197fe82ab752c71a471d63f97c985ffa24aff3395"
 }

--- a/tests/compiler/radar-scale-layout.test.js
+++ b/tests/compiler/radar-scale-layout.test.js
@@ -14,7 +14,7 @@ const comparisonRadar = {
 };
 
 function scaleRadii(markup) {
-  return [...markup.matchAll(/class="radar-scale-ring(?: radar-scale-ring--outer)?"[^>]*data-scale="(40|60|80|100)"[^>]*r="([0-9.]+)"/g)]
+  return [...markup.matchAll(/class="radar-scale-ring"[^>]*data-scale="(40|60|80|100)"[^>]*r="([0-9.]+)"/g)]
     .map((match) => [Number(match[1]), Number(match[2])]);
 }
 
@@ -73,11 +73,10 @@ test('ambient field is a non-quantitative bottom layer and the 100% ring remains
   assert.ok(ambientIndex < firstLabelIndex, 'ambient field must sit below labels and values');
   assert.doesNotMatch(svg, /class="center-halo|class="center-field/);
   assert.match(svg, /\.radar-ambient-field\s*\{[^}]*stroke:\s*none/i);
-  assert.match(svg, /class="radar-scale-ring radar-scale-ring--outer"[^>]*data-scale="100"/);
-  assert.match(svg, /\.radar-scale-ring--outer\s*\{[^}]*stroke-width:\s*1\.5/i);
+  assert.match(svg, /\.radar-scale-ring\[data-scale="100"\]\s*\{[^}]*stroke-width:\s*1\.5/i);
 
   assert.match(html, /\.synthesis-card::before\s*\{[^}]*radial-gradient[^}]*z-index:\s*0/is);
   assert.doesNotMatch(html, /\.synthesis-card::after\s*\{/);
   assert.match(html, /\.orbit\s*\{[^}]*z-index:\s*1/is);
-  assert.match(html, /\.radar-scale-ring--outer\s*\{[^}]*stroke-width:\s*1\.5/is);
+  assert.match(html, /\.orbit \.radar-scale-ring\[data-scale="100"\]\s*\{[^}]*stroke-width:\s*1\.5/is);
 });

--- a/tests/compiler/radar-scale-layout.test.js
+++ b/tests/compiler/radar-scale-layout.test.js
@@ -14,7 +14,7 @@ const comparisonRadar = {
 };
 
 function scaleRadii(markup) {
-  return [...markup.matchAll(/class="radar-scale-ring"[^>]*data-scale="(40|60|80|100)"[^>]*r="([0-9.]+)"/g)]
+  return [...markup.matchAll(/class="radar-scale-ring(?: radar-scale-ring--outer)?"[^>]*data-scale="(40|60|80|100)"[^>]*r="([0-9.]+)"/g)]
     .map((match) => [Number(match[1]), Number(match[2])]);
 }
 
@@ -59,4 +59,25 @@ test('left labels are right-aligned and right labels are left-aligned', () => {
   assert.match(svg, /class="radar-label radar-label--right"[^>]*text-anchor="start"/);
   assert.match(svg, /class="radar-label radar-label--top"[^>]*text-anchor="middle"/);
   assert.match(svg, /class="radar-label radar-label--bottom"[^>]*text-anchor="middle"/);
+});
+
+test('ambient field is a non-quantitative bottom layer and the 100% ring remains the outer data boundary', () => {
+  const svg = renderSvg(comparisonRadar);
+  const html = renderHtml(comparisonRadar);
+  const ambientIndex = svg.indexOf('class="radar-ambient-field"');
+  const firstRingIndex = svg.indexOf('class="radar-scale-ring');
+  const firstLabelIndex = svg.indexOf('class="radar-label');
+
+  assert.ok(ambientIndex >= 0, 'ambient field should render');
+  assert.ok(ambientIndex < firstRingIndex, 'ambient field must sit below quantitative rings');
+  assert.ok(ambientIndex < firstLabelIndex, 'ambient field must sit below labels and values');
+  assert.doesNotMatch(svg, /class="center-halo|class="center-field/);
+  assert.match(svg, /\.radar-ambient-field\s*\{[^}]*stroke:\s*none/i);
+  assert.match(svg, /class="radar-scale-ring radar-scale-ring--outer"[^>]*data-scale="100"/);
+  assert.match(svg, /\.radar-scale-ring--outer\s*\{[^}]*stroke-width:\s*1\.5/i);
+
+  assert.match(html, /\.synthesis-card::before\s*\{[^}]*radial-gradient[^}]*z-index:\s*0/is);
+  assert.doesNotMatch(html, /\.synthesis-card::after\s*\{/);
+  assert.match(html, /\.orbit\s*\{[^}]*z-index:\s*1/is);
+  assert.match(html, /\.radar-scale-ring--outer\s*\{[^}]*stroke-width:\s*1\.5/is);
 });

--- a/tests/compiler/visual-fidelity-contract.test.js
+++ b/tests/compiler/visual-fidelity-contract.test.js
@@ -7,13 +7,14 @@ const composite = JSON.parse(
   fs.readFileSync(new URL('./fixtures/composite.valid.json', import.meta.url), 'utf8')
 );
 
-test('composite SVG keeps premium ambient depth while using four quantitative radar rings', () => {
+test('composite SVG keeps premium ambient depth without creating pseudo-scale rings', () => {
   const svg = renderSvg(composite);
 
-  assert.match(svg, /class="center-halo center-halo--outer"/);
-  assert.match(svg, /class="center-halo center-halo--inner"/);
-  assert.match(svg, /<circle cx="740" cy="458" r="314" class="center-field"\/>/);
+  assert.match(svg, /class="radar-ambient-field"/);
+  assert.match(svg, /\.radar-ambient-field\s*\{[^}]*fill:\s*url\(#radarAmbient\);[^}]*stroke:\s*none/i);
+  assert.doesNotMatch(svg, /class="center-halo|class="center-field/);
   assert.equal((svg.match(/class="radar-scale-ring"/g) ?? []).length, 4);
+  assert.match(svg, /\.radar-scale-ring\[data-scale="100"\]\s*\{[^}]*stroke-width:\s*1\.5/i);
   assert.doesNotMatch(svg, /class="score-core"|class="direction-core"/);
   assert.doesNotMatch(svg, /class="kpi-grid"|class="dashboard-table"/);
 });
@@ -44,12 +45,13 @@ test('composite score remains in the support card instead of occupying the radar
   assert.doesNotMatch(html, /class="score-core"/);
 });
 
-test('HTML uses a signature open center plus elevated support surfaces', () => {
+test('HTML keeps one soft ambient field below the radar and its labels', () => {
   const html = renderHtml(composite);
 
   assert.match(html, /grid-template-columns:\s*300px\s+minmax\(620px,\s*1fr\)\s+320px/);
   assert.match(html, /class="card support-card score-card"/);
   assert.match(html, /\.support-card\s*\{[\s\S]*?background:\s*rgba\(255,\s*255,\s*255,\s*\.82\);[\s\S]*?border-radius:\s*24px;[\s\S]*?box-shadow:/);
-  assert.match(html, /\.synthesis-card::before\s*\{[\s\S]*?width:\s*680px;[\s\S]*?height:\s*680px;/);
-  assert.match(html, /\.synthesis-card::after\s*\{[\s\S]*?width:\s*760px;[\s\S]*?height:\s*760px;/);
+  assert.match(html, /\.synthesis-card::before\s*\{[\s\S]*?width:\s*700px;[\s\S]*?height:\s*700px;[\s\S]*?border:\s*0;[\s\S]*?radial-gradient[\s\S]*?filter:\s*blur\(14px\);[\s\S]*?z-index:\s*0;/);
+  assert.doesNotMatch(html, /\.synthesis-card::after\s*\{/);
+  assert.match(html, /\.orbit\s*\{[\s\S]*?z-index:\s*1;/);
 });


### PR DESCRIPTION
This PR makes the ambient circle a true bottom presentation layer instead of a fifth pseudo-scale ring. It keeps 40/60/80/100 as the only quantitative rings, strengthens the 100% boundary, and ensures labels/values sit above the ambient field. The first commit adds the failing contract test.