### PR TITLE
Package a Claude-ready upload skill

### DIFF
--- a/.github/workflows/compiler-tests.yml
+++ b/.github/workflows/compiler-tests.yml
@@ -13,7 +13,9 @@ on:
       - 'examples/saas/**'
       - 'examples/radar-profile/**'
       - 'tests/compiler/**'
+      - 'scripts/**'
       - 'package.json'
+      - 'README.md'
       - '.github/workflows/compiler-tests.yml'
 
 jobs:
@@ -44,6 +46,13 @@ jobs:
         run: node skills/decision-first-dashboard/scripts/compile-dashboard.js tests/compiler/fixtures/worthiness/dashboard.worthiness.json tests/compiler/fixtures/routing/composite.routing.json tests/compiler/fixtures/grounding/composite.grounded.json tests/compiler/generated/routed-composite
       - name: Compile routed no-score fixture
         run: node skills/decision-first-dashboard/scripts/compile-dashboard.js tests/compiler/fixtures/worthiness/dashboard.worthiness.json tests/compiler/fixtures/routing/no-score.routing.json tests/compiler/fixtures/grounding/no-score.grounded.json tests/compiler/generated/routed-no-score
+      - name: Stage Claude Upload Skill package
+        run: npm run package:claude-skill
+      - uses: actions/upload-artifact@v4
+        with:
+          name: decision-first-dashboard-skill
+          path: dist/claude-skill/
+          if-no-files-found: error
       - uses: actions/upload-artifact@v4
         with:
           name: saas-no-score-render

--- a/README.md
+++ b/README.md
@@ -113,7 +113,15 @@ If those facts are missing, it falls back to `no_score` instead of guessing.
 npx skills add fourleaf13-hue/decision-first-dashboard
 ```
 
-The repository is also packaged as a standard Claude plugin via `.claude-plugin/plugin.json` for Anthropic Plugin Directory submission. Until directory approval, the skill install command above remains the public install path.
+### Claude workspace — Upload skill
+
+For Claude's **Skills → Upload skill** flow, use the dedicated `decision-first-dashboard-skill` artifact from the latest successful [Compiler tests](https://github.com/fourleaf13-hue/decision-first-dashboard/actions/workflows/compiler-tests.yml) run. Download that artifact ZIP and upload it directly to Claude.
+
+That artifact is built from only `skills/decision-first-dashboard/`, with `SKILL.md` at the ZIP root and without `.claude-plugin/plugin.json`.
+
+**Do not use GitHub's Download ZIP for Claude Upload skill.** The repository ZIP contains the plugin manifest and nests `SKILL.md` under the repository/skill folders, which Claude rejects for a standalone skill upload.
+
+The repository is also packaged as a standard Claude plugin via `.claude-plugin/plugin.json` for Anthropic Plugin Directory submission. The plugin package and the standalone Claude Upload Skill package intentionally remain separate.
 
 ## Use
 
@@ -223,6 +231,7 @@ composite  → output.composite.svg / output.composite.html
 
 ```bash
 npm test
+npm run package:claude-skill
 npm run validate:saas
 npm run render:saas
 npm run validate:radar-showcase
