### PR TITLE
Center radar module and unify label spacing

### DIFF
--- a/examples/radar-profile/output.no-score.html
+++ b/examples/radar-profile/output.no-score.html
@@ -313,7 +313,7 @@ body {
 .radar-label small.danger { color: var(--danger); }
 .radar-label small.muted { color: var(--muted); }
 .radar-label--left { text-align: right; transform: translate(-100%, -50%); }
-.radar-label--right { text-align: left; transform: translate(-24px, -50%); }
+.radar-label--right { text-align: left; transform: translate(0, -50%); }
 .radar-label--top,
 .radar-label--bottom { text-align: center; transform: translate(-50%, -50%); }
 
@@ -469,27 +469,27 @@ body {
             <path class="radar-shape radar-shape--previous" d="M310.0 117.1 L440.5 217.6 L407.2 393.8 L231.5 368.0 L181.3 218.2 Z"></path>
             <path class="radar-shape radar-shape--current" d="M310.0 105.8 L449.5 214.7 L410.6 398.4 L236.0 361.9 L177.7 217.0 Z"></path>
           </svg>
-          <div class="radar-dimension radar-label radar-label--top" data-outside-ring="true" style="left:50.00%;top:4.23%">
+          <div class="radar-dimension radar-label radar-label--top" data-outside-ring="true" style="left:50.00%;top:6.15%">
     <span>Revenue attainment</span>
     <strong>82%</strong>
     <small class="positive">↑ 6pp</small>
   </div>
-<div class="radar-dimension radar-label radar-label--right" data-outside-ring="true" style="left:80.65%;top:35.86%">
+<div class="radar-dimension radar-label radar-label--right" data-outside-ring="true" style="left:84.97%;top:36.45%">
     <span>Customer target</span>
     <strong>78%</strong>
     <small class="positive">↑ 5pp</small>
   </div>
-<div class="radar-dimension radar-label radar-label--right" data-outside-ring="true" style="left:72.56%;top:87.03%">
+<div class="radar-dimension radar-label radar-label--right" data-outside-ring="true" style="left:71.62%;top:85.47%">
     <span>Retention</span>
     <strong>91%</strong>
     <small class="positive">↑ 3pp</small>
   </div>
-<div class="radar-dimension radar-label radar-label--left" data-outside-ring="true" style="left:27.44%;top:87.03%">
+<div class="radar-dimension radar-label radar-label--left" data-outside-ring="true" style="left:28.38%;top:85.47%">
     <span>Trial conversion</span>
     <strong>67%</strong>
     <small class="danger">↓ 4pp</small>
   </div>
-<div class="radar-dimension radar-label radar-label--left" data-outside-ring="true" style="left:19.35%;top:35.86%">
+<div class="radar-dimension radar-label radar-label--left" data-outside-ring="true" style="left:15.03%;top:36.45%">
     <span>Expansion</span>
     <strong>74%</strong>
     <small class="positive">↑ 2pp</small>

--- a/examples/radar-profile/output.no-score.svg
+++ b/examples/radar-profile/output.no-score.svg
@@ -52,14 +52,14 @@
       .radar-shape--current { fill: #f45fa5; fill-opacity: .13; stroke: #f45fa5; stroke-width: 3; stroke-linejoin: round; marker-start: url(#radarVertex); marker-mid: url(#radarVertex); }
       .radar-label--left, .radar-label--left tspan { text-anchor: end; }
       .radar-label--right, .radar-label--right tspan { text-anchor: start; }
-      .radar-label--right { transform: translateX(-24px); }
+      .radar-label--right { transform: none; }
       .metric-orb { fill: #f8f7ff; fill-opacity: .98; stroke: #d8d3f4; stroke-width: 1; filter: url(#orbShadow); }
     </style>
   </defs>
 
   <rect width="1440" height="900" fill="url(#pageBg)"/>
   <rect width="1440" height="900" fill="url(#ambientGlow)"/>
-  <circle cx="740" cy="482" r="318" class="radar-ambient-field"/>
+  <circle cx="706" cy="482" r="318" class="radar-ambient-field"/>
 
   <g class="sans">
     <text x="72" y="76" class="ink" font-size="29" font-weight="760" letter-spacing="-0.8">Subscription health</text>
@@ -96,7 +96,7 @@
       
     </g>
 
-    <g transform="translate(42 -6)">
+    <g transform="translate(8 -6)">
       <circle class="radar-scale-ring" data-scale="100" r="188" cx="698" cy="464"/>
 <circle class="radar-scale-ring" data-scale="80" r="150.4" cx="698" cy="464"/>
 <circle class="radar-scale-ring" data-scale="60" r="112.8" cx="698" cy="464"/>
@@ -105,38 +105,38 @@
     <path class="radar-shape radar-shape--previous" d="M698.0 321.1 L828.5 421.6 L795.2 597.8 L619.5 572.0 L569.3 422.2 Z"/>
     <path class="radar-shape radar-shape--current" d="M698.0 309.8 L837.5 418.7 L798.6 602.4 L624.0 565.9 L565.7 421.0 Z"/>
       <g class="radar-dimension-node">
-      <text class="radar-label radar-label--top" data-outside-ring="true" text-anchor="middle" x="698.0" y="205.0">
+      <text class="radar-label radar-label--top" data-outside-ring="true" text-anchor="middle" x="698.0" y="215.0">
         <tspan x="698.0" text-anchor="middle" class="muted" font-size="11" font-weight="650">Revenue attainment</tspan>
         <tspan x="698.0" dy="20" text-anchor="middle" class="ink" font-size="16" font-weight="760">82%</tspan>
         <tspan x="698.0" dy="18" text-anchor="middle" class="positive" font-size="11" font-weight="700">↑ 6pp</tspan>
       </text>
     </g>
 <g class="radar-dimension-node">
-      <text class="radar-label radar-label--right" data-outside-ring="true" text-anchor="start" x="900.0" y="370.5">
-        <tspan x="900.0" text-anchor="start" class="muted" font-size="11" font-weight="650">Customer target</tspan>
-        <tspan x="900.0" dy="20" text-anchor="start" class="ink" font-size="16" font-weight="760">78%</tspan>
-        <tspan x="900.0" dy="18" text-anchor="start" class="positive" font-size="11" font-weight="700">↑ 5pp</tspan>
+      <text class="radar-label radar-label--right" data-outside-ring="true" text-anchor="start" x="914.8" y="373.5">
+        <tspan x="914.8" text-anchor="start" class="muted" font-size="11" font-weight="650">Customer target</tspan>
+        <tspan x="914.8" dy="20" text-anchor="start" class="ink" font-size="16" font-weight="760">78%</tspan>
+        <tspan x="914.8" dy="18" text-anchor="start" class="positive" font-size="11" font-weight="700">↑ 5pp</tspan>
       </text>
     </g>
 <g class="radar-dimension-node">
-      <text class="radar-label radar-label--right" data-outside-ring="true" text-anchor="start" x="837.9" y="636.5">
-        <tspan x="837.9" text-anchor="start" class="muted" font-size="11" font-weight="650">Retention</tspan>
-        <tspan x="837.9" dy="20" text-anchor="start" class="ink" font-size="16" font-weight="760">91%</tspan>
-        <tspan x="837.9" dy="18" text-anchor="start" class="positive" font-size="11" font-weight="700">↑ 3pp</tspan>
+      <text class="radar-label radar-label--right" data-outside-ring="true" text-anchor="start" x="832.0" y="628.5">
+        <tspan x="832.0" text-anchor="start" class="muted" font-size="11" font-weight="650">Retention</tspan>
+        <tspan x="832.0" dy="20" text-anchor="start" class="ink" font-size="16" font-weight="760">91%</tspan>
+        <tspan x="832.0" dy="18" text-anchor="start" class="positive" font-size="11" font-weight="700">↑ 3pp</tspan>
       </text>
     </g>
 <g class="radar-dimension-node">
-      <text class="radar-label radar-label--left" data-outside-ring="true" text-anchor="end" x="558.1" y="636.5">
-        <tspan x="558.1" text-anchor="end" class="muted" font-size="11" font-weight="650">Trial conversion</tspan>
-        <tspan x="558.1" dy="20" text-anchor="end" class="ink" font-size="16" font-weight="760">67%</tspan>
-        <tspan x="558.1" dy="18" text-anchor="end" class="danger" font-size="11" font-weight="700">↓ 4pp</tspan>
+      <text class="radar-label radar-label--left" data-outside-ring="true" text-anchor="end" x="564.0" y="628.5">
+        <tspan x="564.0" text-anchor="end" class="muted" font-size="11" font-weight="650">Trial conversion</tspan>
+        <tspan x="564.0" dy="20" text-anchor="end" class="ink" font-size="16" font-weight="760">67%</tspan>
+        <tspan x="564.0" dy="18" text-anchor="end" class="danger" font-size="11" font-weight="700">↓ 4pp</tspan>
       </text>
     </g>
 <g class="radar-dimension-node">
-      <text class="radar-label radar-label--left" data-outside-ring="true" text-anchor="end" x="500.0" y="370.5">
-        <tspan x="500.0" text-anchor="end" class="muted" font-size="11" font-weight="650">Expansion</tspan>
-        <tspan x="500.0" dy="20" text-anchor="end" class="ink" font-size="16" font-weight="760">74%</tspan>
-        <tspan x="500.0" dy="18" text-anchor="end" class="positive" font-size="11" font-weight="700">↑ 2pp</tspan>
+      <text class="radar-label radar-label--left" data-outside-ring="true" text-anchor="end" x="481.2" y="373.5">
+        <tspan x="481.2" text-anchor="end" class="muted" font-size="11" font-weight="650">Expansion</tspan>
+        <tspan x="481.2" dy="20" text-anchor="end" class="ink" font-size="16" font-weight="760">74%</tspan>
+        <tspan x="481.2" dy="18" text-anchor="end" class="positive" font-size="11" font-weight="700">↑ 2pp</tspan>
       </text>
     </g>
     </g>

--- a/skills/decision-first-dashboard/scripts/render-core.js
+++ b/skills/decision-first-dashboard/scripts/render-core.js
@@ -1,0 +1,668 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { validateDecisionState } from './validate.js';
+
+const currentFile = fileURLToPath(import.meta.url);
+const currentDir = path.dirname(currentFile);
+const noScoreSvgTemplatePath = path.resolve(currentDir, '../templates/no-score.svg');
+const noScoreHtmlTemplatePath = path.resolve(currentDir, '../templates/no-score.html');
+const compositeSvgTemplatePath = path.resolve(currentDir, '../templates/composite.svg');
+const compositeHtmlTemplatePath = path.resolve(currentDir, '../templates/composite.html');
+const cssTemplatePath = path.resolve(currentDir, '../templates/dashboard.css');
+
+function assertValid(data) {
+  const result = validateDecisionState(data);
+  if (!result.valid) {
+    const error = new Error('Decision state failed schema validation');
+    error.validationErrors = result.errors;
+    throw error;
+  }
+}
+
+function escapeMarkup(value = '') {
+  return String(value)
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;');
+}
+
+export function deriveOverallDirection(signals = []) {
+  const known = new Set(
+    signals
+      .map((signal) => signal.direction)
+      .filter((direction) => direction && direction !== 'unknown')
+  );
+
+  if (known.size === 0) return 'unknown';
+  if (known.has('improving') && known.has('deteriorating')) return 'mixed';
+  if (known.has('improving')) return 'improving';
+  if (known.has('deteriorating')) return 'deteriorating';
+  if (known.has('flat')) return 'flat';
+  return 'unknown';
+}
+
+function directionClass(direction) {
+  if (direction === 'improving') return 'positive';
+  if (direction === 'deteriorating') return 'danger';
+  return 'muted';
+}
+
+function deltaWithArrow(delta) {
+  if (!delta) return null;
+  const text = String(delta).trim();
+  if (text.startsWith('+')) return `↑ ${text.slice(1)}`;
+  if (text.startsWith('-')) return `↓ ${text.slice(1)}`;
+  if (/^0(?:\D|$)/.test(text)) return `→ ${text.replace(/^[-+]/, '')}`;
+  return text;
+}
+
+function signalDisplay(signal) {
+  const hasMovement = Boolean(signal.delta);
+  return {
+    primary: hasMovement ? signal.delta : signal.value,
+    detail: hasMovement ? signal.value : null,
+    hasMovement
+  };
+}
+
+function selectRevenueSignal(signals) {
+  return signals.find((signal) => signal.metric === 'mrr')
+    ?? signals.find((signal) => signal.metric === 'arr')
+    ?? null;
+}
+
+function revenueTitle(signal) {
+  return signal ? `${signal.label} context` : 'Revenue context';
+}
+
+function currentRevenueLabel(signal) {
+  return signal ? `Current ${signal.label}` : 'Revenue metric unavailable';
+}
+
+function svgRevenueDeltaBlock(signal) {
+  if (!signal?.delta) return '';
+  return `<text x="98" y="252" class="${directionClass(signal.direction)}" font-size="14" font-weight="650">${escapeMarkup(signal.delta)}</text>`;
+}
+
+function htmlRevenueDeltaBlock(signal) {
+  if (!signal?.delta) return '';
+  return `<div class="metric-delta ${directionClass(signal.direction)}">${escapeMarkup(signal.delta)}</div>`;
+}
+
+function pathForSeries(series, { left, right, top, bottom }) {
+  const min = Math.min(...series);
+  const max = Math.max(...series);
+  const span = Math.max(max - min, 1);
+
+  return series
+    .map((value, index) => {
+      const x = left + ((right - left) * index) / (series.length - 1);
+      const y = bottom - ((value - min) / span) * (bottom - top);
+      return `${index === 0 ? 'M' : 'L'}${x.toFixed(1)} ${y.toFixed(1)}`;
+    })
+    .join(' ');
+}
+
+function svgRevenueVisual(series) {
+  if (!series?.length) {
+    return '<text x="98" y="330" class="muted" font-size="12">Trend data unavailable</text>';
+  }
+  const path = pathForSeries(series, { left: 98, right: 332, top: 286, bottom: 360 });
+  return `<path d="${path}" fill="none" stroke="url(#accentLine)" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>`;
+}
+
+function htmlRevenueVisual(series) {
+  if (!series?.length) {
+    return '<div class="trend-unavailable">Trend data unavailable</div>';
+  }
+  const path = pathForSeries(series, { left: 0, right: 234, top: 6, bottom: 80 });
+  return `<svg class="sparkline" viewBox="0 0 234 86" aria-label="Revenue trend"><path d="${path}"></path></svg>`;
+}
+
+function svgScoreVisual(series) {
+  if (!series?.length) {
+    return '<text x="98" y="330" class="muted" font-size="12">Trend data unavailable</text>';
+  }
+  const path = pathForSeries(series, { left: 98, right: 332, top: 286, bottom: 360 });
+  return `<path d="${path}" fill="none" stroke="url(#accentLine)" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>`;
+}
+
+function htmlScoreVisual(series) {
+  if (!series?.length) {
+    return '<div class="trend-unavailable">Trend data unavailable</div>';
+  }
+  const path = pathForSeries(series, { left: 0, right: 234, top: 6, bottom: 80 });
+  return `<svg class="sparkline" viewBox="0 0 234 86" aria-label="Score trend"><path d="${path}"></path></svg>`;
+}
+
+function splitSignalRows(signals) {
+  const topCount = Math.ceil(signals.length / 2);
+  return {
+    top: signals.slice(0, topCount),
+    bottom: signals.slice(topCount)
+  };
+}
+
+function svgRowXs(count) {
+  return {
+    1: [698],
+    2: [548, 848],
+    3: [478, 698, 918]
+  }[count] ?? [];
+}
+
+function htmlRowXs(count) {
+  return {
+    1: [50],
+    2: [26, 74],
+    3: [15, 50, 85]
+  }[count] ?? [];
+}
+
+const SVG_RADAR_LAYOUT = { cx: 698, cy: 464, radarRadius: 188, labelRadius: 238, labelSafeLeft: 500, labelSafeRight: 900 };
+const HTML_RADAR_LAYOUT = { cx: 310, cy: 260, radarRadius: 188, labelRadius: 238, labelSafeLeft: 120, labelSafeRight: 500 };
+const RADAR_SCALE_STEPS = [40, 60, 80, 100];
+
+function radialPoint(cx, cy, radius, angle) {
+  return {
+    x: cx + Math.cos(angle) * radius,
+    y: cy + Math.sin(angle) * radius
+  };
+}
+
+function pointPath(points, close = false) {
+  const path = points
+    .map((point, index) => `${index === 0 ? 'M' : 'L'}${point.x.toFixed(1)} ${point.y.toFixed(1)}`)
+    .join(' ');
+  return close ? `${path} Z` : path;
+}
+
+function radarSide(angle) {
+  const x = Math.cos(angle);
+  const y = Math.sin(angle);
+  if (Math.abs(x) < 0.15) return y < 0 ? 'top' : 'bottom';
+  return x < 0 ? 'left' : 'right';
+}
+
+function safeRadarLabelPoint(point, angle, layout) {
+  const side = radarSide(angle);
+  if (side === 'left') return { ...point, x: Math.max(point.x, layout.labelSafeLeft) };
+  if (side === 'right') return { ...point, x: Math.min(point.x, layout.labelSafeRight) };
+  return point;
+}
+
+function radarGeometry(dimensions, min, max, layout, valueKey = 'normalizedScore') {
+  const span = max - min;
+  const count = dimensions.length;
+  const axes = [];
+  const shape = [];
+  const labels = [];
+  const angles = [];
+
+  dimensions.forEach((dimension, index) => {
+    const angle = -Math.PI / 2 + (Math.PI * 2 * index) / count;
+    const value = dimension[valueKey];
+    const ratio = Math.min(1, Math.max(0, (value - min) / span));
+    axes.push(radialPoint(layout.cx, layout.cy, layout.radarRadius, angle));
+    shape.push(radialPoint(layout.cx, layout.cy, layout.radarRadius * ratio, angle));
+    labels.push(safeRadarLabelPoint(radialPoint(layout.cx, layout.cy, layout.labelRadius, angle), angle, layout));
+    angles.push(angle);
+  });
+
+  return {
+    shape: pointPath(shape, true),
+    spokes: axes.map((point) => `M${layout.cx} ${layout.cy} L${point.x.toFixed(1)} ${point.y.toFixed(1)}`).join(' '),
+    labels,
+    angles
+  };
+}
+
+function radarScaleRings(layout) {
+  return [...RADAR_SCALE_STEPS].reverse().map((scale) => {
+    const radius = Number((layout.radarRadius * scale / 100).toFixed(1));
+    return `<circle class="radar-scale-ring" data-scale="${scale}" r="${radius}" cx="${layout.cx}" cy="${layout.cy}"/>`;
+  }).join('\n');
+}
+
+function hasCompletePreviousProfile(dimensions) {
+  return dimensions.length > 0 && dimensions.every((dimension) => Number.isFinite(dimension.previousNormalizedScore));
+}
+
+function radarAnchor(side) {
+  if (side === 'left') return 'end';
+  if (side === 'right') return 'start';
+  return 'middle';
+}
+
+function svgRadarVisual(dimensions, min, max) {
+  const current = radarGeometry(dimensions, min, max, SVG_RADAR_LAYOUT);
+  const previous = hasCompletePreviousProfile(dimensions)
+    ? radarGeometry(dimensions, min, max, SVG_RADAR_LAYOUT, 'previousNormalizedScore')
+    : null;
+  const previousPath = previous
+    ? `<path class="radar-shape radar-shape--previous" d="${previous.shape}"/>`
+    : '';
+
+  return `${radarScaleRings(SVG_RADAR_LAYOUT)}
+    <path class="radar-spokes" d="${current.spokes}"/>
+    ${previousPath}
+    <path class="radar-shape radar-shape--current" d="${current.shape}"/>`;
+}
+
+function htmlRadarVisual(dimensions, min, max) {
+  const current = radarGeometry(dimensions, min, max, HTML_RADAR_LAYOUT);
+  const previous = hasCompletePreviousProfile(dimensions)
+    ? radarGeometry(dimensions, min, max, HTML_RADAR_LAYOUT, 'previousNormalizedScore')
+    : null;
+  const previousPath = previous
+    ? `<path class="radar-shape radar-shape--previous" d="${previous.shape}"></path>`
+    : '';
+
+  return `${radarScaleRings(HTML_RADAR_LAYOUT)}
+            <path class="radar-spokes" d="${current.spokes}"></path>
+            ${previousPath}
+            <path class="radar-shape radar-shape--current" d="${current.shape}"></path>`;
+}
+
+function svgRadarNodes(dimensions, min, max, nodeClass) {
+  const geometry = radarGeometry(dimensions, min, max, SVG_RADAR_LAYOUT);
+  return dimensions.map((dimension, index) => {
+    const point = geometry.labels[index];
+    const side = radarSide(geometry.angles[index]);
+    const anchor = radarAnchor(side);
+    const startY = side === 'top' ? point.y - 21 : side === 'bottom' ? point.y - 3 : point.y - 20;
+    const delta = deltaWithArrow(dimension.delta);
+    const deltaNode = delta
+      ? `<tspan x="${point.x.toFixed(1)}" dy="18" text-anchor="${anchor}" class="${directionClass(dimension.direction)}" font-size="11" font-weight="700">${escapeMarkup(delta)}</tspan>`
+      : '';
+    return `<g class="${nodeClass}">
+      <text class="radar-label radar-label--${side}" data-outside-ring="true" text-anchor="${anchor}" x="${point.x.toFixed(1)}" y="${startY.toFixed(1)}">
+        <tspan x="${point.x.toFixed(1)}" text-anchor="${anchor}" class="muted" font-size="11" font-weight="650">${escapeMarkup(dimension.label)}</tspan>
+        <tspan x="${point.x.toFixed(1)}" dy="20" text-anchor="${anchor}" class="ink" font-size="16" font-weight="760">${escapeMarkup(dimension.value)}</tspan>
+        ${deltaNode}
+      </text>
+    </g>`;
+  }).join('\n');
+}
+
+function htmlRadarNodes(dimensions, min, max, className) {
+  const geometry = radarGeometry(dimensions, min, max, HTML_RADAR_LAYOUT);
+  return dimensions.map((dimension, index) => {
+    const point = geometry.labels[index];
+    const side = radarSide(geometry.angles[index]);
+    const delta = deltaWithArrow(dimension.delta);
+    const deltaNode = delta
+      ? `<small class="${directionClass(dimension.direction)}">${escapeMarkup(delta)}</small>`
+      : '';
+    return `<div class="${className} radar-label radar-label--${side}" data-outside-ring="true" style="left:${(point.x / 620 * 100).toFixed(2)}%;top:${(point.y / 520 * 100).toFixed(2)}%">
+    <span>${escapeMarkup(dimension.label)}</span>
+    <strong>${escapeMarkup(dimension.value)}</strong>
+    ${deltaNode}
+  </div>`;
+  }).join('\n');
+}
+
+function svgSignalCluster(signals) {
+  const { top, bottom } = splitSignalRows(signals);
+  const placed = [];
+
+  for (const [rowName, row, y] of [['top', top, 330], ['bottom', bottom, 590]]) {
+    const xs = svgRowXs(row.length);
+    row.forEach((signal, index) => placed.push({ signal, x: xs[index], y, rowName }));
+  }
+
+  const paths = placed
+    .map(({ x, y }) => `M698 464 L${x} ${y}`)
+    .join(' ');
+
+  const nodes = placed.map(({ signal, x, y, rowName }) => {
+    const topRow = rowName === 'top';
+    const primaryY = topRow ? y - 62 : y + 66;
+    const labelY = topRow ? y - 37 : y + 91;
+    const detailY = topRow ? y - 18 : y + 110;
+    const display = signalDisplay(signal);
+    const cardY = topRow ? y - 104 : y + 34;
+    const cardHeight = display.detail ? 92 : 74;
+    const detailNode = display.detail
+      ? `<text x="${x}" y="${detailY}" class="muted" font-size="10" text-anchor="middle">${escapeMarkup(display.detail)}</text>`
+      : '';
+    return `<g class="signal-node">
+      <rect x="${x - 72}" y="${cardY}" width="144" height="${cardHeight}" rx="19" class="metric-orb"/>
+      <circle cx="${x}" cy="${y}" r="8" fill="#ffffff" stroke="#6555e8" stroke-width="3"/>
+      <text x="${x}" y="${primaryY}" class="accent" font-size="23" font-weight="760" text-anchor="middle">${escapeMarkup(display.primary)}</text>
+      <text x="${x}" y="${labelY}" class="ink" font-size="12" font-weight="670" text-anchor="middle">${escapeMarkup(signal.label)}</text>
+      ${detailNode}
+    </g>`;
+  }).join('\n');
+
+  return { paths, nodes };
+}
+
+function htmlSignalCluster(signals) {
+  const { top, bottom } = splitSignalRows(signals);
+  const placed = [];
+
+  for (const [row, y] of [[top, 28], [bottom, 72]]) {
+    const xs = htmlRowXs(row.length);
+    row.forEach((signal, index) => placed.push({ signal, x: xs[index], y }));
+  }
+
+  const paths = placed.map(({ x, y }) => {
+    const px = (620 * x / 100).toFixed(1);
+    const py = (520 * y / 100).toFixed(1);
+    return `M310 260 L${px} ${py}`;
+  }).join(' ');
+
+  const nodes = placed.map(({ signal, x, y }) => {
+    const display = signalDisplay(signal);
+    const detailNode = display.detail ? `<small>${escapeMarkup(display.detail)}</small>` : '';
+    return `<div class="signal metric-orb" style="left:${x}%;top:${y}%">
+    <strong>${escapeMarkup(display.primary)}</strong>
+    <span>${escapeMarkup(signal.label)}</span>
+    ${detailNode}
+  </div>`;
+  }).join('\n');
+
+  return { paths, nodes };
+}
+
+function formatScore(value) {
+  if (Number.isInteger(value)) return String(value);
+  return String(Number(value.toFixed(1)));
+}
+
+function formatWeight(weight) {
+  return `${Number((weight * 100).toFixed(1))}%`;
+}
+
+function svgComponentCluster(components, min, max) {
+  return {
+    visual: svgRadarVisual(components, min, max),
+    nodes: svgRadarNodes(components, min, max, 'score-component-node')
+  };
+}
+
+function htmlComponentCluster(components, min, max) {
+  return {
+    visual: htmlRadarVisual(components, min, max),
+    nodes: htmlRadarNodes(components, min, max, 'score-component')
+  };
+}
+
+function svgCompositionRows(components) {
+  return components.map((component, index) => {
+    const y = 552 + index * 34;
+    const detail = `${formatScore(component.normalizedScore)} · ${formatWeight(component.weight)}`;
+    return `<g>
+      <text x="98" y="${y}" class="ink" font-size="12" font-weight="650">${escapeMarkup(component.label)}</text>
+      <text x="332" y="${y}" class="muted" font-size="11" text-anchor="end">${escapeMarkup(detail)}</text>
+    </g>`;
+  }).join('\n');
+}
+
+function htmlCompositionRows(components) {
+  return components.map((component) => `<div class="composition-row">
+    <span>${escapeMarkup(component.label)}</span>
+    <small>${escapeMarkup(`${formatScore(component.normalizedScore)} · ${formatWeight(component.weight)}`)}</small>
+  </div>`).join('\n');
+}
+
+function movementSignals(signals, revenueMetric = null) {
+  const eligible = signals.filter((signal) => signal.delta);
+  const preferred = ['churn_rate', 'trial_conversion'];
+  const selected = [];
+
+  for (const metric of preferred) {
+    const match = eligible.find((signal) => signal.metric === metric);
+    if (match && !selected.includes(match)) selected.push(match);
+  }
+
+  for (const signal of eligible) {
+    if (selected.length >= 2) break;
+    if (signal.metric !== revenueMetric && !selected.includes(signal)) selected.push(signal);
+  }
+
+  return selected.slice(0, 2);
+}
+
+function svgMovementRows(signals) {
+  if (signals.length === 0) {
+    return '<text x="98" y="566" class="muted" font-size="12">No additional movement signals</text>';
+  }
+
+  return signals.map((signal, index) => {
+    const labelY = 552 + index * 72;
+    const valueY = labelY + 27;
+    const divider = index === 0 && signals.length > 1
+      ? '<line x1="98" y1="600" x2="332" y2="600" stroke="#efedf6"/>'
+      : '';
+    return `<g>
+      <text x="98" y="${labelY}" class="muted" font-size="12">${escapeMarkup(signal.label)}</text>
+      <text x="98" y="${valueY}" class="ink" font-size="21" font-weight="700">${escapeMarkup(signal.value)}</text>
+      <text x="332" y="${valueY}" class="${directionClass(signal.direction)}" font-size="13" font-weight="650" text-anchor="end">${escapeMarkup(signal.delta)}</text>
+      ${divider}
+    </g>`;
+  }).join('\n');
+}
+
+function htmlMovementRows(signals) {
+  if (signals.length === 0) {
+    return '<div class="empty-state">No additional movement signals</div>';
+  }
+
+  return signals.map((signal) => `<div class="context-metric">
+    <span>${escapeMarkup(signal.label)}</span>
+    <strong>${escapeMarkup(signal.value)}</strong>
+    <em class="${directionClass(signal.direction)}">${escapeMarkup(signal.delta)}</em>
+  </div>`).join('\n');
+}
+
+function svgExceptionRows(exceptions = []) {
+  if (exceptions.length === 0) {
+    return '<text x="1064" y="232" class="muted" font-size="13">No confirmed exceptions visible</text>';
+  }
+
+  return exceptions.slice(0, 3).map((item, index) => {
+    const y = 232 + index * 70;
+    const meta = [item.plan, item.mrr ? `${item.mrr} MRR` : null].filter(Boolean).join(' · ');
+    return `<g>
+      <circle cx="1072" cy="${y - 4}" r="5" fill="#e25462"/>
+      <text x="1088" y="${y}" class="ink" font-size="14" font-weight="650">${escapeMarkup(item.name)}</text>
+      <text x="1088" y="${y + 22}" class="muted" font-size="12">${escapeMarkup(meta)}</text>
+      <rect x="1268" y="${y - 19}" width="74" height="26" rx="13" fill="#fff1f3"/>
+      <text x="1305" y="${y - 1}" class="danger" font-size="11" font-weight="650" text-anchor="middle">${escapeMarkup(item.status)}</text>
+    </g>`;
+  }).join('\n');
+}
+
+function svgEventRows(events = []) {
+  if (events.length === 0) {
+    return '<text x="1064" y="534" class="muted" font-size="13">No recent source-supported events</text>';
+  }
+
+  return events.slice(0, 4).map((item, index) => {
+    const y = 534 + index * 68;
+    return `<g>
+      <circle cx="1072" cy="${y - 4}" r="4" fill="#6555e8"/>
+      <text x="1088" y="${y}" class="ink" font-size="13" font-weight="650">${escapeMarkup(item.subject)}</text>
+      <text x="1088" y="${y + 21}" class="muted" font-size="12">${escapeMarkup(item.event)}</text>
+      <text x="1342" y="${y + 21}" class="soft" font-size="11" text-anchor="end">${escapeMarkup(item.time)}</text>
+    </g>`;
+  }).join('\n');
+}
+
+function htmlExceptionRows(exceptions = []) {
+  if (exceptions.length === 0) {
+    return '<div class="empty-state">No confirmed exceptions visible</div>';
+  }
+
+  return exceptions.slice(0, 3).map((item) => {
+    const meta = [item.plan, item.mrr ? `${item.mrr} MRR` : null].filter(Boolean).join(' · ');
+    return `<div class="exception-row">
+      <span class="dot dot--risk" aria-hidden="true"></span>
+      <div class="row-copy"><strong>${escapeMarkup(item.name)}</strong><span>${escapeMarkup(meta)}</span></div>
+      <span class="badge">${escapeMarkup(item.status)}</span>
+    </div>`;
+  }).join('\n');
+}
+
+function htmlEventRows(events = []) {
+  if (events.length === 0) {
+    return '<div class="empty-state">No recent source-supported events</div>';
+  }
+
+  return events.slice(0, 4).map((item) => `<div class="event-row">
+    <span class="dot" aria-hidden="true"></span>
+    <div class="row-copy"><strong>${escapeMarkup(item.subject)}</strong><span>${escapeMarkup(item.event)}</span></div>
+    <span class="event-time">${escapeMarkup(item.time)}</span>
+  </div>`).join('\n');
+}
+
+function fillTemplate(template, replacements) {
+  let output = template;
+  for (const [key, value] of Object.entries(replacements)) {
+    output = output.replaceAll(`{{${key}}}`, value);
+  }
+  return output;
+}
+
+function noScoreViewModel(data) {
+  const revenue = selectRevenueSignal(data.signals);
+  const revenueSeries = data.context?.provenance === 'source' ? data.context.revenueSeries : null;
+  const movement = movementSignals(data.signals, revenue?.metric ?? null);
+  return { revenue, revenueSeries, movement };
+}
+
+function renderNoScoreSvg(data) {
+  const template = fs.readFileSync(noScoreSvgTemplatePath, 'utf8');
+  const { revenue, revenueSeries, movement } = noScoreViewModel(data);
+  const radar = data.radarScale
+    ? {
+        visual: svgRadarVisual(data.signals, data.radarScale.min, data.radarScale.max),
+        nodes: svgRadarNodes(data.signals, data.radarScale.min, data.radarScale.max, 'radar-dimension-node')
+      }
+    : null;
+  const signalCluster = radar ?? svgSignalCluster(data.signals);
+  const orbitVisual = radar
+    ? radar.visual
+    : `<path class="orbit-spokes" d="${signalCluster.paths}" fill="none" stroke="#d6d0ef" stroke-width="1.6"/>`;
+
+  return fillTemplate(template, {
+    REVENUE_TITLE: escapeMarkup(revenueTitle(revenue)),
+    REVENUE_VALUE: escapeMarkup(revenue?.value ?? '—'),
+    REVENUE_DELTA_BLOCK: svgRevenueDeltaBlock(revenue),
+    CURRENT_REVENUE_LABEL: escapeMarkup(currentRevenueLabel(revenue)),
+    REVENUE_VISUAL: svgRevenueVisual(revenueSeries),
+    MOVEMENT_ROWS: svgMovementRows(movement),
+    SVG_ORBIT_VISUAL: orbitVisual,
+    SVG_SIGNAL_NODES: signalCluster.nodes,
+    EXCEPTION_ROWS: svgExceptionRows(data.exceptions),
+    EVENT_ROWS: svgEventRows(data.events)
+  });
+}
+
+function renderNoScoreHtml(data) {
+  const template = fs.readFileSync(noScoreHtmlTemplatePath, 'utf8');
+  const css = fs.readFileSync(cssTemplatePath, 'utf8');
+  const { revenue, revenueSeries, movement } = noScoreViewModel(data);
+  const radar = data.radarScale
+    ? {
+        visual: htmlRadarVisual(data.signals, data.radarScale.min, data.radarScale.max),
+        nodes: htmlRadarNodes(data.signals, data.radarScale.min, data.radarScale.max, 'radar-dimension')
+      }
+    : null;
+  const signalCluster = radar ?? htmlSignalCluster(data.signals);
+  const orbitVisual = radar
+    ? radar.visual
+    : `<path class="orbit-spokes" d="${signalCluster.paths}"></path>`;
+
+  return fillTemplate(template, {
+    CSS: css,
+    REVENUE_TITLE: escapeMarkup(revenueTitle(revenue)),
+    REVENUE_VALUE: escapeMarkup(revenue?.value ?? '—'),
+    HTML_REVENUE_DELTA_BLOCK: htmlRevenueDeltaBlock(revenue),
+    CURRENT_REVENUE_LABEL: escapeMarkup(currentRevenueLabel(revenue)),
+    HTML_REVENUE_VISUAL: htmlRevenueVisual(revenueSeries),
+    HTML_MOVEMENT_ROWS: htmlMovementRows(movement),
+    HTML_ORBIT_VISUAL: orbitVisual,
+    HTML_SIGNAL_NODES: signalCluster.nodes,
+    HTML_EXCEPTION_ROWS: htmlExceptionRows(data.exceptions),
+    HTML_EVENT_ROWS: htmlEventRows(data.events)
+  });
+}
+
+function renderCompositeSvg(data) {
+  const template = fs.readFileSync(compositeSvgTemplatePath, 'utf8');
+  const scoreSeries = data.context?.provenance === 'source' ? data.context.scoreSeries : null;
+  const cluster = svgComponentCluster(data.model.components, data.score.min, data.score.max);
+
+  return fillTemplate(template, {
+    SCORE_LABEL: escapeMarkup(data.score.label),
+    SCORE_VALUE: escapeMarkup(formatScore(data.score.value)),
+    SCORE_MAX: escapeMarkup(formatScore(data.score.max)),
+    SCORE_BAND: escapeMarkup(data.score.band),
+    SVG_SCORE_TREND: svgScoreVisual(scoreSeries),
+    SVG_COMPOSITION_ROWS: svgCompositionRows(data.model.components),
+    SVG_COMPONENT_RADAR: cluster.visual,
+    SVG_COMPONENT_NODES: cluster.nodes,
+    EXCEPTION_ROWS: svgExceptionRows(data.exceptions),
+    EVENT_ROWS: svgEventRows(data.events)
+  });
+}
+
+function renderCompositeHtml(data) {
+  const template = fs.readFileSync(compositeHtmlTemplatePath, 'utf8');
+  const css = fs.readFileSync(cssTemplatePath, 'utf8');
+  const scoreSeries = data.context?.provenance === 'source' ? data.context.scoreSeries : null;
+  const cluster = htmlComponentCluster(data.model.components, data.score.min, data.score.max);
+
+  return fillTemplate(template, {
+    CSS: css,
+    SCORE_LABEL: escapeMarkup(data.score.label),
+    SCORE_VALUE: escapeMarkup(formatScore(data.score.value)),
+    SCORE_MAX: escapeMarkup(formatScore(data.score.max)),
+    SCORE_BAND: escapeMarkup(data.score.band),
+    HTML_SCORE_TREND: htmlScoreVisual(scoreSeries),
+    HTML_COMPOSITION_ROWS: htmlCompositionRows(data.model.components),
+    HTML_COMPONENT_RADAR: cluster.visual,
+    HTML_COMPONENT_NODES: cluster.nodes,
+    HTML_EXCEPTION_ROWS: htmlExceptionRows(data.exceptions),
+    HTML_EVENT_ROWS: htmlEventRows(data.events)
+  });
+}
+
+export function renderSvg(data) {
+  assertValid(data);
+  return data.mode === 'composite' ? renderCompositeSvg(data) : renderNoScoreSvg(data);
+}
+
+export function renderHtml(data) {
+  assertValid(data);
+  return data.mode === 'composite' ? renderCompositeHtml(data) : renderNoScoreHtml(data);
+}
+
+if (process.argv[1] === currentFile) {
+  const inputPath = process.argv[2];
+  const outputDir = process.argv[3] ?? path.dirname(inputPath ?? '.');
+
+  if (!inputPath) {
+    console.error('Usage: node render.js <decision-state.json> [output-dir]');
+    process.exit(2);
+  }
+
+  const data = JSON.parse(fs.readFileSync(inputPath, 'utf8'));
+  const svg = renderSvg(data);
+  const html = renderHtml(data);
+  fs.mkdirSync(outputDir, { recursive: true });
+
+  const outputMode = data.mode === 'composite' ? 'composite' : 'no-score';
+  const svgOutput = path.join(outputDir, `output.${outputMode}.svg`);
+  const htmlOutput = path.join(outputDir, `output.${outputMode}.html`);
+  fs.writeFileSync(svgOutput, svg);
+  fs.writeFileSync(htmlOutput, html);
+  console.log(svgOutput);
+  console.log(htmlOutput);
+}

--- a/skills/decision-first-dashboard/scripts/render.js
+++ b/skills/decision-first-dashboard/scripts/render.js
@@ -1,183 +1,46 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { validateDecisionState } from './validate.js';
+import {
+  deriveOverallDirection as deriveOverallDirectionCore,
+  renderHtml as renderHtmlCore,
+  renderSvg as renderSvgCore
+} from './render-core.js';
 
 const currentFile = fileURLToPath(import.meta.url);
-const currentDir = path.dirname(currentFile);
-const noScoreSvgTemplatePath = path.resolve(currentDir, '../templates/no-score.svg');
-const noScoreHtmlTemplatePath = path.resolve(currentDir, '../templates/no-score.html');
-const compositeSvgTemplatePath = path.resolve(currentDir, '../templates/composite.svg');
-const compositeHtmlTemplatePath = path.resolve(currentDir, '../templates/composite.html');
-const cssTemplatePath = path.resolve(currentDir, '../templates/dashboard.css');
 
-function assertValid(data) {
-  const result = validateDecisionState(data);
-  if (!result.valid) {
-    const error = new Error('Decision state failed schema validation');
-    error.validationErrors = result.errors;
-    throw error;
-  }
+const SVG_LAYOUT = {
+  cx: 698,
+  cy: 464,
+  radarRadius: 188,
+  labelGap: 40,
+  stageTranslateX: 8,
+  stageTranslateY: -6,
+  stageCenterX: 706
+};
+
+const HTML_LAYOUT = {
+  cx: 310,
+  cy: 260,
+  radarRadius: 188,
+  labelGap: 40,
+  width: 620,
+  height: 520
+};
+
+export const deriveOverallDirection = deriveOverallDirectionCore;
+
+function radarDimensions(data) {
+  if (data?.mode === 'composite') return data.model?.components ?? null;
+  if (data?.radarScale && Array.isArray(data.signals)) return data.signals;
+  return null;
 }
-
-function escapeMarkup(value = '') {
-  return String(value)
-    .replaceAll('&', '&amp;')
-    .replaceAll('<', '&lt;')
-    .replaceAll('>', '&gt;')
-    .replaceAll('"', '&quot;')
-    .replaceAll("'", '&#39;');
-}
-
-export function deriveOverallDirection(signals = []) {
-  const known = new Set(
-    signals
-      .map((signal) => signal.direction)
-      .filter((direction) => direction && direction !== 'unknown')
-  );
-
-  if (known.size === 0) return 'unknown';
-  if (known.has('improving') && known.has('deteriorating')) return 'mixed';
-  if (known.has('improving')) return 'improving';
-  if (known.has('deteriorating')) return 'deteriorating';
-  if (known.has('flat')) return 'flat';
-  return 'unknown';
-}
-
-function directionClass(direction) {
-  if (direction === 'improving') return 'positive';
-  if (direction === 'deteriorating') return 'danger';
-  return 'muted';
-}
-
-function deltaWithArrow(delta) {
-  if (!delta) return null;
-  const text = String(delta).trim();
-  if (text.startsWith('+')) return `↑ ${text.slice(1)}`;
-  if (text.startsWith('-')) return `↓ ${text.slice(1)}`;
-  if (/^0(?:\D|$)/.test(text)) return `→ ${text.replace(/^[-+]/, '')}`;
-  return text;
-}
-
-function signalDisplay(signal) {
-  const hasMovement = Boolean(signal.delta);
-  return {
-    primary: hasMovement ? signal.delta : signal.value,
-    detail: hasMovement ? signal.value : null,
-    hasMovement
-  };
-}
-
-function selectRevenueSignal(signals) {
-  return signals.find((signal) => signal.metric === 'mrr')
-    ?? signals.find((signal) => signal.metric === 'arr')
-    ?? null;
-}
-
-function revenueTitle(signal) {
-  return signal ? `${signal.label} context` : 'Revenue context';
-}
-
-function currentRevenueLabel(signal) {
-  return signal ? `Current ${signal.label}` : 'Revenue metric unavailable';
-}
-
-function svgRevenueDeltaBlock(signal) {
-  if (!signal?.delta) return '';
-  return `<text x="98" y="252" class="${directionClass(signal.direction)}" font-size="14" font-weight="650">${escapeMarkup(signal.delta)}</text>`;
-}
-
-function htmlRevenueDeltaBlock(signal) {
-  if (!signal?.delta) return '';
-  return `<div class="metric-delta ${directionClass(signal.direction)}">${escapeMarkup(signal.delta)}</div>`;
-}
-
-function pathForSeries(series, { left, right, top, bottom }) {
-  const min = Math.min(...series);
-  const max = Math.max(...series);
-  const span = Math.max(max - min, 1);
-
-  return series
-    .map((value, index) => {
-      const x = left + ((right - left) * index) / (series.length - 1);
-      const y = bottom - ((value - min) / span) * (bottom - top);
-      return `${index === 0 ? 'M' : 'L'}${x.toFixed(1)} ${y.toFixed(1)}`;
-    })
-    .join(' ');
-}
-
-function svgRevenueVisual(series) {
-  if (!series?.length) {
-    return '<text x="98" y="330" class="muted" font-size="12">Trend data unavailable</text>';
-  }
-  const path = pathForSeries(series, { left: 98, right: 332, top: 286, bottom: 360 });
-  return `<path d="${path}" fill="none" stroke="url(#accentLine)" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>`;
-}
-
-function htmlRevenueVisual(series) {
-  if (!series?.length) {
-    return '<div class="trend-unavailable">Trend data unavailable</div>';
-  }
-  const path = pathForSeries(series, { left: 0, right: 234, top: 6, bottom: 80 });
-  return `<svg class="sparkline" viewBox="0 0 234 86" aria-label="Revenue trend"><path d="${path}"></path></svg>`;
-}
-
-function svgScoreVisual(series) {
-  if (!series?.length) {
-    return '<text x="98" y="330" class="muted" font-size="12">Trend data unavailable</text>';
-  }
-  const path = pathForSeries(series, { left: 98, right: 332, top: 286, bottom: 360 });
-  return `<path d="${path}" fill="none" stroke="url(#accentLine)" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>`;
-}
-
-function htmlScoreVisual(series) {
-  if (!series?.length) {
-    return '<div class="trend-unavailable">Trend data unavailable</div>';
-  }
-  const path = pathForSeries(series, { left: 0, right: 234, top: 6, bottom: 80 });
-  return `<svg class="sparkline" viewBox="0 0 234 86" aria-label="Score trend"><path d="${path}"></path></svg>`;
-}
-
-function splitSignalRows(signals) {
-  const topCount = Math.ceil(signals.length / 2);
-  return {
-    top: signals.slice(0, topCount),
-    bottom: signals.slice(topCount)
-  };
-}
-
-function svgRowXs(count) {
-  return {
-    1: [698],
-    2: [548, 848],
-    3: [478, 698, 918]
-  }[count] ?? [];
-}
-
-function htmlRowXs(count) {
-  return {
-    1: [50],
-    2: [26, 74],
-    3: [15, 50, 85]
-  }[count] ?? [];
-}
-
-const SVG_RADAR_LAYOUT = { cx: 698, cy: 464, radarRadius: 188, labelRadius: 238, labelSafeLeft: 500, labelSafeRight: 900 };
-const HTML_RADAR_LAYOUT = { cx: 310, cy: 260, radarRadius: 188, labelRadius: 238, labelSafeLeft: 120, labelSafeRight: 500 };
-const RADAR_SCALE_STEPS = [40, 60, 80, 100];
 
 function radialPoint(cx, cy, radius, angle) {
   return {
     x: cx + Math.cos(angle) * radius,
     y: cy + Math.sin(angle) * radius
   };
-}
-
-function pointPath(points, close = false) {
-  const path = points
-    .map((point, index) => `${index === 0 ? 'M' : 'L'}${point.x.toFixed(1)} ${point.y.toFixed(1)}`)
-    .join(' ');
-  return close ? `${path} Z` : path;
 }
 
 function radarSide(angle) {
@@ -187,461 +50,95 @@ function radarSide(angle) {
   return x < 0 ? 'left' : 'right';
 }
 
-function safeRadarLabelPoint(point, angle, layout) {
-  const side = radarSide(angle);
-  if (side === 'left') return { ...point, x: Math.max(point.x, layout.labelSafeLeft) };
-  if (side === 'right') return { ...point, x: Math.min(point.x, layout.labelSafeRight) };
-  return point;
-}
-
-function radarGeometry(dimensions, min, max, layout, valueKey = 'normalizedScore') {
-  const span = max - min;
-  const count = dimensions.length;
-  const axes = [];
-  const shape = [];
-  const labels = [];
-  const angles = [];
-
-  dimensions.forEach((dimension, index) => {
-    const angle = -Math.PI / 2 + (Math.PI * 2 * index) / count;
-    const value = dimension[valueKey];
-    const ratio = Math.min(1, Math.max(0, (value - min) / span));
-    axes.push(radialPoint(layout.cx, layout.cy, layout.radarRadius, angle));
-    shape.push(radialPoint(layout.cx, layout.cy, layout.radarRadius * ratio, angle));
-    labels.push(safeRadarLabelPoint(radialPoint(layout.cx, layout.cy, layout.labelRadius, angle), angle, layout));
-    angles.push(angle);
-  });
-
-  return {
-    shape: pointPath(shape, true),
-    spokes: axes.map((point) => `M${layout.cx} ${layout.cy} L${point.x.toFixed(1)} ${point.y.toFixed(1)}`).join(' '),
-    labels,
-    angles
-  };
-}
-
-function radarScaleRings(layout) {
-  return [...RADAR_SCALE_STEPS].reverse().map((scale) => {
-    const radius = Number((layout.radarRadius * scale / 100).toFixed(1));
-    return `<circle class="radar-scale-ring" data-scale="${scale}" r="${radius}" cx="${layout.cx}" cy="${layout.cy}"/>`;
-  }).join('\n');
-}
-
-function hasCompletePreviousProfile(dimensions) {
-  return dimensions.length > 0 && dimensions.every((dimension) => Number.isFinite(dimension.previousNormalizedScore));
-}
-
 function radarAnchor(side) {
   if (side === 'left') return 'end';
   if (side === 'right') return 'start';
   return 'middle';
 }
 
-function svgRadarVisual(dimensions, min, max) {
-  const current = radarGeometry(dimensions, min, max, SVG_RADAR_LAYOUT);
-  const previous = hasCompletePreviousProfile(dimensions)
-    ? radarGeometry(dimensions, min, max, SVG_RADAR_LAYOUT, 'previousNormalizedScore')
-    : null;
-  const previousPath = previous
-    ? `<path class="radar-shape radar-shape--previous" d="${previous.shape}"/>`
-    : '';
-
-  return `${radarScaleRings(SVG_RADAR_LAYOUT)}
-    <path class="radar-spokes" d="${current.spokes}"/>
-    ${previousPath}
-    <path class="radar-shape radar-shape--current" d="${current.shape}"/>`;
+function svgLabelStartY(pointY, side) {
+  if (side === 'top') return pointY - 21;
+  if (side === 'bottom') return pointY - 3;
+  return pointY - 20;
 }
 
-function htmlRadarVisual(dimensions, min, max) {
-  const current = radarGeometry(dimensions, min, max, HTML_RADAR_LAYOUT);
-  const previous = hasCompletePreviousProfile(dimensions)
-    ? radarGeometry(dimensions, min, max, HTML_RADAR_LAYOUT, 'previousNormalizedScore')
-    : null;
-  const previousPath = previous
-    ? `<path class="radar-shape radar-shape--previous" d="${previous.shape}"></path>`
-    : '';
+function tuneSvgLabels(markup, dimensions) {
+  const radius = SVG_LAYOUT.radarRadius + SVG_LAYOUT.labelGap;
+  let index = 0;
 
-  return `${radarScaleRings(HTML_RADAR_LAYOUT)}
-            <path class="radar-spokes" d="${current.spokes}"></path>
-            ${previousPath}
-            <path class="radar-shape radar-shape--current" d="${current.shape}"></path>`;
+  return markup.replace(
+    /<text class="radar-label radar-label--(top|bottom|left|right)"[\s\S]*?<\/text>/g,
+    (block) => {
+      if (index >= dimensions.length) return block;
+      const angle = -Math.PI / 2 + (Math.PI * 2 * index) / dimensions.length;
+      const side = radarSide(angle);
+      const anchor = radarAnchor(side);
+      const point = radialPoint(SVG_LAYOUT.cx, SVG_LAYOUT.cy, radius, angle);
+      const x = point.x.toFixed(1);
+      const y = svgLabelStartY(point.y, side).toFixed(1);
+      index += 1;
+
+      return block
+        .replace(/radar-label--(top|bottom|left|right)/, `radar-label--${side}`)
+        .replace(/text-anchor="(start|end|middle)"/g, `text-anchor="${anchor}"`)
+        .replace(/x="-?[\d.]+"/g, `x="${x}"`)
+        .replace(/y="-?[\d.]+"/, `y="${y}"`);
+    }
+  );
 }
 
-function svgRadarNodes(dimensions, min, max, nodeClass) {
-  const geometry = radarGeometry(dimensions, min, max, SVG_RADAR_LAYOUT);
-  return dimensions.map((dimension, index) => {
-    const point = geometry.labels[index];
-    const side = radarSide(geometry.angles[index]);
-    const anchor = radarAnchor(side);
-    const startY = side === 'top' ? point.y - 21 : side === 'bottom' ? point.y - 3 : point.y - 20;
-    const delta = deltaWithArrow(dimension.delta);
-    const deltaNode = delta
-      ? `<tspan x="${point.x.toFixed(1)}" dy="18" text-anchor="${anchor}" class="${directionClass(dimension.direction)}" font-size="11" font-weight="700">${escapeMarkup(delta)}</tspan>`
-      : '';
-    return `<g class="${nodeClass}">
-      <text class="radar-label radar-label--${side}" data-outside-ring="true" text-anchor="${anchor}" x="${point.x.toFixed(1)}" y="${startY.toFixed(1)}">
-        <tspan x="${point.x.toFixed(1)}" text-anchor="${anchor}" class="muted" font-size="11" font-weight="650">${escapeMarkup(dimension.label)}</tspan>
-        <tspan x="${point.x.toFixed(1)}" dy="20" text-anchor="${anchor}" class="ink" font-size="16" font-weight="760">${escapeMarkup(dimension.value)}</tspan>
-        ${deltaNode}
-      </text>
-    </g>`;
-  }).join('\n');
+function tuneHtmlLabels(markup, dimensions) {
+  const radius = HTML_LAYOUT.radarRadius + HTML_LAYOUT.labelGap;
+  let index = 0;
+
+  return markup.replace(
+    /<div class="[^"]*radar-label radar-label--(top|bottom|left|right)" data-outside-ring="true" style="left:[^;]+%;top:[^"]+%">/g,
+    (block) => {
+      if (index >= dimensions.length) return block;
+      const angle = -Math.PI / 2 + (Math.PI * 2 * index) / dimensions.length;
+      const side = radarSide(angle);
+      const point = radialPoint(HTML_LAYOUT.cx, HTML_LAYOUT.cy, radius, angle);
+      const left = (point.x / HTML_LAYOUT.width * 100).toFixed(2);
+      const top = (point.y / HTML_LAYOUT.height * 100).toFixed(2);
+      index += 1;
+
+      return block
+        .replace(/radar-label--(top|bottom|left|right)/, `radar-label--${side}`)
+        .replace(/left:[^;]+%;top:[^"]+%/, `left:${left}%;top:${top}%`);
+    }
+  );
 }
 
-function htmlRadarNodes(dimensions, min, max, className) {
-  const geometry = radarGeometry(dimensions, min, max, HTML_RADAR_LAYOUT);
-  return dimensions.map((dimension, index) => {
-    const point = geometry.labels[index];
-    const side = radarSide(geometry.angles[index]);
-    const delta = deltaWithArrow(dimension.delta);
-    const deltaNode = delta
-      ? `<small class="${directionClass(dimension.direction)}">${escapeMarkup(delta)}</small>`
-      : '';
-    return `<div class="${className} radar-label radar-label--${side}" data-outside-ring="true" style="left:${(point.x / 620 * 100).toFixed(2)}%;top:${(point.y / 520 * 100).toFixed(2)}%">
-    <span>${escapeMarkup(dimension.label)}</span>
-    <strong>${escapeMarkup(dimension.value)}</strong>
-    ${deltaNode}
-  </div>`;
-  }).join('\n');
+function tuneSvgRadar(markup, dimensions) {
+  let tuned = markup
+    .replace('<circle cx="740" cy="482" r="318" class="radar-ambient-field"/>', `<circle cx="${SVG_LAYOUT.stageCenterX}" cy="482" r="318" class="radar-ambient-field"/>`)
+    .replace('<g transform="translate(42 -6)">', `<g transform="translate(${SVG_LAYOUT.stageTranslateX} ${SVG_LAYOUT.stageTranslateY})">`)
+    .replace('.radar-label--right { transform: translateX(-24px); }', '.radar-label--right { transform: none; }');
+
+  tuned = tuneSvgLabels(tuned, dimensions);
+  return tuned;
 }
 
-function svgSignalCluster(signals) {
-  const { top, bottom } = splitSignalRows(signals);
-  const placed = [];
+function tuneHtmlRadar(markup, dimensions) {
+  let tuned = markup.replace(
+    '.radar-label--right { text-align: left; transform: translate(-24px, -50%); }',
+    '.radar-label--right { text-align: left; transform: translate(0, -50%); }'
+  );
 
-  for (const [rowName, row, y] of [['top', top, 330], ['bottom', bottom, 590]]) {
-    const xs = svgRowXs(row.length);
-    row.forEach((signal, index) => placed.push({ signal, x: xs[index], y, rowName }));
-  }
-
-  const paths = placed
-    .map(({ x, y }) => `M698 464 L${x} ${y}`)
-    .join(' ');
-
-  const nodes = placed.map(({ signal, x, y, rowName }) => {
-    const topRow = rowName === 'top';
-    const primaryY = topRow ? y - 62 : y + 66;
-    const labelY = topRow ? y - 37 : y + 91;
-    const detailY = topRow ? y - 18 : y + 110;
-    const display = signalDisplay(signal);
-    const cardY = topRow ? y - 104 : y + 34;
-    const cardHeight = display.detail ? 92 : 74;
-    const detailNode = display.detail
-      ? `<text x="${x}" y="${detailY}" class="muted" font-size="10" text-anchor="middle">${escapeMarkup(display.detail)}</text>`
-      : '';
-    return `<g class="signal-node">
-      <rect x="${x - 72}" y="${cardY}" width="144" height="${cardHeight}" rx="19" class="metric-orb"/>
-      <circle cx="${x}" cy="${y}" r="8" fill="#ffffff" stroke="#6555e8" stroke-width="3"/>
-      <text x="${x}" y="${primaryY}" class="accent" font-size="23" font-weight="760" text-anchor="middle">${escapeMarkup(display.primary)}</text>
-      <text x="${x}" y="${labelY}" class="ink" font-size="12" font-weight="670" text-anchor="middle">${escapeMarkup(signal.label)}</text>
-      ${detailNode}
-    </g>`;
-  }).join('\n');
-
-  return { paths, nodes };
-}
-
-function htmlSignalCluster(signals) {
-  const { top, bottom } = splitSignalRows(signals);
-  const placed = [];
-
-  for (const [row, y] of [[top, 28], [bottom, 72]]) {
-    const xs = htmlRowXs(row.length);
-    row.forEach((signal, index) => placed.push({ signal, x: xs[index], y }));
-  }
-
-  const paths = placed.map(({ x, y }) => {
-    const px = (620 * x / 100).toFixed(1);
-    const py = (520 * y / 100).toFixed(1);
-    return `M310 260 L${px} ${py}`;
-  }).join(' ');
-
-  const nodes = placed.map(({ signal, x, y }) => {
-    const display = signalDisplay(signal);
-    const detailNode = display.detail ? `<small>${escapeMarkup(display.detail)}</small>` : '';
-    return `<div class="signal metric-orb" style="left:${x}%;top:${y}%">
-    <strong>${escapeMarkup(display.primary)}</strong>
-    <span>${escapeMarkup(signal.label)}</span>
-    ${detailNode}
-  </div>`;
-  }).join('\n');
-
-  return { paths, nodes };
-}
-
-function formatScore(value) {
-  if (Number.isInteger(value)) return String(value);
-  return String(Number(value.toFixed(1)));
-}
-
-function formatWeight(weight) {
-  return `${Number((weight * 100).toFixed(1))}%`;
-}
-
-function svgComponentCluster(components, min, max) {
-  return {
-    visual: svgRadarVisual(components, min, max),
-    nodes: svgRadarNodes(components, min, max, 'score-component-node')
-  };
-}
-
-function htmlComponentCluster(components, min, max) {
-  return {
-    visual: htmlRadarVisual(components, min, max),
-    nodes: htmlRadarNodes(components, min, max, 'score-component')
-  };
-}
-
-function svgCompositionRows(components) {
-  return components.map((component, index) => {
-    const y = 552 + index * 34;
-    const detail = `${formatScore(component.normalizedScore)} · ${formatWeight(component.weight)}`;
-    return `<g>
-      <text x="98" y="${y}" class="ink" font-size="12" font-weight="650">${escapeMarkup(component.label)}</text>
-      <text x="332" y="${y}" class="muted" font-size="11" text-anchor="end">${escapeMarkup(detail)}</text>
-    </g>`;
-  }).join('\n');
-}
-
-function htmlCompositionRows(components) {
-  return components.map((component) => `<div class="composition-row">
-    <span>${escapeMarkup(component.label)}</span>
-    <small>${escapeMarkup(`${formatScore(component.normalizedScore)} · ${formatWeight(component.weight)}`)}</small>
-  </div>`).join('\n');
-}
-
-function movementSignals(signals, revenueMetric = null) {
-  const eligible = signals.filter((signal) => signal.delta);
-  const preferred = ['churn_rate', 'trial_conversion'];
-  const selected = [];
-
-  for (const metric of preferred) {
-    const match = eligible.find((signal) => signal.metric === metric);
-    if (match && !selected.includes(match)) selected.push(match);
-  }
-
-  for (const signal of eligible) {
-    if (selected.length >= 2) break;
-    if (signal.metric !== revenueMetric && !selected.includes(signal)) selected.push(signal);
-  }
-
-  return selected.slice(0, 2);
-}
-
-function svgMovementRows(signals) {
-  if (signals.length === 0) {
-    return '<text x="98" y="566" class="muted" font-size="12">No additional movement signals</text>';
-  }
-
-  return signals.map((signal, index) => {
-    const labelY = 552 + index * 72;
-    const valueY = labelY + 27;
-    const divider = index === 0 && signals.length > 1
-      ? '<line x1="98" y1="600" x2="332" y2="600" stroke="#efedf6"/>'
-      : '';
-    return `<g>
-      <text x="98" y="${labelY}" class="muted" font-size="12">${escapeMarkup(signal.label)}</text>
-      <text x="98" y="${valueY}" class="ink" font-size="21" font-weight="700">${escapeMarkup(signal.value)}</text>
-      <text x="332" y="${valueY}" class="${directionClass(signal.direction)}" font-size="13" font-weight="650" text-anchor="end">${escapeMarkup(signal.delta)}</text>
-      ${divider}
-    </g>`;
-  }).join('\n');
-}
-
-function htmlMovementRows(signals) {
-  if (signals.length === 0) {
-    return '<div class="empty-state">No additional movement signals</div>';
-  }
-
-  return signals.map((signal) => `<div class="context-metric">
-    <span>${escapeMarkup(signal.label)}</span>
-    <strong>${escapeMarkup(signal.value)}</strong>
-    <em class="${directionClass(signal.direction)}">${escapeMarkup(signal.delta)}</em>
-  </div>`).join('\n');
-}
-
-function svgExceptionRows(exceptions = []) {
-  if (exceptions.length === 0) {
-    return '<text x="1064" y="232" class="muted" font-size="13">No confirmed exceptions visible</text>';
-  }
-
-  return exceptions.slice(0, 3).map((item, index) => {
-    const y = 232 + index * 70;
-    const meta = [item.plan, item.mrr ? `${item.mrr} MRR` : null].filter(Boolean).join(' · ');
-    return `<g>
-      <circle cx="1072" cy="${y - 4}" r="5" fill="#e25462"/>
-      <text x="1088" y="${y}" class="ink" font-size="14" font-weight="650">${escapeMarkup(item.name)}</text>
-      <text x="1088" y="${y + 22}" class="muted" font-size="12">${escapeMarkup(meta)}</text>
-      <rect x="1268" y="${y - 19}" width="74" height="26" rx="13" fill="#fff1f3"/>
-      <text x="1305" y="${y - 1}" class="danger" font-size="11" font-weight="650" text-anchor="middle">${escapeMarkup(item.status)}</text>
-    </g>`;
-  }).join('\n');
-}
-
-function svgEventRows(events = []) {
-  if (events.length === 0) {
-    return '<text x="1064" y="534" class="muted" font-size="13">No recent source-supported events</text>';
-  }
-
-  return events.slice(0, 4).map((item, index) => {
-    const y = 534 + index * 68;
-    return `<g>
-      <circle cx="1072" cy="${y - 4}" r="4" fill="#6555e8"/>
-      <text x="1088" y="${y}" class="ink" font-size="13" font-weight="650">${escapeMarkup(item.subject)}</text>
-      <text x="1088" y="${y + 21}" class="muted" font-size="12">${escapeMarkup(item.event)}</text>
-      <text x="1342" y="${y + 21}" class="soft" font-size="11" text-anchor="end">${escapeMarkup(item.time)}</text>
-    </g>`;
-  }).join('\n');
-}
-
-function htmlExceptionRows(exceptions = []) {
-  if (exceptions.length === 0) {
-    return '<div class="empty-state">No confirmed exceptions visible</div>';
-  }
-
-  return exceptions.slice(0, 3).map((item) => {
-    const meta = [item.plan, item.mrr ? `${item.mrr} MRR` : null].filter(Boolean).join(' · ');
-    return `<div class="exception-row">
-      <span class="dot dot--risk" aria-hidden="true"></span>
-      <div class="row-copy"><strong>${escapeMarkup(item.name)}</strong><span>${escapeMarkup(meta)}</span></div>
-      <span class="badge">${escapeMarkup(item.status)}</span>
-    </div>`;
-  }).join('\n');
-}
-
-function htmlEventRows(events = []) {
-  if (events.length === 0) {
-    return '<div class="empty-state">No recent source-supported events</div>';
-  }
-
-  return events.slice(0, 4).map((item) => `<div class="event-row">
-    <span class="dot" aria-hidden="true"></span>
-    <div class="row-copy"><strong>${escapeMarkup(item.subject)}</strong><span>${escapeMarkup(item.event)}</span></div>
-    <span class="event-time">${escapeMarkup(item.time)}</span>
-  </div>`).join('\n');
-}
-
-function fillTemplate(template, replacements) {
-  let output = template;
-  for (const [key, value] of Object.entries(replacements)) {
-    output = output.replaceAll(`{{${key}}}`, value);
-  }
-  return output;
-}
-
-function noScoreViewModel(data) {
-  const revenue = selectRevenueSignal(data.signals);
-  const revenueSeries = data.context?.provenance === 'source' ? data.context.revenueSeries : null;
-  const movement = movementSignals(data.signals, revenue?.metric ?? null);
-  return { revenue, revenueSeries, movement };
-}
-
-function renderNoScoreSvg(data) {
-  const template = fs.readFileSync(noScoreSvgTemplatePath, 'utf8');
-  const { revenue, revenueSeries, movement } = noScoreViewModel(data);
-  const radar = data.radarScale
-    ? {
-        visual: svgRadarVisual(data.signals, data.radarScale.min, data.radarScale.max),
-        nodes: svgRadarNodes(data.signals, data.radarScale.min, data.radarScale.max, 'radar-dimension-node')
-      }
-    : null;
-  const signalCluster = radar ?? svgSignalCluster(data.signals);
-  const orbitVisual = radar
-    ? radar.visual
-    : `<path class="orbit-spokes" d="${signalCluster.paths}" fill="none" stroke="#d6d0ef" stroke-width="1.6"/>`;
-
-  return fillTemplate(template, {
-    REVENUE_TITLE: escapeMarkup(revenueTitle(revenue)),
-    REVENUE_VALUE: escapeMarkup(revenue?.value ?? '—'),
-    REVENUE_DELTA_BLOCK: svgRevenueDeltaBlock(revenue),
-    CURRENT_REVENUE_LABEL: escapeMarkup(currentRevenueLabel(revenue)),
-    REVENUE_VISUAL: svgRevenueVisual(revenueSeries),
-    MOVEMENT_ROWS: svgMovementRows(movement),
-    SVG_ORBIT_VISUAL: orbitVisual,
-    SVG_SIGNAL_NODES: signalCluster.nodes,
-    EXCEPTION_ROWS: svgExceptionRows(data.exceptions),
-    EVENT_ROWS: svgEventRows(data.events)
-  });
-}
-
-function renderNoScoreHtml(data) {
-  const template = fs.readFileSync(noScoreHtmlTemplatePath, 'utf8');
-  const css = fs.readFileSync(cssTemplatePath, 'utf8');
-  const { revenue, revenueSeries, movement } = noScoreViewModel(data);
-  const radar = data.radarScale
-    ? {
-        visual: htmlRadarVisual(data.signals, data.radarScale.min, data.radarScale.max),
-        nodes: htmlRadarNodes(data.signals, data.radarScale.min, data.radarScale.max, 'radar-dimension')
-      }
-    : null;
-  const signalCluster = radar ?? htmlSignalCluster(data.signals);
-  const orbitVisual = radar
-    ? radar.visual
-    : `<path class="orbit-spokes" d="${signalCluster.paths}"></path>`;
-
-  return fillTemplate(template, {
-    CSS: css,
-    REVENUE_TITLE: escapeMarkup(revenueTitle(revenue)),
-    REVENUE_VALUE: escapeMarkup(revenue?.value ?? '—'),
-    HTML_REVENUE_DELTA_BLOCK: htmlRevenueDeltaBlock(revenue),
-    CURRENT_REVENUE_LABEL: escapeMarkup(currentRevenueLabel(revenue)),
-    HTML_REVENUE_VISUAL: htmlRevenueVisual(revenueSeries),
-    HTML_MOVEMENT_ROWS: htmlMovementRows(movement),
-    HTML_ORBIT_VISUAL: orbitVisual,
-    HTML_SIGNAL_NODES: signalCluster.nodes,
-    HTML_EXCEPTION_ROWS: htmlExceptionRows(data.exceptions),
-    HTML_EVENT_ROWS: htmlEventRows(data.events)
-  });
-}
-
-function renderCompositeSvg(data) {
-  const template = fs.readFileSync(compositeSvgTemplatePath, 'utf8');
-  const scoreSeries = data.context?.provenance === 'source' ? data.context.scoreSeries : null;
-  const cluster = svgComponentCluster(data.model.components, data.score.min, data.score.max);
-
-  return fillTemplate(template, {
-    SCORE_LABEL: escapeMarkup(data.score.label),
-    SCORE_VALUE: escapeMarkup(formatScore(data.score.value)),
-    SCORE_MAX: escapeMarkup(formatScore(data.score.max)),
-    SCORE_BAND: escapeMarkup(data.score.band),
-    SVG_SCORE_TREND: svgScoreVisual(scoreSeries),
-    SVG_COMPOSITION_ROWS: svgCompositionRows(data.model.components),
-    SVG_COMPONENT_RADAR: cluster.visual,
-    SVG_COMPONENT_NODES: cluster.nodes,
-    EXCEPTION_ROWS: svgExceptionRows(data.exceptions),
-    EVENT_ROWS: svgEventRows(data.events)
-  });
-}
-
-function renderCompositeHtml(data) {
-  const template = fs.readFileSync(compositeHtmlTemplatePath, 'utf8');
-  const css = fs.readFileSync(cssTemplatePath, 'utf8');
-  const scoreSeries = data.context?.provenance === 'source' ? data.context.scoreSeries : null;
-  const cluster = htmlComponentCluster(data.model.components, data.score.min, data.score.max);
-
-  return fillTemplate(template, {
-    CSS: css,
-    SCORE_LABEL: escapeMarkup(data.score.label),
-    SCORE_VALUE: escapeMarkup(formatScore(data.score.value)),
-    SCORE_MAX: escapeMarkup(formatScore(data.score.max)),
-    SCORE_BAND: escapeMarkup(data.score.band),
-    HTML_SCORE_TREND: htmlScoreVisual(scoreSeries),
-    HTML_COMPOSITION_ROWS: htmlCompositionRows(data.model.components),
-    HTML_COMPONENT_RADAR: cluster.visual,
-    HTML_COMPONENT_NODES: cluster.nodes,
-    HTML_EXCEPTION_ROWS: htmlExceptionRows(data.exceptions),
-    HTML_EVENT_ROWS: htmlEventRows(data.events)
-  });
+  tuned = tuneHtmlLabels(tuned, dimensions);
+  return tuned;
 }
 
 export function renderSvg(data) {
-  assertValid(data);
-  return data.mode === 'composite' ? renderCompositeSvg(data) : renderNoScoreSvg(data);
+  const markup = renderSvgCore(data);
+  const dimensions = radarDimensions(data);
+  return dimensions?.length ? tuneSvgRadar(markup, dimensions) : markup;
 }
 
 export function renderHtml(data) {
-  assertValid(data);
-  return data.mode === 'composite' ? renderCompositeHtml(data) : renderNoScoreHtml(data);
+  const markup = renderHtmlCore(data);
+  const dimensions = radarDimensions(data);
+  return dimensions?.length ? tuneHtmlRadar(markup, dimensions) : markup;
 }
 
 if (process.argv[1] === currentFile) {

--- a/tests/compiler/golden/hashes.json
+++ b/tests/compiler/golden/hashes.json
@@ -1,6 +1,6 @@
 {
   "no-score.svg": "135d2f9a3fe9b8a219e2daeadb53065d1759e1ea6c2aa6851f238ce6f7b84b61",
   "no-score.html": "26f861655327c5249855eadbfe6f343d5a6cb773bc0ae1ff7a37295dbf0b3fc0",
-  "composite.svg": "e81e4765cff843e661b026bfd3d7ec2a3d26032a703822df9c9ff1afca48e4c6",
-  "composite.html": "caddceca9bfcd7ba4093080233b1c600db60fc3f10241493f5585766c7f156ba"
+  "composite.svg": "45f3721c1b3870cf40fd7ed188744aa43871bca2ff9371ae46edbc203cbf3eb5",
+  "composite.html": "ab42f1ab25a975f318f3d03126475245d77d5ddff93f40347f4e297c03e8734c"
 }

--- a/tests/compiler/radar-centered-layout.test.js
+++ b/tests/compiler/radar-centered-layout.test.js
@@ -1,0 +1,70 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import { renderSvg, renderHtml } from '../../skills/decision-first-dashboard/scripts/render.js';
+
+const state = JSON.parse(fs.readFileSync(new URL('../../examples/radar-profile/input.no-score.json', import.meta.url), 'utf8'));
+
+function svgLabels(svg) {
+  return [...svg.matchAll(/<text class="radar-label radar-label--(top|bottom|left|right)"[^>]*x="([\d.]+)" y="([\d.]+)"/g)]
+    .map((match) => ({ side: match[1], x: Number(match[2]), y: Number(match[3]) }));
+}
+
+function htmlLabels(html) {
+  return [...html.matchAll(/radar-label--(top|bottom|left|right)" data-outside-ring="true" style="left:([\d.]+)%;top:([\d.]+)%/g)]
+    .map((match) => ({
+      side: match[1],
+      x: Number(match[2]) * 620 / 100,
+      y: Number(match[3]) * 520 / 100
+    }));
+}
+
+function svgAnchorPoint(label) {
+  const y = label.side === 'top' ? label.y + 21 : label.side === 'bottom' ? label.y + 3 : label.y + 20;
+  return { x: label.x, y };
+}
+
+function assertUniformRadius(points, cx, cy, expectedRadius, tolerance = 0.35) {
+  for (const point of points) {
+    const radius = Math.hypot(point.x - cx, point.y - cy);
+    assert.ok(Math.abs(radius - expectedRadius) <= tolerance, `expected label radius ${expectedRadius}, got ${radius}`);
+  }
+}
+
+test('radar module is centered in the middle stage instead of only centering the raw circle', () => {
+  const svg = renderSvg(state);
+  assert.match(svg, /<g transform="translate\(8 -6\)">/);
+  assert.match(svg, /<circle cx="706" cy="482" r="318" class="radar-ambient-field"\/>/);
+  assert.equal(698 + 8, (376 + 1036) / 2);
+});
+
+test('all SVG dimension labels use one shared radial gap outside the 100% circle', () => {
+  const svg = renderSvg(state);
+  const labels = svgLabels(svg);
+  assert.equal(labels.length, 5);
+  assertUniformRadius(labels.map(svgAnchorPoint), 698, 464, 228);
+  assert.equal(228 - 188, 40);
+  assert.doesNotMatch(svg, /translateX\(-24px\)/);
+});
+
+test('left and right SVG labels remain symmetric and leave room for support cards', () => {
+  const labels = svgLabels(renderSvg(state));
+  const right = labels.filter((label) => label.side === 'right');
+  const left = labels.filter((label) => label.side === 'left');
+  assert.equal(right.length, 2);
+  assert.equal(left.length, 2);
+
+  const rightXs = right.map((label) => label.x).sort((a, b) => a - b);
+  const leftXs = left.map((label) => label.x).sort((a, b) => a - b);
+  assert.ok(Math.abs((rightXs[1] + leftXs[0]) - 1396) < 0.3);
+  assert.ok(Math.abs((rightXs[0] + leftXs[1]) - 1396) < 0.3);
+  assert.ok(Math.max(...rightXs) + 8 <= 924, 'right label anchor must keep a safe margin before the x=1036 support card');
+});
+
+test('HTML uses the same uniform radial label-gap rule without an inward right-side nudge', () => {
+  const html = renderHtml(state);
+  const labels = htmlLabels(html);
+  assert.equal(labels.length, 5);
+  assertUniformRadius(labels, 310, 260, 228, 0.6);
+  assert.doesNotMatch(html, /radar-label--right \{ text-align: left; transform: translate\(-24px, -50%\); \}/);
+});

--- a/tests/compiler/radar-scale-layout.test.js
+++ b/tests/compiler/radar-scale-layout.test.js
@@ -71,22 +71,37 @@ test('left labels are explicitly right-aligned line by line and right labels are
   assert.equal((rightBlock.match(/text-anchor="start"/g) ?? []).length, 4, 'right label and all three lines must share the same left edge');
 });
 
-test('side labels stay inside the center safe zone and cannot overlap support cards', () => {
+test('side labels keep the shared radial gap without colliding with support cards', () => {
   const svg = renderSvg(comparisonRadar);
   const html = renderHtml(comparisonRadar);
+  const svgSides = [...svg.matchAll(/class="radar-label radar-label--(left|right)"[^>]*x="([0-9.]+)"/g)]
+    .map((match) => ({ side: match[1], x: Number(match[2]) }));
 
-  for (const match of svg.matchAll(/class="radar-label radar-label--(left|right)"[^>]*x="([0-9.]+)"/g)) {
-    const [, side, xText] = match;
-    const x = Number(xText);
-    if (side === 'left') assert.ok(x >= 500, `left label x=${x} must clear the left support card`);
-    if (side === 'right') assert.ok(x <= 900, `right label x=${x} must clear the right support card`);
+  assert.deepEqual(svgSides, [
+    { side: 'right', x: 926 },
+    { side: 'left', x: 470 }
+  ]);
+
+  const svgTranslateX = 8;
+  const conservativeLabelWidth = 96;
+  for (const { side, x } of svgSides) {
+    const absoluteX = x + svgTranslateX;
+    if (side === 'left') assert.ok(absoluteX - conservativeLabelWidth >= 376, 'left label must stay clear of the left support card');
+    if (side === 'right') assert.ok(absoluteX + conservativeLabelWidth <= 1036, 'right label must stay clear of the right support card');
   }
 
-  for (const match of html.matchAll(/class="[^\"]*radar-label radar-label--(left|right)[^\"]*"[^>]*style="left:([0-9.]+)%/g)) {
-    const [, side, pctText] = match;
-    const pct = Number(pctText);
-    if (side === 'left') assert.ok(pct >= 19.35, `left HTML label ${pct}% must clear the left support card`);
-    if (side === 'right') assert.ok(pct <= 80.65, `right HTML label ${pct}% must clear the right support card`);
+  const htmlSides = [...html.matchAll(/class="[^\"]*radar-label radar-label--(left|right)[^\"]*"[^>]*style="left:([0-9.]+)%/g)]
+    .map((match) => ({ side: match[1], x: Number(match[2]) * 620 / 100 }));
+  assert.equal(htmlSides.length, 2);
+  assert.ok(Math.abs((htmlSides[0].x + htmlSides[1].x) - 620) < 0.2, 'HTML side-label anchors must remain symmetric');
+
+  const orbitInset = 44;
+  const htmlLabelWidth = 132;
+  const middleStageWidth = 708;
+  const interColumnGap = 24;
+  for (const { side, x } of htmlSides) {
+    if (side === 'left') assert.ok(orbitInset + x - htmlLabelWidth >= -interColumnGap, 'left HTML label may use the grid gap but must not reach the support card');
+    if (side === 'right') assert.ok(orbitInset + x + htmlLabelWidth <= middleStageWidth + interColumnGap, 'right HTML label may use the grid gap but must not reach the support card');
   }
 });
 


### PR DESCRIPTION
Centers the full radar module in the middle stage, removes the asymmetric right-side label nudge, and lays every dimension label on one shared 40px radial gap outside the 100% data circle. The new layout keeps the ambient field centered under the module and preserves room before the support cards. Includes regression tests for centering, symmetry, uniform radial spacing, and HTML/SVG parity.