### PR TITLE
Make HTML the primary deliverable and default to soft attention

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,10 @@ Give your agent a dashboard screenshot, Figma frame, existing dashboard code, or
 
 The skill will first check whether a dashboard is the right format. If it is, it clarifies the decision if needed, routes the metrics, verifies source support, and renders the decision-first output.
 
+**HTML is the primary After deliverable** when file generation is available: use `output.no-score.html` or `output.composite.html` as the browser-openable redesigned dashboard. SVG remains the static preview/support artifact for README comparisons, review, and regression testing rather than the main user deliverable.
+
+Attention is intentionally restrained by default. Ordinary deterioration and routed exceptions stay visible through values, deltas, profile shape, and compact exception surfaces; large red warning banners, alarm icons, and `Action needed` / `Critical` / `Warning` language require explicit source-grounded alert semantics or an explicit user-supplied alert policy.
+
 <details>
 <summary><strong>Under the hood</strong></summary>
 
@@ -193,7 +197,8 @@ Composite output is allowed only when all score-model facts are mechanically gro
 - radar only for 3–6 comparable peer dimensions on one grounded scale;
 - no invented action buttons, targets, scores, weights, or thresholds;
 - active negative/critical exceptions cannot be cosmetically suppressed;
-- SVG and HTML consume the same validated decision state.
+- soft attention is the default; hard-alert treatment requires explicit source-grounded alert semantics;
+- SVG and HTML consume the same validated decision state, with HTML as the primary user-facing deliverable and SVG as preview/support output.
 
 ### Production path
 
@@ -221,8 +226,8 @@ node scripts/compile-dashboard.js path/to/worthiness-assessment.json path/to/rou
 Mode-specific outputs:
 
 ```text
-no_score   → output.no-score.svg / output.no-score.html
-composite  → output.composite.svg / output.composite.html
+no_score   → primary: output.no-score.html    | preview: output.no-score.svg
+composite  → primary: output.composite.html   | preview: output.composite.svg
 ```
 
 </details>