@@ -235,7 +244,7 @@ For Anthropic plugin packaging, validate the repository root with a current Clau
 claude plugin validate . --strict
 ```
 
-GitHub Actions runs the compiler suite, including the plugin manifest contract, executable Worthiness scenario fixtures, Decision Brief intake, 70-KPI Metric Router behavior, routed production compilation, grounded composite/no-score compilation, radar rendering, and byte-level golden snapshots.
+GitHub Actions runs the compiler suite, including the plugin manifest contract, executable Worthiness scenario fixtures, Decision Brief intake, 70-KPI Metric Router behavior, routed production compilation, grounded composite/no-score compilation, radar rendering, byte-level golden snapshots, and the standalone Claude Upload Skill packaging contract.
 
 ## What this is not
 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "scripts": {
     "test": "node --test tests/compiler/*.test.js",
+    "package:claude-skill": "node scripts/stage-claude-skill.mjs",
     "validate:saas": "node skills/decision-first-dashboard/scripts/validate.js examples/saas/input.no-score.json",
     "render:saas": "node skills/decision-first-dashboard/scripts/render.js examples/saas/input.no-score.json examples/saas",
     "validate:radar-showcase": "node skills/decision-first-dashboard/scripts/validate.js examples/radar-profile/input.no-score.json",

--- a/scripts/stage-claude-skill.mjs
+++ b/scripts/stage-claude-skill.mjs
@@ -1,0 +1,42 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const currentFile = fileURLToPath(import.meta.url);
+const repoRoot = path.resolve(path.dirname(currentFile), '..');
+const skillRoot = path.join(repoRoot, 'skills', 'decision-first-dashboard');
+const defaultOutDir = path.join(repoRoot, 'dist', 'claude-skill');
+const outDir = path.resolve(process.argv[2] ?? defaultOutDir);
+const packageEntries = ['SKILL.md', 'scripts', 'schemas', 'templates', 'references'];
+
+function copyEntry(entry) {
+  const source = path.join(skillRoot, entry);
+  const destination = path.join(outDir, entry);
+  if (!fs.existsSync(source)) {
+    throw new Error(`Required skill package entry is missing: ${entry}`);
+  }
+  fs.cpSync(source, destination, { recursive: true });
+}
+
+function assertClaudeUploadShape() {
+  const skillPath = path.join(outDir, 'SKILL.md');
+  if (!fs.existsSync(skillPath)) {
+    throw new Error('Claude upload package must contain SKILL.md at the package root');
+  }
+
+  const skill = fs.readFileSync(skillPath, 'utf8');
+  if (!/^---\nname:\s*decision-first-dashboard\ndescription:\s*.+\n---/s.test(skill)) {
+    throw new Error('Packaged SKILL.md must keep YAML name and description frontmatter');
+  }
+
+  if (fs.existsSync(path.join(outDir, '.claude-plugin'))) {
+    throw new Error('Claude skill upload package must not contain .claude-plugin');
+  }
+}
+
+fs.rmSync(outDir, { recursive: true, force: true });
+fs.mkdirSync(outDir, { recursive: true });
+for (const entry of packageEntries) copyEntry(entry);
+assertClaudeUploadShape();
+
+console.log(`Claude skill staged at ${outDir}`);

--- a/tests/compiler/claude-skill-package.test.js
+++ b/tests/compiler/claude-skill-package.test.js
@@ -1,0 +1,65 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const testDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(testDir, '../..');
+const packScript = path.join(repoRoot, 'scripts', 'stage-claude-skill.mjs');
+const workflowPath = path.join(repoRoot, '.github', 'workflows', 'compiler-tests.yml');
+const readmePath = path.join(repoRoot, 'README.md');
+
+function listRelativeFiles(root) {
+  const files = [];
+  const walk = (dir) => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const absolute = path.join(dir, entry.name);
+      if (entry.isDirectory()) walk(absolute);
+      else files.push(path.relative(root, absolute).replaceAll('\\\\', '/'));
+    }
+  };
+  walk(root);
+  return files.sort();
+}
+
+test('Claude upload package stages the skill with SKILL.md at ZIP root and no plugin manifest', () => {
+  assert.equal(fs.existsSync(packScript), true, 'expected scripts/stage-claude-skill.mjs to exist');
+
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'decision-first-claude-skill-'));
+  const outDir = path.join(tempRoot, 'skill');
+  const run = spawnSync(process.execPath, [packScript, outDir], {
+    cwd: repoRoot,
+    encoding: 'utf8'
+  });
+
+  assert.equal(run.status, 0, run.stderr || run.stdout);
+  assert.equal(fs.existsSync(path.join(outDir, 'SKILL.md')), true, 'SKILL.md must be at package root');
+  assert.equal(fs.existsSync(path.join(outDir, '.claude-plugin', 'plugin.json')), false);
+
+  const skillText = fs.readFileSync(path.join(outDir, 'SKILL.md'), 'utf8');
+  assert.match(skillText, /^---\nname:\s*decision-first-dashboard\ndescription:\s*.+\n---/s);
+
+  const files = listRelativeFiles(outDir);
+  assert.ok(files.some((file) => file.startsWith('scripts/')), 'scripts must be packaged');
+  assert.ok(files.some((file) => file.startsWith('schemas/')), 'schemas must be packaged');
+  assert.ok(files.some((file) => file.startsWith('templates/')), 'templates must be packaged');
+  assert.ok(files.some((file) => file.startsWith('references/')), 'references must be packaged');
+  assert.equal(files.some((file) => file.includes('.claude-plugin/')), false, 'plugin manifest must never enter skill upload package');
+});
+
+test('CI publishes a Claude-ready artifact instead of the whole repository ZIP', () => {
+  const workflow = fs.readFileSync(workflowPath, 'utf8');
+  assert.match(workflow, /npm run package:claude-skill/);
+  assert.match(workflow, /name:\s*decision-first-dashboard-skill/);
+  assert.match(workflow, /path:\s*dist\/claude-skill\//);
+});
+
+test('README tells Claude users to use the dedicated skill artifact, not GitHub Download ZIP', () => {
+  const readme = fs.readFileSync(readmePath, 'utf8');
+  assert.match(readme, /Claude.*Upload skill/is);
+  assert.match(readme, /decision-first-dashboard-skill/i);
+  assert.match(readme, /do not use.*Download ZIP/is);
+});

--- a/tests/compiler/claude-skill-package.test.js
+++ b/tests/compiler/claude-skill-package.test.js
@@ -18,7 +18,7 @@ function listRelativeFiles(root) {
     for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
       const absolute = path.join(dir, entry.name);
       if (entry.isDirectory()) walk(absolute);
-      else files.push(path.relative(root, absolute).replaceAll('\\\\', '/'));
+      else files.push(path.relative(root, absolute).split(path.sep).join('/'));
     }
   };
   walk(root);


### PR DESCRIPTION
Adds a dedicated Claude Upload Skill package so users can upload the skill to Claude without using the whole repository ZIP.

What changed:
- adds `scripts/stage-claude-skill.mjs` to stage only the standalone skill contents;
- keeps `SKILL.md` at the package root;
- includes `scripts/`, `schemas/`, `templates/`, and `references/`;
- excludes `.claude-plugin/plugin.json` by construction;
- adds `npm run package:claude-skill`;
- GitHub Actions now publishes a `decision-first-dashboard-skill` artifact that can be uploaded directly in Claude → Skills → Upload skill;
- README now warns not to use GitHub Download ZIP for the standalone Claude upload flow;
- adds regression tests for package shape and CI/docs contract.

TDD evidence:
- run #383 failed first on all three new packaging expectations;
- run #388 passed the full workflow after implementation;
- downloaded artifact was inspected: `SKILL.md` is at ZIP root and there are no `.claude-plugin` entries.