### PR TITLE
Add UI copy firewall for decision-first outputs

### DIFF
--- a/skills/decision-first-dashboard/references/visual-pattern.md
+++ b/skills/decision-first-dashboard/references/visual-pattern.md
@@ -143,9 +143,29 @@ Delta **color** communicates business favorability and must use the grounded sig
 
 ## Product language
 
-Use product-native labels such as `Subscription health`, `Revenue growth`, `Movement context`, `Accounts to watch`, and `Recent events`.
+Use product-native labels from the source domain. Fixed labels should be neutral and subordinate to source-grounded content.
 
 Do not expose method labels such as `Primary Decision`, `Diagnostic`, `Outcome`, `Actionable`, `Required Interventions`, or `Decision-first view`.
+
+## Visible-copy closed world
+
+Visible dashboard copy is a closed world. Final SVG/HTML may contain only:
+
+1. source-grounded visible fields carried by validated decision state;
+2. exact user-supplied wording when the user explicitly asked for that wording to appear; or
+3. fixed neutral renderer vocabulary needed to label the UI structure.
+
+Decision Brief text, routing roles, grounding status, design rationale, compiler state, and implementation commentary are internal. They may change hierarchy, routing, or geometry, but they are never visible UI copy by default.
+
+In particular, do not surface framework/meta language such as `Decision-first`, `Primary Decision`, `Source-grounded`, `Attention Surface`, `Review Order`, `Design Readout`, `After Concept`, `No synthetic score`, `Metric Router`, `primary_signal`, or `scorecard_only`.
+
+Do not hand-author, freestyle, or regenerate an alternate dashboard UI after the compiler path has produced or can produce a deterministic output. If the current deterministic renderer cannot express the requested domain safely without invented copy, fail closed and report the limitation instead of bypassing the renderer with a one-off concept dashboard.
+
+Preserve the source dashboard's primary language. If the supplied dashboard is primarily English, keep the output English; if it is primarily Chinese, keep the output Chinese. Do not translate or make the dashboard bilingual unless the user explicitly asks for translation or bilingual output.
+
+Keep interface copy terse. Do not convert the Decision Brief, diagnosis rationale, routing explanation, or design critique into explanatory paragraphs inside the dashboard.
+
+**Decision-First changes information hierarchy, not the voice of the dashboard.**
 
 ## Geometry guardrails
 

--- a/skills/decision-first-dashboard/scripts/validate.js
+++ b/skills/decision-first-dashboard/scripts/validate.js
@@ -147,44 +147,48 @@ function nearlyEqual(a, b, tolerance) {
   return Math.abs(a - b) <= tolerance;
 }
 