@@ -244,7 +249,7 @@ For Anthropic plugin packaging, validate the repository root with a current Clau
 claude plugin validate . --strict
 ```
 
-GitHub Actions runs the compiler suite, including the plugin manifest contract, executable Worthiness scenario fixtures, Decision Brief intake, 70-KPI Metric Router behavior, routed production compilation, grounded composite/no-score compilation, radar rendering, byte-level golden snapshots, and the standalone Claude Upload Skill packaging contract.
+GitHub Actions runs the compiler suite, including the plugin manifest contract, executable Worthiness scenario fixtures, Decision Brief intake, 70-KPI Metric Router behavior, routed production compilation, grounded composite/no-score compilation, radar rendering, byte-level golden snapshots, the HTML delivery/attention-intensity contract, and the standalone Claude Upload Skill packaging contract.
 
 ## What this is not
 

--- a/skills/decision-first-dashboard/SKILL.md
+++ b/skills/decision-first-dashboard/SKILL.md
@@ -300,6 +300,12 @@ On final `PASS`, the CLI writes:
 - `no_score` → `output.no-score.svg` and `output.no-score.html`;
 - `composite` → `output.composite.svg` and `output.composite.html`.
 
+### Primary delivery contract
+
+The **primary After deliverable is HTML** whenever file generation is available. Present or link `output.no-score.html` or `output.composite.html` first so the redesigned dashboard is an actual browser-openable interface rather than only a design image.
+
+SVG remains the deterministic **preview** and regression/support artifact for README comparisons, static review, and snapshot testing. A screenshot, PNG, SVG, mockup, or concept image alone does not complete an ordinary dashboard redesign when the HTML renderer is available. Do not regenerate a separate free-form image as the “real” After after deterministic HTML has been rendered.
+
 `worthiness.js` is the lower-level Worthiness evaluator. `compile.js` remains the lower-level grounding-only compiler for tests and internal compatibility. `validate.js` and `render.js` remain lower-level Layer 2 / Layer 3 tools. Do not use these lower-level entry points as a substitute for `compile-dashboard.js` in ordinary Decision-First production workflows.
 
 ### 9. Follow failure transitions literally
@@ -342,6 +348,9 @@ For both modes:
 - product-native labels only;
 - no compiler/framework methodology labels in visible UI;
 - restrained color and generous whitespace;
+- **soft attention is the default** for ordinary deterioration and business exceptions;
+- a **hard alert** treatment requires **explicit source-grounded** alert severity, a breached source threshold, a hard-stop condition, or an explicit user-supplied alert policy;
+- routing something to `exception` requires visibility but does not by itself authorize a large red banner, alarm icon, exclamation badge, or alarm language such as `Action needed`, `Critical`, or `Warning`;
 - negative or critical states may not be cosmetically suppressed;
 - hidden diagnostic/drilldown/scorecard routes are not rendered eagerly.
 
@@ -369,6 +378,7 @@ Before delivery, verify:
 - every `primary_signal` passes the Action Trigger Test and the visible center matches the primary set exactly;
 - diagnostics explain routed primary/exception items rather than competing as peer headlines;
 - active exceptions cannot be hidden and every active exception has a valid rendered `surfacePath`;
+- ordinary exceptions use restrained soft-attention styling unless hard-alert intensity is explicitly grounded;
 - the first-view information budget is respected instead of shrinking typography or adding equal-weight KPI cards;
 - the grounded-bundle schema passes;
 - source SHA-256 matches actual source bytes;
@@ -380,5 +390,6 @@ Before delivery, verify:
 - `composite` weights, weighted score, score scale, and score band pass semantic validation;
 - no unsupported score/status/target/action appears;
 - no framework or compiler labels leak into visible UI;
+- when file delivery is available, HTML is presented as the primary After deliverable and SVG is treated as preview/support output;
 - the center is the first focal point;
 - outputs contain no unresolved template tokens.

--- a/skills/decision-first-dashboard/references/visual-pattern.md
+++ b/skills/decision-first-dashboard/references/visual-pattern.md
@@ -141,6 +141,18 @@ Delta **color** communicates business favorability and must use the grounded sig
 - Radar scale, current normalized values, and any previous-period normalized values must be grounded.
 - Visual depth, ambient fields, cards, and connection lines are presentation only. They do not create evidence or business semantics.
 
+## Attention intensity
+
+**Soft attention is the default** for ordinary business deterioration and exceptions. Visibility and visual intensity are separate decisions.
+
+- A routed `exception` must be surfaced, but the exception role **does not by itself authorize a hard alert** treatment.
+- Prefer compact exception cards, small semantic red/amber accents, source-backed status text, delta arrows, and profile contraction/imbalance for ordinary deterioration.
+- A **hard alert requires explicit source-grounded alert semantics**, such as a source-defined critical/warning state, a breached source threshold, a safety/compliance/security/regulatory/contractual/outage hard stop, or an explicit user-supplied alert policy.
+- Without that support, do not introduce a **large red background**, red banner, **alarm icon**, exclamation badge, or alarm language such as `Action needed`, `Critical`, `Warning`, or equivalent.
+- Do not confuse restrained presentation with suppression: active exceptions remain visible, but their visual intensity must match the evidence.
+
+This keeps executive-facing views calm enough to scan while still surfacing real problems. The shape, concrete values, direction arrows, and compact exception treatment should carry ordinary warning meaning before alarm-style UI is considered.
+
 ## Product language
 
 Use product-native labels from the source domain. Fixed labels should be neutral and subordinate to source-grounded content.

--- a/tests/compiler/delivery-visual-contract.test.js
+++ b/tests/compiler/delivery-visual-contract.test.js
@@ -1,0 +1,29 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const testDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(testDir, '../..');
+const skill = fs.readFileSync(path.join(repoRoot, 'skills', 'decision-first-dashboard', 'SKILL.md'), 'utf8');
+const visual = fs.readFileSync(path.join(repoRoot, 'skills', 'decision-first-dashboard', 'references', 'visual-pattern.md'), 'utf8');
+const readme = fs.readFileSync(path.join(repoRoot, 'README.md'), 'utf8');
+
+test('HTML is the primary After deliverable and SVG is a preview/support artifact', () => {
+  assert.match(skill, /primary After deliverable.*HTML/is);
+  assert.match(skill, /SVG.*preview/is);
+  assert.match(readme, /HTML.*primary.*deliverable/is);
+});
+
+test('soft attention is the default and hard alerts require explicit source-grounded alert semantics', () => {
+  assert.match(skill, /soft attention.*default/is);
+  assert.match(skill, /hard alert.*explicit.*source/is);
+  assert.match(visual, /soft attention.*default/is);
+  assert.match(visual, /hard alert.*explicit.*source/is);
+});
+
+test('a routed exception alone does not authorize alarm-heavy visual treatment', () => {
+  assert.match(visual, /exception.*does not.*authorize.*hard alert/is);
+  assert.match(visual, /large red.*background|red banner|alarm icon/is);
+});


### PR DESCRIPTION
Makes HTML the primary user-facing After deliverable and separates exception visibility from alarm intensity.

What changed:
- `output.no-score.html` / `output.composite.html` are now the primary After deliverables when file generation is available;
- SVG remains a deterministic preview/regression/support artifact;
- ordinary deterioration and business exceptions default to soft attention;
- routing an item to `exception` requires visibility but does not by itself authorize alarm-heavy UI;
- large red backgrounds/banners, alarm icons, exclamation badges, or `Action needed` / `Critical` / `Warning` language require explicit source-grounded alert semantics, a grounded hard-stop/threshold breach, or an explicit user alert policy;
- safety/compliance/security/regulatory/contractual/outage hard stops remain unsuppressible;
- README and visual reference now document the same delivery/intensity contract;
- adds regression tests so these rules cannot silently drift.

TDD evidence:
- run #390 failed first: 148/151 passed, with exactly the 3 new delivery/attention contract tests failing;
- after implementation, run #393 passed the full workflow, including all tests, validations, renders, grounded compile fixtures, and Claude skill packaging.