### PR TITLE
Fix radar scale tiers and label safe zones

### DIFF
--- a/examples/radar-profile/output.no-score.html
+++ b/examples/radar-profile/output.no-score.html
@@ -219,16 +219,17 @@ body {
 .orbit svg { position: absolute; inset: 0; width: 620px; height: 520px; overflow: visible; }
 .orbit .orbit-spokes { fill: none; stroke: var(--accent-line); stroke-width: 1.45; vector-effect: non-scaling-stroke; }
 .orbit .radar-scale-ring {
-  fill: none;
+  fill: #ffffff;
+  fill-opacity: 1;
   stroke: #d8d9eb;
   stroke-width: 1;
-  stroke-opacity: .76;
+  stroke-opacity: .86;
   vector-effect: non-scaling-stroke;
 }
 .orbit .radar-scale-ring[data-scale="100"] {
-  stroke: #b7b3d4;
+  stroke: #aaa7cb;
   stroke-width: 1.5;
-  stroke-opacity: .98;
+  stroke-opacity: 1;
 }
 .orbit .radar-spokes { fill: none; stroke: #dedff0; stroke-width: 1; vector-effect: non-scaling-stroke; }
 .orbit .radar-shape--previous {
@@ -285,6 +286,7 @@ body {
   width: 132px;
   z-index: 4;
   line-height: 1.1;
+  white-space: nowrap;
 }
 .radar-label span {
   display: block;
@@ -311,7 +313,7 @@ body {
 .radar-label small.danger { color: var(--danger); }
 .radar-label small.muted { color: var(--muted); }
 .radar-label--left { text-align: right; transform: translate(-100%, -50%); }
-.radar-label--right { text-align: left; transform: translate(0, -50%); }
+.radar-label--right { text-align: left; transform: translate(-24px, -50%); }
 .radar-label--top,
 .radar-label--bottom { text-align: center; transform: translate(-50%, -50%); }
 
@@ -459,10 +461,10 @@ body {
                 <circle cx="7" cy="7" r="5" fill="#f45fa5" stroke="#ffffff" stroke-width="2"></circle>
               </marker>
             </defs>
-            <circle class="radar-scale-ring" data-scale="40" r="75.2" cx="310" cy="260"/>
-<circle class="radar-scale-ring" data-scale="60" r="112.8" cx="310" cy="260"/>
+            <circle class="radar-scale-ring" data-scale="100" r="188" cx="310" cy="260"/>
 <circle class="radar-scale-ring" data-scale="80" r="150.4" cx="310" cy="260"/>
-<circle class="radar-scale-ring" data-scale="100" r="188" cx="310" cy="260"/>
+<circle class="radar-scale-ring" data-scale="60" r="112.8" cx="310" cy="260"/>
+<circle class="radar-scale-ring" data-scale="40" r="75.2" cx="310" cy="260"/>
             <path class="radar-spokes" d="M310 260 L310.0 72.0 M310 260 L488.8 201.9 M310 260 L420.5 412.1 M310 260 L199.5 412.1 M310 260 L131.2 201.9"></path>
             <path class="radar-shape radar-shape--previous" d="M310.0 117.1 L440.5 217.6 L407.2 393.8 L231.5 368.0 L181.3 218.2 Z"></path>
             <path class="radar-shape radar-shape--current" d="M310.0 105.8 L449.5 214.7 L410.6 398.4 L236.0 361.9 L177.7 217.0 Z"></path>
@@ -472,7 +474,7 @@ body {
     <strong>82%</strong>
     <small class="positive">↑ 6pp</small>
   </div>
-<div class="radar-dimension radar-label radar-label--right" data-outside-ring="true" style="left:86.51%;top:35.86%">
+<div class="radar-dimension radar-label radar-label--right" data-outside-ring="true" style="left:80.65%;top:35.86%">
     <span>Customer target</span>
     <strong>78%</strong>
     <small class="positive">↑ 5pp</small>
@@ -487,7 +489,7 @@ body {
     <strong>67%</strong>
     <small class="danger">↓ 4pp</small>
   </div>
-<div class="radar-dimension radar-label radar-label--left" data-outside-ring="true" style="left:13.49%;top:35.86%">
+<div class="radar-dimension radar-label radar-label--left" data-outside-ring="true" style="left:19.35%;top:35.86%">
     <span>Expansion</span>
     <strong>74%</strong>
     <small class="positive">↑ 2pp</small>

--- a/examples/radar-profile/output.no-score.svg
+++ b/examples/radar-profile/output.no-score.svg
@@ -45,11 +45,14 @@
       .support-shadow { fill: #655b8f; fill-opacity: .065; }
       .support-panel { fill: #ffffff; fill-opacity: .97; stroke: #e1e4f1; stroke-width: 1; filter: url(#panelShadow); }
       .radar-ambient-field { fill: url(#radarAmbient); stroke: none; filter: url(#ambientFieldBlur); }
-      .radar-scale-ring { fill: none; stroke: #d8d9eb; stroke-width: 1; stroke-opacity: .76; }
-      .radar-scale-ring[data-scale="100"] { stroke: #b7b3d4; stroke-width: 1.5; stroke-opacity: .98; }
+      .radar-scale-ring { fill: #ffffff; fill-opacity: 1; stroke: #d8d9eb; stroke-width: 1; stroke-opacity: .86; }
+      .radar-scale-ring[data-scale="100"] { stroke: #aaa7cb; stroke-width: 1.5; stroke-opacity: 1; }
       .radar-spokes { fill: none; stroke: #dedff0; stroke-width: 1; }
       .radar-shape--previous { fill: #3b82f6; fill-opacity: .07; stroke: #3b82f6; stroke-width: 3; stroke-linejoin: round; }
       .radar-shape--current { fill: #f45fa5; fill-opacity: .13; stroke: #f45fa5; stroke-width: 3; stroke-linejoin: round; marker-start: url(#radarVertex); marker-mid: url(#radarVertex); }
+      .radar-label--left, .radar-label--left tspan { text-anchor: end; }
+      .radar-label--right, .radar-label--right tspan { text-anchor: start; }
+      .radar-label--right { transform: translateX(-24px); }
       .metric-orb { fill: #f8f7ff; fill-opacity: .98; stroke: #d8d3f4; stroke-width: 1; filter: url(#orbShadow); }
     </style>
   </defs>
@@ -94,46 +97,46 @@
     </g>
 
     <g transform="translate(42 -6)">
-      <circle class="radar-scale-ring" data-scale="40" r="75.2" cx="698" cy="464"/>
-<circle class="radar-scale-ring" data-scale="60" r="112.8" cx="698" cy="464"/>
+      <circle class="radar-scale-ring" data-scale="100" r="188" cx="698" cy="464"/>
 <circle class="radar-scale-ring" data-scale="80" r="150.4" cx="698" cy="464"/>
-<circle class="radar-scale-ring" data-scale="100" r="188" cx="698" cy="464"/>
+<circle class="radar-scale-ring" data-scale="60" r="112.8" cx="698" cy="464"/>
+<circle class="radar-scale-ring" data-scale="40" r="75.2" cx="698" cy="464"/>
     <path class="radar-spokes" d="M698 464 L698.0 276.0 M698 464 L876.8 405.9 M698 464 L808.5 616.1 M698 464 L587.5 616.1 M698 464 L519.2 405.9"/>
     <path class="radar-shape radar-shape--previous" d="M698.0 321.1 L828.5 421.6 L795.2 597.8 L619.5 572.0 L569.3 422.2 Z"/>
     <path class="radar-shape radar-shape--current" d="M698.0 309.8 L837.5 418.7 L798.6 602.4 L624.0 565.9 L565.7 421.0 Z"/>
       <g class="radar-dimension-node">
       <text class="radar-label radar-label--top" data-outside-ring="true" text-anchor="middle" x="698.0" y="205.0">
-        <tspan x="698.0" class="muted" font-size="11" font-weight="650">Revenue attainment</tspan>
-        <tspan x="698.0" dy="20" class="ink" font-size="16" font-weight="760">82%</tspan>
-        <tspan x="698.0" dy="18" class="positive" font-size="11" font-weight="700">↑ 6pp</tspan>
+        <tspan x="698.0" text-anchor="middle" class="muted" font-size="11" font-weight="650">Revenue attainment</tspan>
+        <tspan x="698.0" dy="20" text-anchor="middle" class="ink" font-size="16" font-weight="760">82%</tspan>
+        <tspan x="698.0" dy="18" text-anchor="middle" class="positive" font-size="11" font-weight="700">↑ 6pp</tspan>
       </text>
     </g>
 <g class="radar-dimension-node">
-      <text class="radar-label radar-label--right" data-outside-ring="true" text-anchor="start" x="924.4" y="370.5">
-        <tspan x="924.4" class="muted" font-size="11" font-weight="650">Customer target</tspan>
-        <tspan x="924.4" dy="20" class="ink" font-size="16" font-weight="760">78%</tspan>
-        <tspan x="924.4" dy="18" class="positive" font-size="11" font-weight="700">↑ 5pp</tspan>
+      <text class="radar-label radar-label--right" data-outside-ring="true" text-anchor="start" x="900.0" y="370.5">
+        <tspan x="900.0" text-anchor="start" class="muted" font-size="11" font-weight="650">Customer target</tspan>
+        <tspan x="900.0" dy="20" text-anchor="start" class="ink" font-size="16" font-weight="760">78%</tspan>
+        <tspan x="900.0" dy="18" text-anchor="start" class="positive" font-size="11" font-weight="700">↑ 5pp</tspan>
       </text>
     </g>
 <g class="radar-dimension-node">
       <text class="radar-label radar-label--right" data-outside-ring="true" text-anchor="start" x="837.9" y="636.5">
-        <tspan x="837.9" class="muted" font-size="11" font-weight="650">Retention</tspan>
-        <tspan x="837.9" dy="20" class="ink" font-size="16" font-weight="760">91%</tspan>
-        <tspan x="837.9" dy="18" class="positive" font-size="11" font-weight="700">↑ 3pp</tspan>
+        <tspan x="837.9" text-anchor="start" class="muted" font-size="11" font-weight="650">Retention</tspan>
+        <tspan x="837.9" dy="20" text-anchor="start" class="ink" font-size="16" font-weight="760">91%</tspan>
+        <tspan x="837.9" dy="18" text-anchor="start" class="positive" font-size="11" font-weight="700">↑ 3pp</tspan>
       </text>
     </g>
 <g class="radar-dimension-node">
       <text class="radar-label radar-label--left" data-outside-ring="true" text-anchor="end" x="558.1" y="636.5">
-        <tspan x="558.1" class="muted" font-size="11" font-weight="650">Trial conversion</tspan>
-        <tspan x="558.1" dy="20" class="ink" font-size="16" font-weight="760">67%</tspan>
-        <tspan x="558.1" dy="18" class="danger" font-size="11" font-weight="700">↓ 4pp</tspan>
+        <tspan x="558.1" text-anchor="end" class="muted" font-size="11" font-weight="650">Trial conversion</tspan>
+        <tspan x="558.1" dy="20" text-anchor="end" class="ink" font-size="16" font-weight="760">67%</tspan>
+        <tspan x="558.1" dy="18" text-anchor="end" class="danger" font-size="11" font-weight="700">↓ 4pp</tspan>
       </text>
     </g>
 <g class="radar-dimension-node">
-      <text class="radar-label radar-label--left" data-outside-ring="true" text-anchor="end" x="471.6" y="370.5">
-        <tspan x="471.6" class="muted" font-size="11" font-weight="650">Expansion</tspan>
-        <tspan x="471.6" dy="20" class="ink" font-size="16" font-weight="760">74%</tspan>
-        <tspan x="471.6" dy="18" class="positive" font-size="11" font-weight="700">↑ 2pp</tspan>
+      <text class="radar-label radar-label--left" data-outside-ring="true" text-anchor="end" x="500.0" y="370.5">
+        <tspan x="500.0" text-anchor="end" class="muted" font-size="11" font-weight="650">Expansion</tspan>
+        <tspan x="500.0" dy="20" text-anchor="end" class="ink" font-size="16" font-weight="760">74%</tspan>
+        <tspan x="500.0" dy="18" text-anchor="end" class="positive" font-size="11" font-weight="700">↑ 2pp</tspan>
       </text>
     </g>
     </g>

--- a/skills/decision-first-dashboard/scripts/render.js
+++ b/skills/decision-first-dashboard/scripts/render.js
@@ -162,8 +162,8 @@ function htmlRowXs(count) {
   }[count] ?? [];
 }
 
-const SVG_RADAR_LAYOUT = { cx: 698, cy: 464, radarRadius: 188, labelRadius: 238 };
-const HTML_RADAR_LAYOUT = { cx: 310, cy: 260, radarRadius: 188, labelRadius: 238 };
+const SVG_RADAR_LAYOUT = { cx: 698, cy: 464, radarRadius: 188, labelRadius: 238, labelSafeLeft: 500, labelSafeRight: 900 };
+const HTML_RADAR_LAYOUT = { cx: 310, cy: 260, radarRadius: 188, labelRadius: 238, labelSafeLeft: 120, labelSafeRight: 500 };
 const RADAR_SCALE_STEPS = [40, 60, 80, 100];
 
 function radialPoint(cx, cy, radius, angle) {
@@ -180,6 +180,20 @@ function pointPath(points, close = false) {
   return close ? `${path} Z` : path;
 }
 
+function radarSide(angle) {
+  const x = Math.cos(angle);
+  const y = Math.sin(angle);
+  if (Math.abs(x) < 0.15) return y < 0 ? 'top' : 'bottom';
+  return x < 0 ? 'left' : 'right';
+}
+
+function safeRadarLabelPoint(point, angle, layout) {
+  const side = radarSide(angle);
+  if (side === 'left') return { ...point, x: Math.max(point.x, layout.labelSafeLeft) };
+  if (side === 'right') return { ...point, x: Math.min(point.x, layout.labelSafeRight) };
+  return point;
+}
+
 function radarGeometry(dimensions, min, max, layout, valueKey = 'normalizedScore') {
   const span = max - min;
   const count = dimensions.length;
@@ -194,7 +208,7 @@ function radarGeometry(dimensions, min, max, layout, valueKey = 'normalizedScore
     const ratio = Math.min(1, Math.max(0, (value - min) / span));
     axes.push(radialPoint(layout.cx, layout.cy, layout.radarRadius, angle));
     shape.push(radialPoint(layout.cx, layout.cy, layout.radarRadius * ratio, angle));
-    labels.push(radialPoint(layout.cx, layout.cy, layout.labelRadius, angle));
+    labels.push(safeRadarLabelPoint(radialPoint(layout.cx, layout.cy, layout.labelRadius, angle), angle, layout));
     angles.push(angle);
   });
 
@@ -207,7 +221,7 @@ function radarGeometry(dimensions, min, max, layout, valueKey = 'normalizedScore
 }
 
 function radarScaleRings(layout) {
-  return RADAR_SCALE_STEPS.map((scale) => {
+  return [...RADAR_SCALE_STEPS].reverse().map((scale) => {
     const radius = Number((layout.radarRadius * scale / 100).toFixed(1));
     return `<circle class="radar-scale-ring" data-scale="${scale}" r="${radius}" cx="${layout.cx}" cy="${layout.cy}"/>`;
   }).join('\n');
@@ -215,13 +229,6 @@ function radarScaleRings(layout) {
 
 function hasCompletePreviousProfile(dimensions) {
   return dimensions.length > 0 && dimensions.every((dimension) => Number.isFinite(dimension.previousNormalizedScore));
-}
-
-function radarSide(angle) {
-  const x = Math.cos(angle);
-  const y = Math.sin(angle);
-  if (Math.abs(x) < 0.15) return y < 0 ? 'top' : 'bottom';
-  return x < 0 ? 'left' : 'right';
 }
 
 function radarAnchor(side) {
@@ -269,12 +276,12 @@ function svgRadarNodes(dimensions, min, max, nodeClass) {
     const startY = side === 'top' ? point.y - 21 : side === 'bottom' ? point.y - 3 : point.y - 20;
     const delta = deltaWithArrow(dimension.delta);
     const deltaNode = delta
-      ? `<tspan x="${point.x.toFixed(1)}" dy="18" class="${directionClass(dimension.direction)}" font-size="11" font-weight="700">${escapeMarkup(delta)}</tspan>`
+      ? `<tspan x="${point.x.toFixed(1)}" dy="18" text-anchor="${anchor}" class="${directionClass(dimension.direction)}" font-size="11" font-weight="700">${escapeMarkup(delta)}</tspan>`
       : '';
     return `<g class="${nodeClass}">
       <text class="radar-label radar-label--${side}" data-outside-ring="true" text-anchor="${anchor}" x="${point.x.toFixed(1)}" y="${startY.toFixed(1)}">
-        <tspan x="${point.x.toFixed(1)}" class="muted" font-size="11" font-weight="650">${escapeMarkup(dimension.label)}</tspan>
-        <tspan x="${point.x.toFixed(1)}" dy="20" class="ink" font-size="16" font-weight="760">${escapeMarkup(dimension.value)}</tspan>
+        <tspan x="${point.x.toFixed(1)}" text-anchor="${anchor}" class="muted" font-size="11" font-weight="650">${escapeMarkup(dimension.label)}</tspan>
+        <tspan x="${point.x.toFixed(1)}" dy="20" text-anchor="${anchor}" class="ink" font-size="16" font-weight="760">${escapeMarkup(dimension.value)}</tspan>
         ${deltaNode}
       </text>
     </g>`;

--- a/skills/decision-first-dashboard/templates/composite.svg
+++ b/skills/decision-first-dashboard/templates/composite.svg
@@ -42,11 +42,14 @@
       .support-shadow { fill: #655b8f; fill-opacity: .065; }
       .support-panel { fill: #ffffff; fill-opacity: .97; stroke: #e1e4f1; stroke-width: 1; filter: url(#panelShadow); }
       .radar-ambient-field { fill: url(#radarAmbient); stroke: none; filter: url(#ambientFieldBlur); }
-      .radar-scale-ring { fill: none; stroke: #d8d9eb; stroke-width: 1; stroke-opacity: .76; }
-      .radar-scale-ring[data-scale="100"] { stroke: #b7b3d4; stroke-width: 1.5; stroke-opacity: .98; }
+      .radar-scale-ring { fill: #ffffff; fill-opacity: 1; stroke: #d8d9eb; stroke-width: 1; stroke-opacity: .86; }
+      .radar-scale-ring[data-scale="100"] { stroke: #aaa7cb; stroke-width: 1.5; stroke-opacity: 1; }
       .radar-spokes { fill: none; stroke: #dedff0; stroke-width: 1; }
       .radar-shape--previous { fill: #3b82f6; fill-opacity: .07; stroke: #3b82f6; stroke-width: 3; stroke-linejoin: round; }
       .radar-shape--current { fill: #f45fa5; fill-opacity: .13; stroke: #f45fa5; stroke-width: 3; stroke-linejoin: round; marker-start: url(#radarVertex); marker-mid: url(#radarVertex); }
+      .radar-label--left, .radar-label--left tspan { text-anchor: end; }
+      .radar-label--right, .radar-label--right tspan { text-anchor: start; }
+      .radar-label--right { transform: translateX(-24px); }
     </style>
   </defs>
 

--- a/skills/decision-first-dashboard/templates/dashboard.css
+++ b/skills/decision-first-dashboard/templates/dashboard.css
@@ -213,16 +213,17 @@ body {
 .orbit svg { position: absolute; inset: 0; width: 620px; height: 520px; overflow: visible; }
 .orbit .orbit-spokes { fill: none; stroke: var(--accent-line); stroke-width: 1.45; vector-effect: non-scaling-stroke; }
 .orbit .radar-scale-ring {
-  fill: none;
+  fill: #ffffff;
+  fill-opacity: 1;
   stroke: #d8d9eb;
   stroke-width: 1;
-  stroke-opacity: .76;
+  stroke-opacity: .86;
   vector-effect: non-scaling-stroke;
 }
 .orbit .radar-scale-ring[data-scale="100"] {
-  stroke: #b7b3d4;
+  stroke: #aaa7cb;
   stroke-width: 1.5;
-  stroke-opacity: .98;
+  stroke-opacity: 1;
 }
 .orbit .radar-spokes { fill: none; stroke: #dedff0; stroke-width: 1; vector-effect: non-scaling-stroke; }
 .orbit .radar-shape--previous {
@@ -279,6 +280,7 @@ body {
   width: 132px;
   z-index: 4;
   line-height: 1.1;
+  white-space: nowrap;
 }
 .radar-label span {
   display: block;
@@ -305,7 +307,7 @@ body {
 .radar-label small.danger { color: var(--danger); }
 .radar-label small.muted { color: var(--muted); }
 .radar-label--left { text-align: right; transform: translate(-100%, -50%); }
-.radar-label--right { text-align: left; transform: translate(0, -50%); }
+.radar-label--right { text-align: left; transform: translate(-24px, -50%); }
 .radar-label--top,
 .radar-label--bottom { text-align: center; transform: translate(-50%, -50%); }
 

--- a/skills/decision-first-dashboard/templates/no-score.svg
+++ b/skills/decision-first-dashboard/templates/no-score.svg
@@ -45,11 +45,14 @@
       .support-shadow { fill: #655b8f; fill-opacity: .065; }
       .support-panel { fill: #ffffff; fill-opacity: .97; stroke: #e1e4f1; stroke-width: 1; filter: url(#panelShadow); }
       .radar-ambient-field { fill: url(#radarAmbient); stroke: none; filter: url(#ambientFieldBlur); }
-      .radar-scale-ring { fill: none; stroke: #d8d9eb; stroke-width: 1; stroke-opacity: .76; }
-      .radar-scale-ring[data-scale="100"] { stroke: #b7b3d4; stroke-width: 1.5; stroke-opacity: .98; }
+      .radar-scale-ring { fill: #ffffff; fill-opacity: 1; stroke: #d8d9eb; stroke-width: 1; stroke-opacity: .86; }
+      .radar-scale-ring[data-scale="100"] { stroke: #aaa7cb; stroke-width: 1.5; stroke-opacity: 1; }
       .radar-spokes { fill: none; stroke: #dedff0; stroke-width: 1; }
       .radar-shape--previous { fill: #3b82f6; fill-opacity: .07; stroke: #3b82f6; stroke-width: 3; stroke-linejoin: round; }
       .radar-shape--current { fill: #f45fa5; fill-opacity: .13; stroke: #f45fa5; stroke-width: 3; stroke-linejoin: round; marker-start: url(#radarVertex); marker-mid: url(#radarVertex); }
+      .radar-label--left, .radar-label--left tspan { text-anchor: end; }
+      .radar-label--right, .radar-label--right tspan { text-anchor: start; }
+      .radar-label--right { transform: translateX(-24px); }
       .metric-orb { fill: #f8f7ff; fill-opacity: .98; stroke: #d8d3f4; stroke-width: 1; filter: url(#orbShadow); }
     </style>
   </defs>

--- a/tests/compiler/golden/hashes.json
+++ b/tests/compiler/golden/hashes.json
@@ -1,6 +1,6 @@
 {
-  "no-score.svg": "42a19508abf38c48b2452a1111cf1dbe28b8c8dc25ac4e3f0abeff48c66e8d37",
-  "no-score.html": "3aed07fc55af50223fbcc4f869c0be0ab4942dd8af4d2b21bcd77ae6aa07a4c5",
-  "composite.svg": "c70a062ce76442523035353f529b611ed915ae314cd3849de00860af3f8d8b19",
-  "composite.html": "658bcc666749903bf7a3a03197fe82ab752c71a471d63f97c985ffa24aff3395"
+  "no-score.svg": "135d2f9a3fe9b8a219e2daeadb53065d1759e1ea6c2aa6851f238ce6f7b84b61",
+  "no-score.html": "26f861655327c5249855eadbfe6f343d5a6cb773bc0ae1ff7a37295dbf0b3fc0",
+  "composite.svg": "e81e4765cff843e661b026bfd3d7ec2a3d26032a703822df9c9ff1afca48e4c6",
+  "composite.html": "caddceca9bfcd7ba4093080233b1c600db60fc3f10241493f5585766c7f156ba"
 }

--- a/tests/compiler/radar-scale-layout.test.js
+++ b/tests/compiler/radar-scale-layout.test.js
@@ -22,8 +22,16 @@ test('profile radar uses exactly four proportional 40/60/80/100 scale rings', ()
   const svg = renderSvg(comparisonRadar);
   const html = renderHtml(comparisonRadar);
 
-  assert.deepEqual(scaleRadii(svg), [[40, 75.2], [60, 112.8], [80, 150.4], [100, 188]]);
-  assert.deepEqual(scaleRadii(html), [[40, 75.2], [60, 112.8], [80, 150.4], [100, 188]]);
+  assert.deepEqual(scaleRadii(svg), [[100, 188], [80, 150.4], [60, 112.8], [40, 75.2]]);
+  assert.deepEqual(scaleRadii(html), [[100, 188], [80, 150.4], [60, 112.8], [40, 75.2]]);
+});
+
+test('quantitative radar tiers are opaque white circles with visible gray boundaries', () => {
+  const svg = renderSvg(comparisonRadar);
+  const html = renderHtml(comparisonRadar);
+
+  assert.match(svg, /\.radar-scale-ring\s*\{[^}]*fill:\s*#ffffff;[^}]*fill-opacity:\s*1;[^}]*stroke:/i);
+  assert.match(html, /\.orbit \.radar-scale-ring\s*\{[^}]*fill:\s*#ffffff;[^}]*fill-opacity:\s*1;[^}]*stroke:/i);
 });
 
 test('previous month is blue below the current pink profile and current vertices stay visible', () => {
@@ -52,13 +60,34 @@ test('radar center stays empty and all dimension copy sits outside the 100% ring
   assert.match(svg, /class="danger"[^>]*>↓ 6pp</);
 });
 
-test('left labels are right-aligned and right labels are left-aligned', () => {
+test('left labels are explicitly right-aligned line by line and right labels are left-aligned', () => {
   const svg = renderSvg(comparisonRadar);
 
-  assert.match(svg, /class="radar-label radar-label--left"[^>]*text-anchor="end"/);
-  assert.match(svg, /class="radar-label radar-label--right"[^>]*text-anchor="start"/);
-  assert.match(svg, /class="radar-label radar-label--top"[^>]*text-anchor="middle"/);
-  assert.match(svg, /class="radar-label radar-label--bottom"[^>]*text-anchor="middle"/);
+  const leftBlock = svg.match(/<text class="radar-label radar-label--left"[\s\S]*?<\/text>/)?.[0] ?? '';
+  const rightBlock = svg.match(/<text class="radar-label radar-label--right"[\s\S]*?<\/text>/)?.[0] ?? '';
+  assert.match(leftBlock, /text-anchor="end"/);
+  assert.equal((leftBlock.match(/text-anchor="end"/g) ?? []).length, 4, 'left label and all three lines must share the same right edge');
+  assert.match(rightBlock, /text-anchor="start"/);
+  assert.equal((rightBlock.match(/text-anchor="start"/g) ?? []).length, 4, 'right label and all three lines must share the same left edge');
+});
+
+test('side labels stay inside the center safe zone and cannot overlap support cards', () => {
+  const svg = renderSvg(comparisonRadar);
+  const html = renderHtml(comparisonRadar);
+
+  for (const match of svg.matchAll(/class="radar-label radar-label--(left|right)"[^>]*x="([0-9.]+)"/g)) {
+    const [, side, xText] = match;
+    const x = Number(xText);
+    if (side === 'left') assert.ok(x >= 500, `left label x=${x} must clear the left support card`);
+    if (side === 'right') assert.ok(x <= 900, `right label x=${x} must clear the right support card`);
+  }
+
+  for (const match of html.matchAll(/class="[^\"]*radar-label radar-label--(left|right)[^\"]*"[^>]*style="left:([0-9.]+)%/g)) {
+    const [, side, pctText] = match;
+    const pct = Number(pctText);
+    if (side === 'left') assert.ok(pct >= 19.35, `left HTML label ${pct}% must clear the left support card`);
+    if (side === 'right') assert.ok(pct <= 80.65, `right HTML label ${pct}% must clear the right support card`);
+  }
 });
 
 test('ambient field is a non-quantitative bottom layer and the 100% ring remains the outer data boundary', () => {


### PR DESCRIPTION
Restores the four quantitative 40/60/80/100 radar tiers as opaque white circles over the ambient field, paints them largest-to-smallest so all four boundaries remain visible, makes left/right text alignment explicit line-by-line, and constrains side labels so they cannot collide with support cards. Includes regression tests for ring order, white fills, alignment, and safe zones.