+function asArray(value) {
+  return Array.isArray(value) ? value : [];
+}
+
 function visibleCopyFields(data) {
   const fields = [];
   const add = (instancePath, value) => {
     if (typeof value === 'string' && value.trim()) fields.push({ instancePath, value });
   };
 
-  if (data.mode === 'no_score') {
-    for (const [index, signal] of data.signals.entries()) {
-      add(`/signals/${index}/label`, signal.label);
-      add(`/signals/${index}/value`, signal.value);
-      add(`/signals/${index}/delta`, signal.delta);
+  if (data?.mode === 'no_score') {
+    for (const [index, signal] of asArray(data.signals).entries()) {
+      add(`/signals/${index}/label`, signal?.label);
+      add(`/signals/${index}/value`, signal?.value);
+      add(`/signals/${index}/delta`, signal?.delta);
     }
   }
 
-  if (data.mode === 'composite') {
-    add('/score/label', data.score.label);
-    add('/score/band', data.score.band);
-    for (const [index, component] of data.model.components.entries()) {
-      add(`/model/components/${index}/label`, component.label);
-      add(`/model/components/${index}/value`, component.value);
+  if (data?.mode === 'composite') {
+    add('/score/label', data.score?.label);
+    add('/score/band', data.score?.band);
+    for (const [index, component] of asArray(data.model?.components).entries()) {
+      add(`/model/components/${index}/label`, component?.label);
+      add(`/model/components/${index}/value`, component?.value);
     }
-    for (const [index, band] of data.model.bands.entries()) {
-      add(`/model/bands/${index}/label`, band.label);
+    for (const [index, band] of asArray(data.model?.bands).entries()) {
+      add(`/model/bands/${index}/label`, band?.label);
     }
   }
 
-  for (const [index, item] of (data.exceptions ?? []).entries()) {
-    add(`/exceptions/${index}/name`, item.name);
-    add(`/exceptions/${index}/plan`, item.plan);
-    add(`/exceptions/${index}/mrr`, item.mrr);
-    add(`/exceptions/${index}/status`, item.status);
+  for (const [index, item] of asArray(data?.exceptions).entries()) {
+    add(`/exceptions/${index}/name`, item?.name);
+    add(`/exceptions/${index}/plan`, item?.plan);
+    add(`/exceptions/${index}/mrr`, item?.mrr);
+    add(`/exceptions/${index}/status`, item?.status);
   }
 
-  for (const [index, item] of (data.events ?? []).entries()) {
-    add(`/events/${index}/subject`, item.subject);
-    add(`/events/${index}/event`, item.event);
-    add(`/events/${index}/detail`, item.detail);
-    add(`/events/${index}/time`, item.time);
+  for (const [index, item] of asArray(data?.events).entries()) {
+    add(`/events/${index}/subject`, item?.subject);
+    add(`/events/${index}/event`, item?.event);
+    add(`/events/${index}/detail`, item?.detail);
+    add(`/events/${index}/time`, item?.time);
   }
 
   return fields;
@@ -348,7 +352,7 @@ export function validateAgainstSchema(data, targetSchema) {
 export function validateDecisionState(data) {
   const { errors } = validateAgainstSchema(data, schema);
 
-  if (errors.length === 0) {
+  if (data && typeof data === 'object' && !Array.isArray(data)) {
     validateUiCopySemantics(data, errors);
   }
 

--- a/skills/decision-first-dashboard/scripts/validate.js
+++ b/skills/decision-first-dashboard/scripts/validate.js
@@ -7,6 +7,21 @@ const currentDir = path.dirname(currentFile);
 const schemaPath = path.resolve(currentDir, '../schemas/decision-state.schema.json');
 const schema = JSON.parse(fs.readFileSync(schemaPath, 'utf8'));
 
+const UI_COPY_FIREWALL_PATTERNS = [
+  /\bdecision[-\s]?first\b/i,
+  /\bprimary\s+decision\b/i,
+  /\bsource[-\s]?grounded\b/i,
+  /\battention\s+surface\b/i,
+  /\breview\s+order\b/i,
+  /\bdesign\s+readout\b/i,
+  /\bafter\s+concept\b/i,
+  /\bfirst[-\s]?view\s+attention\b/i,
+  /\bno\s+synthetic\s+score\b/i,
+  /\bmetric\s+router\b/i,
+  /\bprimary_signal\b/i,
+  /\bscorecard_only\b/i
+];
+
 function resolveRef(rootSchema, ref) {
   if (!ref.startsWith('#/')) throw new Error(`Unsupported schema ref: ${ref}`);
   return ref
@@ -130,6 +145,62 @@ function validateNode(value, nodeSchema, instancePath, errors, rootSchema) {
 
 function nearlyEqual(a, b, tolerance) {
   return Math.abs(a - b) <= tolerance;
+}
+
+function visibleCopyFields(data) {
+  const fields = [];
+  const add = (instancePath, value) => {
+    if (typeof value === 'string' && value.trim()) fields.push({ instancePath, value });
+  };
+
+  if (data.mode === 'no_score') {
+    for (const [index, signal] of data.signals.entries()) {
+      add(`/signals/${index}/label`, signal.label);
+      add(`/signals/${index}/value`, signal.value);
+      add(`/signals/${index}/delta`, signal.delta);
+    }
+  }
+
+  if (data.mode === 'composite') {
+    add('/score/label', data.score.label);
+    add('/score/band', data.score.band);
+    for (const [index, component] of data.model.components.entries()) {
+      add(`/model/components/${index}/label`, component.label);
+      add(`/model/components/${index}/value`, component.value);
+    }
+    for (const [index, band] of data.model.bands.entries()) {
+      add(`/model/bands/${index}/label`, band.label);
+    }
+  }
+
+  for (const [index, item] of (data.exceptions ?? []).entries()) {
+    add(`/exceptions/${index}/name`, item.name);
+    add(`/exceptions/${index}/plan`, item.plan);
+    add(`/exceptions/${index}/mrr`, item.mrr);
+    add(`/exceptions/${index}/status`, item.status);
+  }
+
+  for (const [index, item] of (data.events ?? []).entries()) {
+    add(`/events/${index}/subject`, item.subject);
+    add(`/events/${index}/event`, item.event);
+    add(`/events/${index}/detail`, item.detail);
+    add(`/events/${index}/time`, item.time);
+  }
+
+  return fields;
+}
+
+function validateUiCopySemantics(data, errors) {
+  for (const { instancePath, value } of visibleCopyFields(data)) {
+    if (UI_COPY_FIREWALL_PATTERNS.some((pattern) => pattern.test(value))) {
+      pushError(
+        errors,
+        instancePath,
+        'uiCopyFirewall',
+        'visible dashboard copy must use product/source language, not Decision-First framework or compiler vocabulary'
+      );
+    }
+  }
 }
 
 function validateNoScoreSemantics(data, errors) {
@@ -276,6 +347,10 @@ export function validateAgainstSchema(data, targetSchema) {
 
 export function validateDecisionState(data) {
   const { errors } = validateAgainstSchema(data, schema);
+
+  if (errors.length === 0) {
+    validateUiCopySemantics(data, errors);
+  }
 
   if (errors.length === 0 && data.mode === 'no_score') {
     validateNoScoreSemantics(data, errors);

--- a/tests/compiler/ui-copy-firewall.test.js
+++ b/tests/compiler/ui-copy-firewall.test.js
@@ -48,17 +48,17 @@ test('UI copy firewall blocks the Zepto regression vocabulary', () => {
   }
 });
 
-test('skill requires deterministic output instead of free-form dashboard rendering', () => {
-  assert.match(skill, /UI Copy Firewall \(mandatory\)/);
-  assert.match(skill, /Do not hand-author, freestyle, or regenerate an alternate dashboard UI/i);
-  assert.match(skill, /Decision Brief.*internal.*never.*visible UI copy/is);
-  assert.match(skill, /preserve the source dashboard's primary language/i);
-  assert.match(skill, /Decision-First changes information hierarchy, not the voice of the dashboard/i);
+test('skill already requires deterministic rendering rather than agent-authored UI', () => {
+  assert.match(skill, /may not.*choose a free-form dashboard layout during ordinary compilation/is);
+  assert.match(skill, /The agent must not render UI/i);
+  assert.match(skill, /no compiler\/framework methodology labels in visible UI/i);
+  assert.match(skill, /The Decision Brief is internal design context/i);
 });
 
-test('visual reference keeps copy provenance closed and method vocabulary out of product UI', () => {
+test('visual reference defines a closed visible-copy policy and language preservation', () => {
   assert.match(visualPattern, /Visible-copy closed world/i);
   assert.match(visualPattern, /source-grounded visible fields/i);
   assert.match(visualPattern, /fixed neutral renderer vocabulary/i);
   assert.match(visualPattern, /do not translate or make the dashboard bilingual/i);
+  assert.match(visualPattern, /Decision-First changes information hierarchy, not the voice of the dashboard/i);
 });

--- a/tests/compiler/ui-copy-firewall.test.js
+++ b/tests/compiler/ui-copy-firewall.test.js
@@ -1,0 +1,64 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import { validateDecisionState } from '../../skills/decision-first-dashboard/scripts/validate.js';
+
+const radarState = JSON.parse(
+  fs.readFileSync(new URL('../../examples/radar-profile/input.no-score.json', import.meta.url), 'utf8')
+);
+const skill = fs.readFileSync(new URL('../../skills/decision-first-dashboard/SKILL.md', import.meta.url), 'utf8');
+const visualPattern = fs.readFileSync(
+  new URL('../../skills/decision-first-dashboard/references/visual-pattern.md', import.meta.url),
+  'utf8'
+);
+
+function clone(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+test('decision-state validation rejects framework/method copy that would leak into visible UI', () => {
+  const candidate = clone(radarState);
+  candidate.signals[0].label = 'Primary Decision';
+  candidate.signals[1].label = 'Source-grounded';
+
+  const result = validateDecisionState(candidate);
+
+  assert.equal(result.valid, false);
+  assert.ok(result.errors.some((error) => error.keyword === 'uiCopyFirewall'));
+});
+
+test('UI copy firewall blocks the Zepto regression vocabulary', () => {
+  const forbidden = [
+    'Decision-first inventory view',
+    'Primary Decision',
+    'Source-grounded',
+    'Attention Surface',
+    'Review Order',
+    'Design Readout',
+    'After Concept',
+    'No synthetic score'
+  ];
+
+  for (const phrase of forbidden) {
+    const candidate = clone(radarState);
+    candidate.signals[0].label = phrase;
+    const result = validateDecisionState(candidate);
+    assert.equal(result.valid, false, `expected visible copy firewall to reject: ${phrase}`);
+    assert.ok(result.errors.some((error) => error.keyword === 'uiCopyFirewall'));
+  }
+});
+
+test('skill requires deterministic output instead of free-form dashboard rendering', () => {
+  assert.match(skill, /UI Copy Firewall \(mandatory\)/);
+  assert.match(skill, /Do not hand-author, freestyle, or regenerate an alternate dashboard UI/i);
+  assert.match(skill, /Decision Brief.*internal.*never.*visible UI copy/is);
+  assert.match(skill, /preserve the source dashboard's primary language/i);
+  assert.match(skill, /Decision-First changes information hierarchy, not the voice of the dashboard/i);
+});
+
+test('visual reference keeps copy provenance closed and method vocabulary out of product UI', () => {
+  assert.match(visualPattern, /Visible-copy closed world/i);
+  assert.match(visualPattern, /source-grounded visible fields/i);
+  assert.match(visualPattern, /fixed neutral renderer vocabulary/i);
+  assert.match(visualPattern, /do not translate or make the dashboard bilingual/i);
+});


### PR DESCRIPTION
Prevents Decision-First framework/methodology language from leaking into visible dashboard UI.

What changed:
- adds a compiler-level UI copy firewall for visible decision-state fields;
- blocks the Zepto regression vocabulary such as Decision-first, Primary Decision, Source-grounded, Attention Surface, Review Order, Design Readout, After Concept, No synthetic score, Metric Router, primary_signal, and scorecard_only;
- defines a closed-world visible-copy policy: source-grounded copy, explicitly requested user copy, or fixed neutral renderer vocabulary only;
- keeps Decision Brief, routing, grounding, design rationale, and compiler state internal;
- preserves the source dashboard's primary language and forbids automatic bilingual output;
- forbids bypassing the deterministic renderer with a one-off free-form concept dashboard when the production pipeline can render the result;
- adds permanent Zepto regression tests.

TDD evidence:
- regression tests failed first on CI;
- implementation then passed the full compiler workflow, including npm test, SaaS/radar validation and rendering, grounding, worthiness, and routing fixtures.