### PR TITLE
Enforce intake and canonical output provenance

### DIFF
--- a/.github/workflows/compiler-tests.yml
+++ b/.github/workflows/compiler-tests.yml
@@ -42,10 +42,21 @@ jobs:
         run: node skills/decision-first-dashboard/scripts/compile.js tests/compiler/fixtures/grounding/no-score.grounded.json tests/compiler/generated/v3-no-score
       - name: Evaluate dashboard worthiness fixture
         run: node skills/decision-first-dashboard/scripts/worthiness.js tests/compiler/fixtures/worthiness/dashboard.worthiness.json
+      - name: Evaluate confirmed Decision Brief fixture
+        run: node skills/decision-first-dashboard/scripts/intake.js tests/compiler/fixtures/intake/confirmed.decision-brief.json
+      - name: Evaluate ambiguous agent first-turn fixture
+        run: node skills/decision-first-dashboard/scripts/agent-eval.js tests/compiler/fixtures/agent-eval/sales-dashboard-ambiguous.eval.json tests/compiler/fixtures/agent-eval/sales-dashboard-good-first-turn.json
+      - name: Assert native-artifact bypass fixture is rejected
+        shell: bash
+        run: |
+          if node skills/decision-first-dashboard/scripts/agent-eval.js tests/compiler/fixtures/agent-eval/sales-dashboard-ambiguous.eval.json tests/compiler/fixtures/agent-eval/sales-dashboard-bad-first-turn.json; then
+            echo "Expected native-artifact bypass fixture to fail" >&2
+            exit 1
+          fi
       - name: Compile routed composite fixture
-        run: node skills/decision-first-dashboard/scripts/compile-dashboard.js tests/compiler/fixtures/worthiness/dashboard.worthiness.json tests/compiler/fixtures/routing/composite.routing.json tests/compiler/fixtures/grounding/composite.grounded.json tests/compiler/generated/routed-composite
+        run: node skills/decision-first-dashboard/scripts/compile-dashboard.js tests/compiler/fixtures/worthiness/dashboard.worthiness.json tests/compiler/fixtures/intake/composite-confirmed.decision-brief.json tests/compiler/fixtures/routing/composite.routing.json tests/compiler/fixtures/grounding/composite.grounded.json tests/compiler/generated/routed-composite
       - name: Compile routed no-score fixture
-        run: node skills/decision-first-dashboard/scripts/compile-dashboard.js tests/compiler/fixtures/worthiness/dashboard.worthiness.json tests/compiler/fixtures/routing/no-score.routing.json tests/compiler/fixtures/grounding/no-score.grounded.json tests/compiler/generated/routed-no-score
+        run: node skills/decision-first-dashboard/scripts/compile-dashboard.js tests/compiler/fixtures/worthiness/dashboard.worthiness.json tests/compiler/fixtures/intake/confirmed.decision-brief.json tests/compiler/fixtures/routing/no-score.routing.json tests/compiler/fixtures/grounding/no-score.grounded.json tests/compiler/generated/routed-no-score
       - name: Stage Claude Upload Skill package
         run: npm run package:claude-skill
       - uses: actions/upload-artifact@v4
@@ -69,5 +80,7 @@ jobs:
             tests/compiler/generated/v3-no-score/output.no-score.html
             tests/compiler/generated/routed-composite/output.composite.svg
             tests/compiler/generated/routed-composite/output.composite.html
+            tests/compiler/generated/routed-composite/output.manifest.json
             tests/compiler/generated/routed-no-score/output.no-score.svg
             tests/compiler/generated/routed-no-score/output.no-score.html
+            tests/compiler/generated/routed-no-score/output.manifest.json

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ The After showcase uses five source-backed percentage dimensions on one 0–100 
 
 You don't need to know the perfect KPI set or chart type first.
 
-The skill first checks whether a persistent dashboard is warranted. If it is, it asks only enough questions to understand the decision and what action could change. Then it routes the available metrics by role instead of putting everything on the first screen.
+The skill first checks whether a persistent dashboard is warranted. If it is, it asks only enough questions to understand the decision and what action could change. **Decision and Action must be explicitly confirmed before routing or rendering can proceed.** Then it routes the available metrics by role instead of putting everything on the first screen.
 
 A source can contain 70 valid KPIs without becoming a 70-KPI dashboard.
 
@@ -131,7 +131,11 @@ Give your agent a dashboard screenshot, Figma frame, existing dashboard code, or
 
 The skill will first check whether a dashboard is the right format. If it is, it clarifies the decision if needed, routes the metrics, verifies source support, and renders the decision-first output.
 
-**HTML is the primary After deliverable** when file generation is available: use `output.no-score.html` or `output.composite.html` as the browser-openable redesigned dashboard. SVG remains the static preview/support artifact for README comparisons, review, and regression testing rather than the main user deliverable.
+An ambiguous prompt such as “redesign this dashboard” is **not render permission**. A screenshot can establish source facts, but it cannot silently confirm the user's Decision or Action. If either is unresolved, the machine intake gate returns `ASK_DECISION_BRIEF_QUESTION` and no dashboard artifact is produced.
+
+**HTML is the primary After deliverable** when file generation is available: use the canonical `output.no-score.html` or `output.composite.html` written by `compile-dashboard.js`. SVG remains the static preview/support artifact for README comparisons, review, and regression testing rather than the main user deliverable.
+
+The canonical compiler also writes `output.manifest.json` and stamps the HTML/SVG with machine-verifiable provenance. A second agent-authored HTML, image, SVG, React app, or native artifact is not the canonical After merely because it looks better.
 
 Attention is intentionally restrained by default. Ordinary deterioration and routed exceptions stay visible through values, deltas, profile shape, and compact exception surfaces; large red warning banners, alarm icons, and `Action needed` / `Critical` / `Warning` language require explicit source-grounded alert semantics or an explicit user-supplied alert policy.
 
@@ -153,15 +157,25 @@ REDIRECT_NON_DASHBOARD
 FIX_WORTHINESS_ASSESSMENT
 ```
 
-If the request is only “visibility” or is better handled as a one-off analysis, scheduled summary, alert, report, or chat/query workflow, dashboard rendering stops by default. If the user explicitly chooses a dashboard after seeing that trade-off, `userOverride: true` can continue to the Decision Brief — but it still must pass routing and grounding.
+If the request is only “visibility” or is better handled as a one-off analysis, scheduled summary, alert, report, or chat/query workflow, dashboard rendering stops by default. If the user explicitly chooses a dashboard after seeing that trade-off, `userOverride: true` can continue to the Decision Brief — but it still must pass intake, routing, and grounding.
 
-This machine gate checks schema and internal semantic consistency. **It does not prove the agent interpreted the user's natural-language intent correctly.** A separate end-to-end agent eval suite is still needed to measure model behavior on raw prompts.
+This machine gate checks schema and internal semantic consistency. **It does not prove the agent interpreted the user's natural-language intent correctly.** Live host/model behavior still requires end-to-end evaluation.
 
 Any Worthiness questions count toward the same five-question intake budget as the Decision Brief; this is not a second questionnaire.
 
-### Adaptive Decision Brief
+### Adaptive Decision Brief + machine intake gate
 
-The skill asks one question at a time, no more than five total across Worthiness + Decision Brief intake, and stops as soon as it has enough confirmed context. Source facts can suggest intent, but they do not silently become business intent. Unless Decision + Action are already explicit, the skill asks for confirmation before routing or rendering.
+The skill asks one question at a time, no more than five total across Worthiness + Decision Brief intake, and stops as soon as it has enough confirmed context. Source facts can suggest intent, but they do not silently become business intent.
+
+The structured Decision Brief matches `schemas/decision-brief.schema.json`. `scripts/intake.js` requires both `decision.status` and `action.status` to be `confirmed` before routing is allowed:
+
+```text
+ALLOW_ROUTING
+ASK_DECISION_BRIEF_QUESTION
+FIX_DECISION_BRIEF
+```
+
+An inferred Decision or Action is not equivalent to confirmation. The routing manifest must also preserve the confirmed Decision and Action wording; changing either downstream is a routing failure.
 
 ### Metric Router
 
@@ -169,17 +183,21 @@ The Action Trigger Test asks: **if this metric changes materially, what decision
 
 The routing manifest preserves the complete extracted inventory while keeping only the minimum sufficient first-view signals visible. Active exceptions cannot be hidden to make the dashboard look healthier.
 
-### Three production gates
+### Four production gates
 
-The production compiler has three ordered gates:
+The canonical production compiler has four ordered gates:
 
 1. **Worthiness gate** — validates the structured Worthiness Assessment and decides whether to continue, clarify, redirect, or repair the assessment.
-2. **Routing gate** — verifies metric-routing semantics.
-3. **Grounding gate** — verifies that rendered source claims resolve back to source evidence.
+2. **Intake gate** — validates the Decision Brief and blocks routing until Decision + Action are confirmed.
+3. **Routing gate** — verifies metric-routing semantics and exact binding to the confirmed Decision + Action.
+4. **Grounding gate** — verifies that rendered source claims resolve back to source evidence.
 
-Downstream transitions remain:
+Downstream transitions include:
 
 ```text
+ALLOW_ROUTING
+ASK_DECISION_BRIEF_QUESTION
+FIX_DECISION_BRIEF
 PASS
 FIX_METRIC_ROUTING
 RETURN_TO_EVIDENCE_EXTRACTION
@@ -188,6 +206,14 @@ FIX_DECISION_STATE
 ```
 
 Composite output is allowed only when all score-model facts are mechanically grounded. Screenshot workflows should first create a verifiable text/JSON sidecar for claims that need byte-level grounding.
+
+### Canonical output provenance
+
+A successful `compile-dashboard.js` run stamps the final HTML with canonical renderer metadata and embeds a provenance record in the SVG. It also writes `output.manifest.json` containing hashes for the source, Worthiness Assessment, Decision Brief, routing manifest, grounded bundle, decision state, HTML, and SVG.
+
+This turns “does this look like our renderer?” into a machine-verifiable question. If a final artifact does not have canonical provenance, it is not the canonical Decision-First After.
+
+The repository also includes a recorded agent E2E regression based on a real ambiguous Sales Dashboard prompt. The passing first turn asks one question for missing decision context; a native artifact that skips intake is rejected. This is a deterministic recorded-turn contract, not a live model benchmark.
 
 ### Visual rules
 
@@ -206,7 +232,8 @@ Composite output is allowed only when all score-model facts are mechanically gro
 User context
 → structured Worthiness Assessment
 → worthiness validation
-→ Decision Brief
+→ structured Decision Brief
+→ intake validation
 → evidence extraction
 → Metric Router
 → no_score / composite decision
@@ -214,13 +241,15 @@ User context
 → routing validation
 → grounding validation
 → deterministic render
+→ canonical HTML / SVG + output.manifest.json
 ```
 
 From the skill directory:
 
 ```bash
 node scripts/worthiness.js path/to/worthiness-assessment.json
-node scripts/compile-dashboard.js path/to/worthiness-assessment.json path/to/routing-manifest.json path/to/grounded-bundle.json path/to/output-directory
+node scripts/intake.js path/to/decision-brief.json
+node scripts/compile-dashboard.js path/to/worthiness-assessment.json path/to/decision-brief.json path/to/routing-manifest.json path/to/grounded-bundle.json path/to/output-directory
 ```
 
 Mode-specific outputs:
@@ -228,6 +257,7 @@ Mode-specific outputs:
 ```text
 no_score   → primary: output.no-score.html    | preview: output.no-score.svg
 composite  → primary: output.composite.html   | preview: output.composite.svg
+both       → audit: output.manifest.json
 ```
 
 </details>
@@ -249,13 +279,13 @@ For Anthropic plugin packaging, validate the repository root with a current Clau
 claude plugin validate . --strict
 ```
 
-GitHub Actions runs the compiler suite, including the plugin manifest contract, executable Worthiness scenario fixtures, Decision Brief intake, 70-KPI Metric Router behavior, routed production compilation, grounded composite/no-score compilation, radar rendering, byte-level golden snapshots, the HTML delivery/attention-intensity contract, and the standalone Claude Upload Skill packaging contract.
+GitHub Actions runs the compiler suite, including the plugin manifest contract, executable Worthiness scenario fixtures, the machine Decision Brief intake gate, the recorded ambiguous-prompt agent E2E contract, 70-KPI Metric Router behavior, canonical provenance, routed production compilation, grounded composite/no-score compilation, radar rendering, byte-level golden snapshots, the HTML delivery/attention-intensity contract, and the standalone Claude Upload Skill packaging contract.
 
 ## What this is not
 
 This is not a generic chart library and not a prompt that asks AI to freestyle a prettier admin dashboard.
 
-It is a decision-first workflow with worthiness, routing, evidence checks, and deterministic rendering so the output is useful **and** auditable.
+It is a decision-first workflow with worthiness, intake, routing, evidence checks, canonical provenance, and deterministic rendering so the output is useful **and** auditable.
 
 ## License
 

--- a/skills/decision-first-dashboard/SKILL.md
+++ b/skills/decision-first-dashboard/SKILL.md
@@ -7,13 +7,25 @@ description: Use when redesigning KPI-heavy dashboards where users must scan mul
 
 ## Core principle
 
-Separate agent judgment from compiler judgment and deterministic rendering.
+Decision-First does not mean Minimal-Data. Preserve rich evidence, create strong hierarchy, and expose only justified meaning.
 
-**Source / context → Worthiness Assessment → worthiness gate → Decision Brief → Metric Routing Manifest → grounded evidence bundle → routing + grounding gates → deterministic renderer → SVG / HTML**
+**Source / context → Worthiness Assessment → worthiness gate → Decision Brief → intake gate → Metric Routing Manifest → grounded evidence bundle → routing + grounding gates → deterministic renderer → canonical HTML / SVG + output.manifest.json**
 
-The agent may assess whether a dashboard is warranted, clarify decision intent, extract and classify evidence, and propose routing. It may not invent source support, bypass worthiness/routing/grounding gates, or choose a free-form dashboard layout during ordinary compilation.
+The agent may assess whether a dashboard is warranted, clarify decision intent, extract and classify evidence, and propose routing. It may not invent source support, bypass worthiness/intake/routing/grounding gates, or choose a free-form dashboard layout during ordinary compilation.
 
 A dashboard earns first-view screen space only when the information can change a decision, trigger an action, surface an exception, explain a primary signal, or support deliberate drill-down.
+
+## Mandatory execution contract
+
+This contract applies whenever the skill is actually invoked for a dashboard redesign.
+
+1. **Do not render before intake passes.** A screenshot, dataset, title, KPI mix, or domain pattern may establish source facts but cannot by itself confirm business intent. If Decision or Action is not explicitly confirmed, stop and ask one question. Do not generate an image, HTML, SVG, React app, dashboard artifact, Key Insights, or action recommendations first.
+2. **The agent must not render UI.** The agent prepares structured inputs; `compile-dashboard.js` owns canonical production delivery.
+3. **No free-form fallback.** If the runtime cannot execute the production scripts, stop at the unresolved question or structured state. Do not substitute an agent-authored dashboard.
+4. **Canonical After means exact compiler output.** The primary After is the HTML bytes written by `compile-dashboard.js`. Do not treat that HTML as a reference and redraw it afterward.
+5. **Require provenance.** Canonical HTML/SVG must carry the compiler provenance markers and the run must emit `output.manifest.json`. A visually similar artifact without canonical provenance is not the official Decision-First output.
+
+Host-level skill discovery is outside the repository's control. A generic product request may still fail to invoke an installed skill in some environments; measure that separately with live product tests. Once this skill is invoked, the execution contract above is mandatory.
 
 ## Three layers
 
@@ -22,7 +34,7 @@ A dashboard earns first-view screen space only when the information can change a
 The agent may:
 
 - produce a structured Worthiness Assessment from explicit user/context evidence;
-- build an adaptive Decision Brief from user context and source structure;
+- build a structured adaptive Decision Brief;
 - extract literal source facts;
 - classify every extracted metric with the Metric Router;
 - produce a Metric Routing Manifest;
@@ -33,376 +45,300 @@ The agent must not render UI, fabricate score-model evidence, or decide its own 
 
 ### Layer 2 — Compiler contract
 
-Code decides whether worthiness, routing, and grounding can proceed.
-
 The production compiler validates, in order:
 
-1. the Worthiness Assessment against `schemas/worthiness-assessment.schema.json` plus its semantic consistency rules;
-2. the Metric Routing Manifest and its semantic rules;
-3. exact agreement between routed `primary_signal` metrics and the visible center metrics/components;
-4. exact agreement between no-score diagnostics routed as supporting and `decisionState.supportingSignals`;
-5. active-exception surfacing rules;
-6. the closed grounded-bundle contract;
-7. the closed `decision-state` contract;
-8. source file SHA-256;
-9. evidence reference integrity;
-10. exact JSON Pointer or text-span grounding;
-11. required claim coverage;
-12. composite score mathematics and score-band semantics.
+1. Worthiness Assessment against `schemas/worthiness-assessment.schema.json` plus semantic consistency rules;
+2. Decision Brief against `schemas/decision-brief.schema.json`;
+3. confirmed Decision + Action before routing, plus exact binding into the routing manifest;
+4. Metric Routing Manifest against `schemas/metric-routing.schema.json` and semantic rules;
+5. exact agreement between routed `primary_signal` metrics and visible center metrics/components;
+6. exact agreement between no-score diagnostics routed as supporting and `decisionState.supportingSignals`;
+7. active-exception surfacing rules;
+8. the closed grounded-bundle and decision-state contracts;
+9. source SHA-256, evidence integrity, exact JSON Pointer/text-span grounding, and required claim coverage;
+10. composite score mathematics and score-band semantics.
 
-Worthiness transitions are:
+Worthiness transitions:
 
-- `BUILD_DECISION_BRIEF`;
-- `ASK_WORTHINESS_QUESTION`;
-- `REDIRECT_NON_DASHBOARD`;
-- `FIX_WORTHINESS_ASSESSMENT`.
+- `BUILD_DECISION_BRIEF`
+- `ASK_WORTHINESS_QUESTION`
+- `REDIRECT_NON_DASHBOARD`
+- `FIX_WORTHINESS_ASSESSMENT`
 
-Downstream machine-readable transitions remain:
+Decision Brief intake transitions:
 
-- `PASS`;
-- `FIX_METRIC_ROUTING`;
-- `RETURN_TO_EVIDENCE_EXTRACTION`;
-- `FALLBACK_TO_NO_SCORE`;
-- `FIX_DECISION_STATE`.
+- `ALLOW_ROUTING`
+- `ASK_DECISION_BRIEF_QUESTION`
+- `FIX_DECISION_BRIEF`
+
+Downstream transitions:
+
+- `PASS`
+- `FIX_METRIC_ROUTING`
+- `RETURN_TO_EVIDENCE_EXTRACTION`
+- `FALLBACK_TO_NO_SCORE`
+- `FIX_DECISION_STATE`
 
 ### Layer 3 — Deterministic renderer
 
-`render.js` consumes only validated decision state and fills fixed SVG/HTML templates. It does not inspect the hidden routing inventory, source data, or invent business meaning.
+`render.js` consumes only validated decision state and fills deterministic SVG/HTML compositions. It does not inspect hidden routing inventory, source data, or invent business meaning.
 
-Keeping hidden routing inventory out of the renderer is intentional: `drilldown`, `scorecard_only`, and diagnostics routed `on_demand` stay preserved for traceability without becoming hidden DOM, eager chart work, or first-view clutter. Only diagnostics explicitly routed with `visibility: "supporting"` may enter the closed `supportingSignals` decision-state layer and render as subordinate context.
+`drilldown`, `scorecard_only`, and diagnostics routed `on_demand` remain preserved for traceability without becoming eager first-view clutter. Only diagnostics explicitly routed with `visibility: "supporting"` may enter the closed `supportingSignals` layer and render as subordinate context.
 
 ## Workflow
 
 ### 1. Run the Dashboard Worthiness Test
 
-Before starting the Decision Brief or committing to dashboard output, ask whether the request deserves to become a persistent dashboard at all. This is a lightweight preflight, not a separate questionnaire: reuse context already supplied, ask one question at a time only when needed, and count any worthiness questions toward the same **five-question total intake budget** used by the Decision Brief.
+Before starting the Decision Brief or committing to dashboard output, ask whether the request deserves to become a persistent dashboard at all. Reuse context already supplied, ask one question at a time only when needed, and count Worthiness questions toward the same **five-question total intake budget** used by the Decision Brief.
 
-A dashboard is justified when the workflow has a real recurring decision or recurring monitoring loop, a clear **accountability path**, and a meaningful response that changes when an important signal changes. An accountability path may be a single owner, an on-call team, a distributed responsible team, or a recurring shared decision forum such as a board or cross-functional review. A monitoring dashboard can qualify when a recurring exception changes attention, escalation, or intervention.
+A dashboard is justified when the workflow has a real recurring decision or recurring monitoring loop, a clear **accountability path**, and a meaningful response that changes when an important signal changes. An accountability path may be a single owner, an on-call team, a distributed responsible team, or a recurring **shared decision forum**.
 
 Use three tests:
 
-1. **Recurring Loop Test** — is there a recurring decision, review, or exception-monitoring loop rather than a one-off question?
-2. **Accountability Path Test** — is there an identifiable person, team, or shared forum accountable for responding to the result?
-3. **Response Change Test** — when a material signal changes, does an action, priority, escalation, intervention, or coordination change?
+1. **Recurring Loop Test** — recurring decision, review, or exception-monitoring loop rather than a one-off question.
+2. **Accountability Path Test** — identifiable person, team, or shared forum accountable for responding.
+3. **Response Change Test** — when a material signal changes, an action, priority, escalation, intervention, or coordination changes.
 
-**“Visibility” alone is not a decision and is not sufficient justification for a dashboard.** Wanting to feel informed, copy an old report, or fill a reporting slot does not automatically pass the test. Shared visibility can still be legitimate when it belongs to a recurring accountable forum and changes coordination or priorities.
+**Visibility alone is not a decision and is not sufficient justification for a dashboard.**
 
-The agent must express the judgment as a structured assessment matching:
+The compiler, not the agent, determines the transition. If the request fails the Worthiness Test, **do not build or render a dashboard** by default. Recommend the smallest fitting alternative such as a **one-off analysis**, **scheduled summary**, **alert**, **report**, or **chat/query** workflow.
 
-`schemas/worthiness-assessment.schema.json`
+If the user explicitly chooses a dashboard after seeing that trade-off, `userOverride: true` may enter the Decision Brief, but it does not bypass intake, Metric Router, grounding, or rendering contracts.
 
-The assessment records `purpose`, `decisionLoop`, `accountability`, `responseChange`, `recommendedFormat`, and optional `userOverride`. Status fields distinguish `confirmed`, `inferred`, and `absent` instead of letting uncertainty silently become fact.
-
-The compiler, not the agent, determines the transition:
-
-- confirmed recurring loop + confirmed accountability path + confirmed response change → `BUILD_DECISION_BRIEF`;
-- inferred or unclear worthiness → `ASK_WORTHINESS_QUESTION`;
-- visibility-only, one-off, or otherwise non-recurring requests → `REDIRECT_NON_DASHBOARD` with a concrete non-dashboard `recommendedFormat`;
-- malformed or contradictory assessments → `FIX_WORTHINESS_ASSESSMENT`.
-
-If the request fails the Worthiness Test, **do not build or render a dashboard by default**. Explain the mismatch briefly and recommend the smallest format that fits the actual job, such as a **one-off analysis**, **scheduled summary**, **alert**, **report**, or **chat/query** workflow. Do not continue into Metric Routing or deterministic rendering merely because the user originally asked for a dashboard.
-
-If the user explicitly chooses a dashboard after seeing that trade-off, record `userOverride: true` and `recommendedFormat: "dashboard"`. That explicit user override may enter the Decision Brief, but it does **not** bypass Metric Router, grounding, evidence, or rendering contracts. The agent may not set `userOverride` merely to avoid a redirect.
-
-Worthiness is design context, not source evidence. The machine gate verifies the assessment's schema and internal semantic consistency; it **does not prove the agent interpreted the user's natural-language intent correctly**. End-to-end model behavior therefore still requires a separate agent scenario/eval layer.
+Worthiness is design context, not source evidence. The machine gate verifies schema and semantic consistency; it does not prove the agent interpreted natural-language intent correctly.
 
 ### 2. Build an adaptive Decision Brief
 
-Before routing metrics or choosing a visual mode, establish the minimum decision context needed to design the dashboard. Tell the user briefly that better dashboard design requires a few questions. Ask **one question at a time**, ask **no more than five questions total across Worthiness + Decision Brief intake**, and **stop immediately once enough information** exists to route metrics and make a defensible design decision.
+Before routing metrics or choosing a visual mode, establish the minimum decision context needed to design the dashboard. Ask **one question at a time**, ask **no more than five questions** total across Worthiness + Decision Brief intake, and **stop immediately once enough information** exists.
 
-**Intent-confirmation gate:** a screenshot, uploaded dataset, dashboard title, visible KPI mix, domain pattern, or source structure can establish data facts and suggest candidate intent, but a **screenshot alone cannot satisfy the Decision Brief**. Unless the user has **explicitly stated both the Decision and the Action** in the request or prior conversation, ask **at least one question** and obtain user confirmation before Metric Router classification or rendering.
+**Intent-confirmation gate:** a **screenshot cannot satisfy the Decision Brief** by itself. Unless the user has **explicitly stated both the Decision and the Action** in the request or prior conversation, ask **at least one question** and obtain confirmation before Metric Router classification or rendering.
 
-The five intake dimensions are a question pool, not a fixed questionnaire:
+The intake dimensions are a question pool, not a fixed questionnaire:
 
-- **Decision** — what should the dashboard help the user determine?
+- **Decision** — what should the dashboard help determine?
 - **Action** — what decision or action changes when an important signal changes?
 - **Exception** — what condition deserves immediate attention?
 - **Diagnosis** — where should the user investigate next after a problem appears?
-- **Audience / cadence** — who uses the dashboard, how quickly must they understand it, and how often is it reviewed?
+- **Audience / cadence** — who uses it, how quickly, and how often?
 
-Use two notions of “known”:
+Use two notions of known:
 
-- **Observed source fact** — directly visible or mechanically extracted from source. Never ask the user to repeat source facts already present in the request, prior answers, or source structure.
-- **Business intent** — Decision, Action, exception policy, diagnosis priority, and audience/cadence. This is confirmed only when explicitly supplied by the user or confirmed by the user after the agent proposes an inferred candidate.
+- **Observed source fact** — directly visible or mechanically extracted. **Never ask the user to repeat source facts** already available.
+- **Business intent** — Decision, Action, exception policy, diagnosis priority, and audience/cadence. It is confirmed only when explicitly supplied or explicitly confirmed by the user.
 
-An **inferred candidate requires confirmation**. It may make the next question easier, but it does not count as a completed Decision Brief until the user responds. Do not use “inferable from the data” as a reason to skip confirmation of business intent.
+An **inferred candidate requires confirmation**. Do not use **“inferable from the data”** to **skip confirmation** of **business intent**.
 
-After every answer, run an information-sufficiency check. If the confirmed Decision, confirmed Action, and relevant Exception, Diagnosis, or Audience context provide enough information for routing, stop. Do not ask all five questions merely for completeness.
-
-The zero-question path is narrow: use it only when the user's request or already-established conversation context explicitly states both what the dashboard should help decide and what action/prioritization changes based on that decision, and the Worthiness Test can also be resolved from already-established context. Source data by itself never qualifies.
+After each answer, evaluate sufficiency. The zero-question path is narrow: use it only when the user's request or already-established context explicitly states both Decision and Action and Worthiness is already resolved. Source data alone never qualifies.
 
 If the user is unsure:
 
-1. reduce the open question to **2–4 concrete choices** grounded in known context;
-2. include an explicit “I'm not sure — help me decide” path;
-3. if uncertainty remains, **infer the most defensible answer from the data** and **ask for confirmation**;
-4. if the data cannot support a defensible inference, leave that dimension unresolved and proceed conservatively.
+1. offer **2–4 concrete choices** grounded in known context;
+2. include an “I'm not sure — help me decide” path;
+3. **infer the most defensible answer from the data** only as a candidate and **ask for confirmation**;
+4. otherwise leave the dimension unresolved.
 
-**Do not invent a threshold.** Use only source-backed targets, historical ranges, peer baselines, or explicit rules when they exist.
+**Do not invent a threshold.**
 
 Support both intake orders:
 
-- **data-first** — **profile the uploaded data before asking**. Identify fields, metrics, dimensions, time range, targets/benchmarks, and evidence gaps; then ask only for missing decision context.
-- **question-first** — clarify the decision context first, then **request only the data needed** to support that decision, its diagnosis path, relevant exceptions, and evidence mode.
+- **data-first** — **profile the uploaded data before asking**, then ask only for missing decision context;
+- **question-first** — clarify decision context first, then **request only the data needed**.
 
-The Decision Brief is internal design context. It may guide routing and information hierarchy, but it is not automatically source evidence.
+The Decision Brief is internal design context. It is not automatically source evidence and **no compiler/framework methodology labels in visible UI** are permitted.
+
+The structured brief must match `schemas/decision-brief.schema.json`. `scripts/intake.js` requires both Decision and Action to have `status: "confirmed"`. Otherwise the pipeline returns `ASK_DECISION_BRIEF_QUESTION` and produces no dashboard artifact.
 
 ### 3. Extract verified facts only
 
-Identify the primary user and decision from the Decision Brief, then capture only source-supported metrics, deltas, account states, events, targets, thresholds, and score rules.
-
-Never invent scores, targets, thresholds, customer states, events, workflows, actions, or causal claims. Direction is not the same as health.
+Capture only source-supported metrics, deltas, states, events, targets, thresholds, and score rules. Never invent scores, targets, thresholds, customer states, events, workflows, actions, or causal claims. Direction is not the same as health.
 
 ### 4. Route every extracted metric
 
-Use the **Metric Router** whenever the source exposes more metrics than a user can reasonably scan at first view. The canonical stress case is **70-KPI overload**: a source may contain roughly 70 valid KPIs, but validity does not make every KPI a first-view peer.
+Use the **Metric Router** when the source exposes more metrics than a user can reasonably scan at first view. The canonical stress case is **70-KPI overload**.
 
 > **Preserve everything without showing everything.**
 
-Preserve the full extracted metric inventory in a separate routing manifest. The manifest must match:
+The routing manifest must match `schemas/metric-routing.schema.json`. It contains the confirmed `decision`, confirmed `action`, `inventoryCount`, and one routing entry per extracted metric. `inventoryCount` must equal the inventory size.
 
-`schemas/metric-routing.schema.json`
+Route every metric to exactly one role:
 
-It contains confirmed `decision`, confirmed `action`, `inventoryCount`, and one routing entry per extracted metric. `inventoryCount` must equal the number of routing entries; duplicate or missing metric routes are invalid.
-
-Route each metric to exactly one role:
-
-- `primary_signal` — directly changes the main decision or next action;
+- `primary_signal` — directly changes the main decision/action;
 - `diagnostic` — explains a routed primary signal or exception;
-- `exception` — a breach, outlier, critical account/event, or hard-stop condition requiring attention;
-- `drilldown` — useful only after deliberate investigation begins;
-- `scorecard_only` — retained for completeness, audit, or secondary scorecard use, but not promoted to the decision-first view.
+- `exception` — breach, outlier, critical account/event, or hard-stop condition;
+- `drilldown` — useful after deliberate investigation starts;
+- `scorecard_only` — retained for completeness/audit but not promoted to the decision-first view.
 
-Apply the **Action Trigger Test** to every candidate metric:
+Apply the **Action Trigger Test**: if this metric changes materially, what decision or action changes?
 
-1. If this metric changes materially, does the user's decision or action change?
-2. If yes in the ordinary decision loop, route it to `primary_signal` and state the `decisionImpact`.
-3. If a threshold, safety, compliance, contractual, outage, or other critical condition is breached, route it to `exception`.
-4. If it mainly explains a primary signal or exception, route it to `diagnostic` and identify what it `explains`.
-5. If it matters only after investigation begins, route it to `drilldown`.
-6. If no decision, action, diagnosis, or exception handling changes, route it to `scorecard_only`.
-
-Do not promote several metrics to `primary_signal` merely because they are all relevant. If one metric mainly explains another primary signal, or is a **complementary slice** of the same distribution, route it as `diagnostic` unless a material change would independently alter the confirmed decision or action.
+Do not promote metrics merely because they are relevant. If one mainly explains another primary signal, or is a **complementary slice** of the same distribution, route it as diagnostic unless a material change **independently alters the confirmed decision or action**.
 
 Compiler-enforced routing rules:
 
-- `primary_signal` must have `changesDecision: true`, a non-empty `decisionImpact`, and `visibility: "first_view"`.
-- The current deterministic renderer accepts **3–6 primary signals**; more than six fails the first-view information budget instead of silently squeezing more KPI peers into the layout.
-- The routed `primary_signal` metric IDs must exactly equal `decisionState.signals[*].metric` in `no_score`, or `decisionState.model.components[*].metric` in `composite`.
-- `diagnostic` metrics must have `changesDecision: false`, must point via `explains` to a routed `primary_signal` or `exception`, and must stay `supporting` or `on_demand`.
-- In `no_score`, the metric IDs in `decisionState.supportingSignals` must exactly equal the diagnostics routed with `visibility: "supporting"`; a supporting diagnostic must explain a routed primary signal or active exception.
-- At most four diagnostics may use `visibility: "supporting"`; additional diagnostics must use `on_demand`. The renderer never truncates a larger set silently.
-- `supportingSignals` are subordinate diagnostic context only: they never replace a routed primary signal, never participate in radar eligibility, and cannot contain a metric already present in `signals`.
-- `drilldown` metrics must stay `on_demand`.
-- `scorecard_only` metrics must stay `scorecard` and cannot claim to change the current decision.
-- **Active exceptions cannot be hidden** because a stakeholder dislikes red or negative states. An active exception must use `visibility: "first_view"` and its `surfacePath` must resolve to an actually rendered `/exceptions/<n>` or `/events/<n>` item in the decision state.
-- Current first-view information budget is at most 11 decision items: 3–6 primary signals plus active exceptions. Supporting diagnostics have their separate four-item subordinate budget. Do not solve overload by shrinking type or adding more equal-weight cards.
-- Do not promote a metric because it is easy to visualize, numerically large, or already placed in a KPI card.
-- Do not leak role labels such as `primary_signal` or `scorecard_only` into product UI.
+- `primary_signal` requires `changesDecision: true`, non-empty `decisionImpact`, and `visibility: "first_view"`;
+- 3–6 primary signals are allowed in the current renderer;
+- routed primaries must exactly equal rendered center metrics/components;
+- diagnostics require `changesDecision: false`, an `explains` target, and `supporting` or `on_demand` visibility;
+- no-score `supportingSignals` **must exactly equal** diagnostics routed as supporting;
+- **at most four diagnostics** may use supporting visibility; **additional diagnostics must use `on_demand`**;
+- `drilldown` stays `on_demand`; `scorecard_only` stays `scorecard`;
+- **active exceptions cannot be hidden** and must resolve through `surfacePath` to a rendered exception/event;
+- current **first-view information budget** is at most 11 decision items: 3–6 primary signals plus active exceptions;
+- supporting diagnostics have a separate four-item subordinate budget.
 
-A supporting-context semantic mismatch is a routing failure and must return `FIX_METRIC_ROUTING`; do not silently drop or repair the metric in the renderer. If the routing is valid but a visible supporting signal lacks source evidence, grounding must return `RETURN_TO_EVIDENCE_EXTRACTION`.
-
-The routing manifest is a durable decision trace. It preserves what was considered, why it was promoted or demoted, and what would change the decision, so later analysis does not have to rediscover the same KPI-prioritization logic from scratch.
+A supporting semantic mismatch returns `FIX_METRIC_ROUTING`; missing evidence returns `RETURN_TO_EVIDENCE_EXTRACTION`.
 
 ### 5. Choose the evidence mode
 
-The compiler supports two mutually exclusive decision-state modes.
+Use `composite` only when the source already provides overall score/scale, normalized component scores, component weights, a weighted-average aggregation rule, and complete score bands.
 
-Use `composite` only when the source already provides all of the following:
+If any required composite fact cannot be mechanically grounded, return `FALLBACK_TO_NO_SCORE`. Never invent score math.
 
-- an overall score and score scale;
-- normalized component scores;
-- component weights;
-- a weighted-average aggregation rule;
-- complete score bands / thresholds that determine displayed status.
+For `no_score`, do not create a synthetic overall score or health band.
 
-Composite accepts only:
+**Radar eligibility is independent of overall-score eligibility.** A no-score radar requires **3–6 peer dimensions** describing the same object/condition, one shared source-backed numeric scale, and a **source-grounded `normalizedScore`** for every displayed dimension. **Fewer than three dimensions are not radar-eligible.**
 
-- `normalization: "source_provided"`;
-- `aggregation: "weighted_average"`;
-- source-grounded score, component, weight, band, exception, event, and trend facts.
-
-If any required composite scoring fact cannot be mechanically grounded, transition to `FALLBACK_TO_NO_SCORE`. Do not fill gaps with inferred formulas, guessed weights, or invented benchmarks.
-
-For `no_score`, do not create `Healthy`, `Marginal`, `At risk`, or a 0–100 overall score. Overall direction remains a deterministic renderer derivation from validated signal directions.
-
-**Radar eligibility is independent of overall-score eligibility.** A `no_score` dashboard may render a closed radar profile only when the source explicitly provides:
-
-- **3–6 peer dimensions** describing the same object or condition as one profile;
-- one shared, source-backed numeric scale in `radarScale.min` / `radarScale.max`;
-- a source-grounded `normalizedScore` for every displayed dimension.
-
-Three dimensions are sufficient and render as a triangle. **Fewer than three dimensions are not radar-eligible.** Four to six dimensions render with the corresponding number of vertices.
-
-Radar is a profile chart, not a generic multi-metric chart. Do not connect heterogeneous raw KPIs such as revenue dollars, customer counts, percentages, latency, ratios, or unrelated business outcomes merely because several numbers exist.
-
-A radar must pass two gates:
+A radar must pass:
 
 - **Profile Test** — 3–6 peer dimensions, same object, same grounded scale;
-- **Action Trigger Test** — every displayed radar dimension must also be a routed `primary_signal`, meaning a material change can alter the confirmed decision or action.
+- **Action Trigger Test** — every displayed radar dimension is also a routed primary signal.
 
-If the Profile Test passes but the Action Trigger Test fails, keep those dimensions in diagnostic/drilldown/scorecard layers instead of using a decorative radar as the dominant visual.
+Never connect heterogeneous raw KPIs merely because several numbers exist.
 
 ### 6. Build a grounded bundle
 
-The grounded bundle remains separate from the routing inventory and contains only facts used by the rendered decision state:
+The grounded bundle stays separate from the routing inventory and must match `schemas/grounded-bundle.schema.json`; `decisionState` must independently match `schemas/decision-state.schema.json`.
 
-```json
-{
-  "source": {
-    "kind": "json",
-    "path": "source.json",
-    "sha256": "..."
-  },
-  "decisionState": {},
-  "evidence": [],
-  "claims": []
-}
-```
+Supported grounding:
 
-The envelope must match `schemas/grounded-bundle.schema.json` and `decisionState` must independently match `schemas/decision-state.schema.json`.
+- JSON → `json_pointer` anchor;
+- text → exact `text_span` anchor.
 
-Supported source grounding:
-
-- JSON source → `json_pointer` anchor;
-- text source → exact `text_span` anchor with `literal` and `valueText`.
-
-The compiler verifies the source file hash before accepting source claims.
-
-Image-only coordinates are not strong composite grounding because this repository has no deterministic OCR/token extractor. For screenshot inputs, first produce a verifiable text/JSON sidecar.
+The compiler verifies source SHA-256. Screenshot workflows should first create a verifiable text/JSON sidecar for claims that need byte-level grounding.
 
 ### 7. Required grounding coverage
 
-For `composite`, ground all source-dependent scoring facts:
+Ground every source-dependent field that becomes visible. Composite additionally grounds the complete score model. No-score radar additionally grounds `radarScale.min/max` and each `normalizedScore`.
 
-- score label/value/min/max/band;
-- normalization and aggregation;
-- each component label/value/normalized score/weight;
-- each score-band label/min/max;
-- score-series values when present;
-- visible exception/event fields when present.
-
-For ordinary `no_score`, ground each visible primary signal label/value, optional source delta/direction, every visible `supportingSignals` label/value and optional source delta/direction, source series values, and visible exception/event fields.
-
-For a `no_score` radar, additionally ground:
-
-- `radarScale.min` and `radarScale.max`;
-- every signal `normalizedScore` used as a radar vertex.
-
-A missing supporting-signal claim returns to evidence extraction just like any other visible source claim. A missing radar-scale or normalized-score claim also returns to evidence extraction. Do not silently fall back to an ungrounded visual.
-
-Do not ground deterministic renderer synthesis or Metric Router role decisions as if they were source facts.
+Do not ground deterministic renderer synthesis or Metric Router roles as if they were source facts.
 
 ### 8. Compile through all gates
 
-Production execution is:
+Canonical production execution:
 
 ```bash
-node scripts/compile-dashboard.js <worthiness-assessment.json> <routing-manifest.json> <grounded-bundle.json> <output-dir>
+node scripts/compile-dashboard.js <worthiness-assessment.json> <decision-brief.json> <routing-manifest.json> <grounded-bundle.json> <output-dir>
 ```
 
-The production path runs the Worthiness gate first. `FIX_WORTHINESS_ASSESSMENT`, `ASK_WORTHINESS_QUESTION`, or `REDIRECT_NON_DASHBOARD` produces no SVG/HTML. Only `BUILD_DECISION_BRIEF` may continue to Metric Router validation. On routing failure the compiler returns `FIX_METRIC_ROUTING`; only after routing passes does it run the grounding compiler.
+Before that, the individual preflight evaluators may be run directly:
+
+```bash
+node scripts/worthiness.js <worthiness-assessment.json>
+node scripts/intake.js <decision-brief.json>
+```
+
+`FIX_WORTHINESS_ASSESSMENT`, `ASK_WORTHINESS_QUESTION`, `REDIRECT_NON_DASHBOARD`, `FIX_DECISION_BRIEF`, or `ASK_DECISION_BRIEF_QUESTION` produces no final SVG/HTML. Only `ALLOW_ROUTING` may enter Metric Router validation.
 
 On final `PASS`, the CLI writes:
 
-- `no_score` → `output.no-score.svg` and `output.no-score.html`;
-- `composite` → `output.composite.svg` and `output.composite.html`.
+- `no_score` → `output.no-score.html` + `output.no-score.svg`;
+- `composite` → `output.composite.html` + `output.composite.svg`;
+- both modes → `output.manifest.json`.
 
 ### Primary delivery contract
 
-The **primary After deliverable is HTML** whenever file generation is available. Present or link `output.no-score.html` or `output.composite.html` first so the redesigned dashboard is an actual browser-openable interface rather than only a design image.
+The **primary After deliverable is HTML** whenever file generation is available. Present or link the canonical `output.no-score.html` or `output.composite.html` first.
 
-SVG remains the deterministic **preview** and regression/support artifact for README comparisons, static review, and snapshot testing. A screenshot, PNG, SVG, mockup, or concept image alone does not complete an ordinary dashboard redesign when the HTML renderer is available. Do not regenerate a separate free-form image as the “real” After after deterministic HTML has been rendered.
+SVG is a deterministic preview/regression artifact. A screenshot, PNG, SVG, mockup, or concept image alone does not complete an ordinary redesign when the HTML renderer is available.
 
-`worthiness.js` is the lower-level Worthiness evaluator. `compile.js` remains the lower-level grounding-only compiler for tests and internal compatibility. `validate.js` and `render.js` remain lower-level Layer 2 / Layer 3 tools. Do not use these lower-level entry points as a substitute for `compile-dashboard.js` in ordinary Decision-First production workflows.
+Every canonical HTML includes `decision-first-renderer=canonical` provenance metadata; SVG contains `<metadata id="decision-first-provenance">`; `output.manifest.json` records the source, Worthiness, Decision Brief, routing, grounded bundle, decision-state, HTML, and SVG hashes.
+
+Do not regenerate a separate free-form image or app as the “real” After. If the runtime cannot execute the production compiler, do not fake a substitute.
+
+`compile.js`, `validate.js`, and `render.js` remain lower-level compatibility/testing tools. They are not substitutes for `compile-dashboard.js` in ordinary production workflows.
 
 ### 9. Follow failure transitions literally
 
-- `FIX_WORTHINESS_ASSESSMENT` → repair malformed or contradictory structured worthiness fields; do not guess a transition.
-- `ASK_WORTHINESS_QUESTION` → ask only the minimum missing question and keep the same five-question total intake budget.
-- `REDIRECT_NON_DASHBOARD` → stop dashboard compilation and use the validated `recommendedFormat` unless the user explicitly overrides after the trade-off is explained.
-- `BUILD_DECISION_BRIEF` → continue into the existing Decision Brief; this is not final render permission.
-- `FIX_METRIC_ROUTING` → repair routing roles, action-trigger logic, first-view budget, primary/visible mismatch, supporting-context mismatch, or exception surfacing; do not bypass the gate.
-- `FIX_DECISION_STATE` → repair contract/schema errors only; do not weaken validation.
-- `RETURN_TO_EVIDENCE_EXTRACTION` → re-read source and repair evidence/claims.
-- `FALLBACK_TO_NO_SCORE` → abandon unsupported composite scoring and rebuild a grounded no-score state.
-- `PASS` → render deterministically.
-
-Do not turn a failed worthiness, routing, or grounding check into an invitation to guess.
+- `FIX_WORTHINESS_ASSESSMENT` → repair the structured assessment;
+- `ASK_WORTHINESS_QUESTION` → ask the minimum missing Worthiness question;
+- `REDIRECT_NON_DASHBOARD` → stop dashboard compilation;
+- `BUILD_DECISION_BRIEF` → continue to Decision Brief, not final render;
+- `FIX_DECISION_BRIEF` → repair malformed intake state;
+- `ASK_DECISION_BRIEF_QUESTION` → ask one high-information question for unresolved Decision/Action;
+- `ALLOW_ROUTING` → continue to Metric Router;
+- `FIX_METRIC_ROUTING` → repair routing; do not bypass it;
+- `RETURN_TO_EVIDENCE_EXTRACTION` → repair evidence/claims;
+- `FALLBACK_TO_NO_SCORE` → abandon unsupported composite scoring;
+- `FIX_DECISION_STATE` → repair contract/schema errors;
+- `PASS` → deliver the exact canonical compiler outputs.
 
 ## Visual contract
 
-The renderer owns layout after routing and grounding have passed.
+The renderer owns layout only after all upstream gates have passed.
 
 For `no_score`:
 
-- when all 3–6 routed primary dimensions have grounded `normalizedScore` values on one grounded `radarScale`, render a true closed radar profile;
-- otherwise use the non-radar signal layout and never connect heterogeneous raw KPI values into a fake radar;
-- one lead primary signal is the dominant focal point and the remaining primaries stay in the decision tier;
-- validated `supportingSignals` render only as a compact, lower-weight diagnostic rail and collapse completely when absent;
-- a primary-only center layout uses the compact density path rather than preserving a giant empty stage;
-- compact left business context only when source-supported;
-- compact right exceptions/events only when present.
+- true radar only when all eligible primary dimensions have grounded normalized scores on one grounded scale;
+- otherwise use the non-radar signal layout without fake spokes;
+- one lead primary signal may be the dominant focal point;
+- validated `supportingSignals` render as lower-weight diagnostic context and collapse when absent;
+- primary-only center layouts use the compact density path;
+- support modules appear only when source-supported.
 
 For `composite`:
 
-- dominant center source-supported score and band;
-- 3–6 routed normalized weighted components form a true closed radar profile;
-- compact left score trend and score composition;
-- compact right exceptions/events.
+- source-supported score/band;
+- 3–6 normalized weighted components may form a true radar;
+- compact trend/composition and exception/event support only when grounded.
 
 For both modes:
 
-- no flat KPI wall;
-- no dominant full-width customer table;
-- no invented action controls;
-- product-native labels only;
+- no flat four-equal-KPI wall;
+- no dominant full-width table;
+- no invented action controls, targets, scores, weights, thresholds, trend facts, or insights;
+- product-native source-derived copy only;
 - no compiler/framework methodology labels in visible UI;
-- restrained color and generous whitespace;
-- **soft attention is the default** for ordinary deterioration and business exceptions;
-- a **hard alert** treatment requires **explicit source-grounded** alert severity, a breached source threshold, a hard-stop condition, or an explicit user-supplied alert policy;
-- routing something to `exception` requires visibility but does not by itself authorize a large red banner, alarm icon, exclamation badge, or alarm language such as `Action needed`, `Critical`, or `Warning`;
-- negative or critical states may not be cosmetically suppressed;
-- hidden diagnostic/drilldown/scorecard routes are not rendered eagerly.
+- **soft attention is the default**;
+- hard alert treatment requires source-grounded severity/threshold, hard-stop status, or explicit user alert policy;
+- negative/critical states may not be cosmetically suppressed.
 
 See `references/visual-pattern.md` and `references/visual-stack-routing.md`.
 
 ## Hard stops
 
-Safety, compliance, security, regulatory, contractual, or outage conditions override ordinary synthesis. Never average them into a reassuring status. Never hide them because a stakeholder wants the dashboard to look more positive.
+Safety, compliance, security, regulatory, contractual, or outage conditions override ordinary synthesis. Never average an active hard stop into a reassuring status.
+
+## Agent E2E regression
+
+The repository contains a recorded ambiguous-prompt regression based on a real Sales Dashboard screenshot and the user request:
+
+> 帮我 redesign 一下这个 dashboard，感觉信息很多但不好用。
+
+The passing first turn asks one question covering missing Decision/Action context and produces no artifact. A recorded native-artifact response that skips intake is rejected by `scripts/agent-eval.js`.
+
+This harness verifies a recorded first-turn contract. It is not a live model benchmark and cannot guarantee that a host product will automatically invoke the skill for every generic dashboard prompt.
 
 ## Final gate
 
 Before delivery, verify:
 
-- `schemas/worthiness-assessment.schema.json` is respected and the compiler, not the agent, owned the Worthiness transition;
-- inferred or unclear worthiness did not silently pass; it produced `ASK_WORTHINESS_QUESTION` unless the user explicitly resolved it;
-- the accountability path may be a single owner, responsible team, or shared forum; do not require one named individual when a recurring accountable forum exists;
-- `REDIRECT_NON_DASHBOARD` stopped rendering unless the user explicitly chose the dashboard trade-off and `userOverride: true` was recorded;
-- any worthiness questions counted toward the same five-question intake budget rather than creating a second questionnaire;
-- the Decision Brief contains enough confirmed decision context to route metrics, and intake stopped as soon as that context was sufficient;
-- source facts were not mistaken for business intent; if Decision and Action were not explicitly stated beforehand, at least one user-confirmation question was asked;
-- no more than five questions were asked, one at a time, with no redundant request for source information already known;
-- user uncertainty did not cause invented business intent, thresholds, targets, or source claims;
-- `schemas/metric-routing.schema.json` is respected;
-- `inventoryCount` equals the routed metric inventory and no metric is duplicated or omitted;
-- every `primary_signal` passes the Action Trigger Test and the visible center matches the primary set exactly;
-- diagnostics explain routed primary/exception items rather than competing as peer headlines;
-- no-score `supportingSignals` exactly match diagnostics routed with supporting visibility, stay within the four-item budget, and do not overlap primaries;
-- complementary distribution slices were not promoted to peer primaries unless they independently change the confirmed decision/action;
-- active exceptions cannot be hidden and every active exception has a valid rendered `surfacePath`;
-- ordinary exceptions use restrained soft-attention styling unless hard-alert intensity is explicitly grounded;
-- the first-view information budget is respected instead of shrinking typography or adding equal-weight KPI cards;
-- the grounded-bundle schema passes;
-- source SHA-256 matches actual source bytes;
-- every required visible/source scoring fact, including rendered supporting context, has a resolvable claim and evidence anchor;
-- every grounded value matches the referenced decision-state value under allowed deterministic normalization only;
-- `no_score` overall direction matches signal directions;
-- a `no_score` radar passes both the Profile Test and Action Trigger Test;
-- raw mixed-unit KPIs never masquerade as radar dimensions;
-- `composite` weights, weighted score, score scale, and score band pass semantic validation;
-- no unsupported score/status/target/action appears;
+- Worthiness schema passes and the compiler owns the transition;
+- unresolved Worthiness never silently passes;
+- accountability may be one owner, team, or shared forum;
+- redirects stop rendering unless the user explicitly overrides;
+- Decision Brief follows the one-question-at-a-time / five-question budget;
+- source facts were not mistaken for business intent;
+- Decision and Action are explicitly confirmed before routing;
+- `schemas/decision-brief.schema.json` passes and `intake.js` returns `ALLOW_ROUTING`;
+- routing Decision/Action exactly preserve confirmed intake wording;
+- `schemas/metric-routing.schema.json` passes and `inventoryCount` is complete;
+- every primary passes the Action Trigger Test;
+- diagnostics remain subordinate and complementary slices do not inflate primaries;
+- active exceptions surface correctly;
+- first-view budgets are respected;
+- grounding schema, source SHA-256, evidence references, and visible claim coverage pass;
+- no unsupported score/status/target/action/insight appears;
 - no framework or compiler labels leak into visible UI;
-- when file delivery is available, HTML is presented as the primary After deliverable and SVG is treated as preview/support output;
-- the center is the first focal point;
+- HTML is the primary After deliverable;
+- final HTML/SVG contain canonical provenance and `output.manifest.json` exists;
+- the delivered After is the exact compiler output, not a free-form redraw;
 - outputs contain no unresolved template tokens.

--- a/skills/decision-first-dashboard/schemas/decision-brief.schema.json
+++ b/skills/decision-first-dashboard/schemas/decision-brief.schema.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["decision", "action"],
+  "properties": {
+    "decision": { "$ref": "#/definitions/slot" },
+    "action": { "$ref": "#/definitions/slot" },
+    "exception": { "$ref": "#/definitions/slot" },
+    "diagnosis": { "$ref": "#/definitions/slot" },
+    "audience": { "$ref": "#/definitions/slot" },
+    "cadence": { "$ref": "#/definitions/slot" }
+  },
+  "definitions": {
+    "slot": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status"],
+      "properties": {
+        "status": { "enum": ["confirmed", "inferred", "absent"] },
+        "value": { "type": "string", "minLength": 1, "maxLength": 240 }
+      }
+    }
+  }
+}

--- a/skills/decision-first-dashboard/scripts/agent-eval.js
+++ b/skills/decision-first-dashboard/scripts/agent-eval.js
@@ -1,0 +1,75 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const currentFile = fileURLToPath(import.meta.url);
+
+function add(errors, code, message) {
+  errors.push({ code, message });
+}
+
+export function evaluateRecordedAgentTurn(spec, response) {
+  const errors = [];
+  const expected = spec.expectedFirstTurn ?? {};
+  const outputs = Array.isArray(response.outputs) ? response.outputs : [];
+  const assumptions = Array.isArray(response.assumptions) ? response.assumptions : [];
+  const askedSlots = Array.isArray(response.askedSlots) ? response.askedSlots : [];
+
+  if (expected.artifactAllowed === false && (response.responseType === 'artifact' || outputs.length > 0)) {
+    add(errors, 'AGENT_OUTPUT_BYPASSED_INTAKE', 'ambiguous first turn must ask for missing decision context before generating an artifact');
+  }
+
+  if (typeof expected.requiredQuestionCount === 'number' && response.questionCount !== expected.requiredQuestionCount) {
+    add(errors, 'QUESTION_COUNT_MISMATCH', `expected ${expected.requiredQuestionCount} intake question, received ${response.questionCount ?? 0}`);
+  }
+
+  for (const slot of expected.requiredMissingSlots ?? []) {
+    if (!askedSlots.includes(slot)) {
+      add(errors, 'REQUIRED_INTAKE_SLOT_NOT_ASKED', `first-turn question must cover missing slot: ${slot}`);
+    }
+  }
+
+  for (const assumption of expected.forbiddenAssumptions ?? []) {
+    if (assumptions.includes(assumption)) {
+      add(errors, 'UNCONFIRMED_ASSUMPTION', `agent assumed ${assumption} before confirmation`);
+    }
+  }
+
+  for (const output of expected.forbiddenOutputs ?? []) {
+    if (outputs.includes(output)) {
+      add(errors, 'FORBIDDEN_OUTPUT', `first turn produced forbidden output: ${output}`);
+    }
+  }
+
+  if (response.responseType === 'artifact' && response.canonicalProvenance !== true) {
+    add(errors, 'CANONICAL_PROVENANCE_REQUIRED', 'final dashboard artifacts must come from the canonical compiler output path');
+  }
+
+  return {
+    valid: errors.length === 0,
+    stage: 'agent_e2e',
+    transition: errors.length === 0 ? 'PASS' : 'FAIL_AGENT_E2E',
+    errors
+  };
+}
+
+if (process.argv[1] === currentFile) {
+  const specPath = process.argv[2];
+  const responsePath = process.argv[3];
+  if (!specPath || !responsePath) {
+    process.stderr.write(`${JSON.stringify({
+      valid: false,
+      stage: 'agent_e2e',
+      transition: 'FAIL_AGENT_E2E',
+      errors: [{ code: 'AGENT_EVAL_USAGE', message: 'Usage: node agent-eval.js <eval-spec.json> <recorded-response.json>' }]
+    })}\n`);
+    process.exit(2);
+  }
+
+  const spec = JSON.parse(fs.readFileSync(path.resolve(specPath), 'utf8'));
+  const response = JSON.parse(fs.readFileSync(path.resolve(responsePath), 'utf8'));
+  const result = evaluateRecordedAgentTurn(spec, response);
+  const stream = result.valid ? process.stdout : process.stderr;
+  stream.write(`${JSON.stringify(result)}\n`);
+  process.exit(result.valid ? 0 : 1);
+}

--- a/skills/decision-first-dashboard/scripts/compile-dashboard.js
+++ b/skills/decision-first-dashboard/scripts/compile-dashboard.js
@@ -4,10 +4,51 @@ import { fileURLToPath } from 'node:url';
 import { compileGroundedBundle } from './compile.js';
 import { validateMetricRouting } from './routing.js';
 import { evaluateWorthinessAssessment } from './worthiness.js';
+import { evaluateDecisionBrief } from './intake.js';
+import {
+  buildCanonicalProvenance,
+  finalizeOutputManifest,
+  injectHtmlProvenance,
+  injectSvgProvenance
+} from './provenance.js';
 
 const currentFile = fileURLToPath(import.meta.url);
 
-export function compileDecisionDashboard(worthinessAssessment, routingManifest, bundle, { baseDir = process.cwd() } = {}) {
+function normalizeIntent(value) {
+  return typeof value === 'string' ? value.trim().replace(/\s+/g, ' ') : '';
+}
+
+function validateConfirmedIntentBinding(decisionBrief, routingManifest) {
+  const errors = [];
+  const confirmedDecision = normalizeIntent(decisionBrief?.decision?.value);
+  const confirmedAction = normalizeIntent(decisionBrief?.action?.value);
+  const routedDecision = normalizeIntent(routingManifest?.decision);
+  const routedAction = normalizeIntent(routingManifest?.action);
+
+  if (confirmedDecision !== routedDecision) {
+    errors.push({
+      code: 'CONFIRMED_DECISION_MISMATCH',
+      path: '/decision',
+      message: 'routing decision must exactly preserve the confirmed Decision Brief wording'
+    });
+  }
+  if (confirmedAction !== routedAction) {
+    errors.push({
+      code: 'CONFIRMED_ACTION_MISMATCH',
+      path: '/action',
+      message: 'routing action must exactly preserve the confirmed Decision Brief wording'
+    });
+  }
+  return errors;
+}
+
+export function compileDecisionDashboard(
+  worthinessAssessment,
+  decisionBrief,
+  routingManifest,
+  bundle,
+  { baseDir = process.cwd() } = {}
+) {
   const worthiness = evaluateWorthinessAssessment(worthinessAssessment);
   if (!worthiness.valid || worthiness.transition !== 'BUILD_DECISION_BRIEF') {
     return {
@@ -22,6 +63,45 @@ export function compileDecisionDashboard(worthinessAssessment, routingManifest, 
       },
       svg: null,
       html: null,
+      manifest: null,
+      outputMode: null
+    };
+  }
+
+  const intake = evaluateDecisionBrief(decisionBrief);
+  if (!intake.valid || intake.transition !== 'ALLOW_ROUTING') {
+    return {
+      result: {
+        valid: false,
+        stage: 'intake',
+        transition: intake.transition,
+        errors: intake.errors,
+        missingSlots: intake.missingSlots,
+        worthinessSummary: worthiness.summary,
+        intakeSummary: intake.summary
+      },
+      svg: null,
+      html: null,
+      manifest: null,
+      outputMode: null
+    };
+  }
+
+  const intentErrors = validateConfirmedIntentBinding(decisionBrief, routingManifest);
+  if (intentErrors.length > 0) {
+    return {
+      result: {
+        valid: false,
+        stage: 'routing',
+        transition: 'FIX_METRIC_ROUTING',
+        errors: intentErrors,
+        worthinessSummary: worthiness.summary,
+        intakeSummary: intake.summary,
+        routingSummary: null
+      },
+      svg: null,
+      html: null,
+      manifest: null,
       outputMode: null
     };
   }
@@ -35,20 +115,50 @@ export function compileDecisionDashboard(worthinessAssessment, routingManifest, 
         transition: 'FIX_METRIC_ROUTING',
         errors: routing.errors,
         worthinessSummary: worthiness.summary,
+        intakeSummary: intake.summary,
         routingSummary: routing.summary
       },
       svg: null,
       html: null,
+      manifest: null,
       outputMode: null
     };
   }
 
   const compiled = compileGroundedBundle(bundle, { baseDir });
+  if (!compiled.result.valid || compiled.result.transition !== 'PASS') {
+    return {
+      ...compiled,
+      manifest: null,
+      result: {
+        ...compiled.result,
+        worthinessSummary: worthiness.summary,
+        intakeSummary: intake.summary,
+        routingSummary: routing.summary
+      }
+    };
+  }
+
+  const provenance = buildCanonicalProvenance({
+    worthinessAssessment,
+    decisionBrief,
+    routingManifest,
+    bundle,
+    mode: bundle.decisionState.mode
+  });
+  const html = injectHtmlProvenance(compiled.html, provenance);
+  const svg = injectSvgProvenance(compiled.svg, provenance);
+  const manifest = finalizeOutputManifest(provenance, html, svg);
+
   return {
     ...compiled,
+    html,
+    svg,
+    manifest,
     result: {
       ...compiled.result,
       worthinessSummary: worthiness.summary,
+      intakeSummary: intake.summary,
       routingSummary: routing.summary
     }
   };
@@ -56,27 +166,40 @@ export function compileDecisionDashboard(worthinessAssessment, routingManifest, 
 
 if (process.argv[1] === currentFile) {
   const worthinessPath = process.argv[2];
-  const routingPath = process.argv[3];
-  const bundlePath = process.argv[4];
-  const outputDir = process.argv[5] ?? path.dirname(bundlePath ?? '.');
+  const decisionBriefPath = process.argv[3];
+  const routingPath = process.argv[4];
+  const bundlePath = process.argv[5];
+  const outputDir = process.argv[6] ?? path.dirname(bundlePath ?? '.');
 
-  if (!worthinessPath || !routingPath || !bundlePath) {
+  if (!worthinessPath || !decisionBriefPath || !routingPath || !bundlePath) {
     process.stderr.write(`${JSON.stringify({
       valid: false,
-      stage: 'worthiness',
-      transition: 'FIX_WORTHINESS_ASSESSMENT',
-      errors: [{ code: 'WORTHINESS_ASSESSMENT_INVALID', path: '', message: 'Usage: node compile-dashboard.js <worthiness-assessment.json> <routing-manifest.json> <grounded-bundle.json> [output-dir]' }]
+      stage: 'intake',
+      transition: 'FIX_DECISION_BRIEF',
+      errors: [{
+        code: 'DECISION_PIPELINE_INPUT_INVALID',
+        path: '',
+        message: 'Usage: node compile-dashboard.js <worthiness-assessment.json> <decision-brief.json> <routing-manifest.json> <grounded-bundle.json> [output-dir]'
+      }]
     })}\n`);
     process.exit(2);
   }
 
   const absoluteWorthiness = path.resolve(worthinessPath);
+  const absoluteDecisionBrief = path.resolve(decisionBriefPath);
   const absoluteRouting = path.resolve(routingPath);
   const absoluteBundle = path.resolve(bundlePath);
   const worthinessAssessment = JSON.parse(fs.readFileSync(absoluteWorthiness, 'utf8'));
+  const decisionBrief = JSON.parse(fs.readFileSync(absoluteDecisionBrief, 'utf8'));
   const routingManifest = JSON.parse(fs.readFileSync(absoluteRouting, 'utf8'));
   const bundle = JSON.parse(fs.readFileSync(absoluteBundle, 'utf8'));
-  const compiled = compileDecisionDashboard(worthinessAssessment, routingManifest, bundle, { baseDir: path.dirname(absoluteBundle) });
+  const compiled = compileDecisionDashboard(
+    worthinessAssessment,
+    decisionBrief,
+    routingManifest,
+    bundle,
+    { baseDir: path.dirname(absoluteBundle) }
+  );
 
   if (!compiled.result.valid || compiled.result.transition !== 'PASS') {
     process.stderr.write(`${JSON.stringify(compiled.result)}\n`);
@@ -86,7 +209,9 @@ if (process.argv[1] === currentFile) {
   fs.mkdirSync(outputDir, { recursive: true });
   const svgOutput = path.join(outputDir, `output.${compiled.outputMode}.svg`);
   const htmlOutput = path.join(outputDir, `output.${compiled.outputMode}.html`);
+  const manifestOutput = path.join(outputDir, 'output.manifest.json');
   fs.writeFileSync(svgOutput, compiled.svg);
   fs.writeFileSync(htmlOutput, compiled.html);
-  process.stdout.write(`${svgOutput}\n${htmlOutput}\n`);
+  fs.writeFileSync(manifestOutput, `${JSON.stringify(compiled.manifest, null, 2)}\n`);
+  process.stdout.write(`${svgOutput}\n${htmlOutput}\n${manifestOutput}\n`);
 }

--- a/skills/decision-first-dashboard/scripts/intake.js
+++ b/skills/decision-first-dashboard/scripts/intake.js
@@ -1,0 +1,105 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { validateAgainstSchema } from './validate.js';
+
+const currentFile = fileURLToPath(import.meta.url);
+const currentDir = path.dirname(currentFile);
+const schema = JSON.parse(fs.readFileSync(path.resolve(currentDir, '../schemas/decision-brief.schema.json'), 'utf8'));
+
+function add(errors, code, path, message) {
+  errors.push({ code, path, message });
+}
+
+function semanticErrors(brief) {
+  const errors = [];
+  for (const slotName of ['decision', 'action', 'exception', 'diagnosis', 'audience', 'cadence']) {
+    const slot = brief?.[slotName];
+    if (!slot) continue;
+    if (slot.status === 'confirmed' && typeof slot.value !== 'string') {
+      add(errors, 'CONFIRMED_SLOT_VALUE_REQUIRED', `/${slotName}/value`, `confirmed ${slotName} requires an explicit value`);
+    }
+    if (slot.status === 'absent' && Object.hasOwn(slot, 'value')) {
+      add(errors, 'ABSENT_SLOT_VALUE_CONFLICT', `/${slotName}/value`, `absent ${slotName} must not carry a value`);
+    }
+  }
+  return errors;
+}
+
+function summaryOf(brief) {
+  const summary = {};
+  for (const slotName of ['decision', 'action', 'exception', 'diagnosis', 'audience', 'cadence']) {
+    if (brief?.[slotName]) summary[`${slotName}Status`] = brief[slotName].status;
+  }
+  return summary;
+}
+
+export function evaluateDecisionBrief(brief) {
+  const schemaResult = validateAgainstSchema(brief, schema);
+  if (!schemaResult.valid) {
+    return {
+      valid: false,
+      stage: 'intake',
+      transition: 'FIX_DECISION_BRIEF',
+      errors: schemaResult.errors.map((error) => ({
+        code: 'DECISION_BRIEF_SCHEMA_INVALID',
+        path: error.instancePath,
+        message: `${error.keyword}: ${error.message}`
+      })),
+      missingSlots: [],
+      summary: null
+    };
+  }
+
+  const errors = semanticErrors(brief);
+  if (errors.length > 0) {
+    return {
+      valid: false,
+      stage: 'intake',
+      transition: 'FIX_DECISION_BRIEF',
+      errors,
+      missingSlots: [],
+      summary: summaryOf(brief)
+    };
+  }
+
+  const missingSlots = ['decision', 'action'].filter((slotName) => brief[slotName].status !== 'confirmed');
+  if (missingSlots.length > 0) {
+    return {
+      valid: true,
+      stage: 'intake',
+      transition: 'ASK_DECISION_BRIEF_QUESTION',
+      errors: [],
+      missingSlots,
+      summary: summaryOf(brief)
+    };
+  }
+
+  return {
+    valid: true,
+    stage: 'intake',
+    transition: 'ALLOW_ROUTING',
+    errors: [],
+    missingSlots: [],
+    summary: summaryOf(brief)
+  };
+}
+
+if (process.argv[1] === currentFile) {
+  const inputPath = process.argv[2];
+  if (!inputPath) {
+    process.stderr.write(`${JSON.stringify({
+      valid: false,
+      stage: 'intake',
+      transition: 'FIX_DECISION_BRIEF',
+      errors: [{ code: 'DECISION_BRIEF_INVALID', path: '', message: 'Usage: node intake.js <decision-brief.json>' }]
+    })}\n`);
+    process.exit(2);
+  }
+
+  const brief = JSON.parse(fs.readFileSync(path.resolve(inputPath), 'utf8'));
+  const result = evaluateDecisionBrief(brief);
+  const stream = result.valid ? process.stdout : process.stderr;
+  stream.write(`${JSON.stringify(result)}\n`);
+  process.exit(result.valid ? 0 : 1);
+}

--- a/skills/decision-first-dashboard/scripts/provenance.js
+++ b/skills/decision-first-dashboard/scripts/provenance.js
@@ -1,0 +1,78 @@
+import crypto from 'node:crypto';
+
+function stableValue(value) {
+  if (Array.isArray(value)) return value.map(stableValue);
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(Object.keys(value).sort().map((key) => [key, stableValue(value[key])]));
+  }
+  return value;
+}
+
+export function stableJson(value) {
+  return JSON.stringify(stableValue(value));
+}
+
+export function sha256Text(text) {
+  return crypto.createHash('sha256').update(text, 'utf8').digest('hex');
+}
+
+export function sha256Object(value) {
+  return sha256Text(stableJson(value));
+}
+
+function escapeXmlText(value) {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;');
+}
+
+export function buildCanonicalProvenance({ worthinessAssessment, decisionBrief, routingManifest, bundle, mode }) {
+  return {
+    provenanceVersion: 1,
+    canonical: true,
+    compiler: 'compile-dashboard.js',
+    renderer: 'deterministic',
+    mode,
+    sourceSha256: bundle.source.sha256,
+    worthinessAssessmentSha256: sha256Object(worthinessAssessment),
+    decisionBriefSha256: sha256Object(decisionBrief),
+    routingManifestSha256: sha256Object(routingManifest),
+    groundedBundleSha256: sha256Object(bundle),
+    decisionStateSha256: sha256Object(bundle.decisionState)
+  };
+}
+
+export function injectHtmlProvenance(html, provenance) {
+  const metas = [
+    '<meta name="decision-first-renderer" content="canonical">',
+    `<meta name="decision-first-mode" content="${provenance.mode}">`,
+    `<meta name="decision-first-provenance-version" content="${provenance.provenanceVersion}">`,
+    `<meta name="decision-first-decision-state-sha256" content="${provenance.decisionStateSha256}">`,
+    `<meta name="decision-first-routing-manifest-sha256" content="${provenance.routingManifestSha256}">`
+  ].join('');
+  if (!html.includes('<head>')) throw new Error('Canonical HTML renderer output must contain <head>');
+  return html.replace('<head>', `<head>${metas}`);
+}
+
+export function injectSvgProvenance(svg, provenance) {
+  const metadata = escapeXmlText(stableJson(provenance));
+  if (!svg.startsWith('<svg')) throw new Error('Canonical SVG renderer output must start with <svg');
+  const close = svg.indexOf('>');
+  return `${svg.slice(0, close + 1)}<metadata id="decision-first-provenance">${metadata}</metadata>${svg.slice(close + 1)}`;
+}
+
+export function finalizeOutputManifest(provenance, html, svg) {
+  return {
+    ...provenance,
+    htmlSha256: sha256Text(html),
+    svgSha256: sha256Text(svg)
+  };
+}
+
+export function hasCanonicalHtmlProvenance(html) {
+  return typeof html === 'string' &&
+    html.includes('<meta name="decision-first-renderer" content="canonical">') &&
+    /<meta name="decision-first-decision-state-sha256" content="[a-f0-9]{64}">/.test(html) &&
+    /<meta name="decision-first-routing-manifest-sha256" content="[a-f0-9]{64}">/.test(html);
+}

--- a/tests/compiler/compile-dashboard.test.js
+++ b/tests/compiler/compile-dashboard.test.js
@@ -11,9 +11,15 @@ const root = path.resolve(fileURLToPath(new URL('../..', import.meta.url)));
 const groundingDir = fileURLToPath(new URL('./fixtures/grounding/', import.meta.url));
 const routingDir = fileURLToPath(new URL('./fixtures/routing/', import.meta.url));
 const worthinessDir = fileURLToPath(new URL('./fixtures/worthiness/', import.meta.url));
+const intakeDir = fileURLToPath(new URL('./fixtures/intake/', import.meta.url));
 const noScoreBundle = JSON.parse(fs.readFileSync(path.join(groundingDir, 'no-score.grounded.json'), 'utf8'));
 const noScoreRouting = JSON.parse(fs.readFileSync(path.join(routingDir, 'no-score.routing.json'), 'utf8'));
 const dashboardWorthiness = JSON.parse(fs.readFileSync(path.join(worthinessDir, 'dashboard.worthiness.json'), 'utf8'));
+const noScoreBrief = JSON.parse(fs.readFileSync(path.join(intakeDir, 'confirmed.decision-brief.json'), 'utf8'));
+
+function briefNameFor(routingName) {
+  return routingName.startsWith('composite') ? 'composite-confirmed.decision-brief.json' : 'confirmed.decision-brief.json';
+}
 
 function runCli(routingName, bundleName) {
   const outputDir = fs.mkdtempSync(path.join(os.tmpdir(), 'decision-first-routed-'));
@@ -21,6 +27,7 @@ function runCli(routingName, bundleName) {
   const result = spawnSync(process.execPath, [
     script,
     path.join(worthinessDir, 'dashboard.worthiness.json'),
+    path.join(intakeDir, briefNameFor(routingName)),
     path.join(routingDir, routingName),
     path.join(groundingDir, bundleName),
     outputDir
@@ -28,28 +35,29 @@ function runCli(routingName, bundleName) {
   return { result, outputDir };
 }
 
-test('production compile passes worthiness before routing, grounding, and rendering', () => {
-  const compiled = compileDecisionDashboard(dashboardWorthiness, noScoreRouting, noScoreBundle, { baseDir: groundingDir });
+test('production compile passes worthiness and intake before routing, grounding, and rendering', () => {
+  const compiled = compileDecisionDashboard(dashboardWorthiness, noScoreBrief, noScoreRouting, noScoreBundle, { baseDir: groundingDir });
   assert.equal(compiled.result.valid, true);
   assert.equal(compiled.result.transition, 'PASS');
   assert.equal(compiled.result.worthinessSummary.accountabilityMode, 'single_owner');
+  assert.equal(compiled.result.intakeSummary.decisionStatus, 'confirmed');
+  assert.equal(compiled.result.intakeSummary.actionStatus, 'confirmed');
   assert.equal(compiled.result.routingSummary.inventoryCount, 5);
   assert.equal(compiled.result.routingSummary.primaryCount, 5);
   assert.match(compiled.svg, /Current overview/);
   assert.match(compiled.html, /Current overview/);
+  assert.match(compiled.html, /decision-first-renderer/);
   assert.doesNotMatch(compiled.svg, /Subscription health|Revenue context|Trend data unavailable/);
   assert.doesNotMatch(compiled.html, /Subscription health|Revenue context|Trend data unavailable/);
 });
 
-test('invalid Metric Router output blocks compilation after worthiness and before grounding', () => {
+test('invalid Metric Router output blocks compilation after intake and before grounding', () => {
   const routing = structuredClone(noScoreRouting);
   routing.metrics[0].changesDecision = false;
   delete routing.metrics[0].decisionImpact;
-
   const bundle = structuredClone(noScoreBundle);
   bundle.source.sha256 = '0'.repeat(64);
-
-  const compiled = compileDecisionDashboard(dashboardWorthiness, routing, bundle, { baseDir: groundingDir });
+  const compiled = compileDecisionDashboard(dashboardWorthiness, noScoreBrief, routing, bundle, { baseDir: groundingDir });
   assert.equal(compiled.result.valid, false);
   assert.equal(compiled.result.stage, 'routing');
   assert.equal(compiled.result.transition, 'FIX_METRIC_ROUTING');
@@ -58,16 +66,18 @@ test('invalid Metric Router output blocks compilation after worthiness and befor
   assert.equal(compiled.html, null);
 });
 
-test('production CLI writes no-score output only after all three gates pass', () => {
+test('production CLI writes no-score output only after all four gates pass', () => {
   const { result, outputDir } = runCli('no-score.routing.json', 'no-score.grounded.json');
   assert.equal(result.status, 0, result.stderr);
   assert.equal(fs.existsSync(path.join(outputDir, 'output.no-score.svg')), true);
   assert.equal(fs.existsSync(path.join(outputDir, 'output.no-score.html')), true);
+  assert.equal(fs.existsSync(path.join(outputDir, 'output.manifest.json')), true);
 });
 
-test('production CLI writes composite output only after all three gates pass', () => {
+test('production CLI writes composite output only after all four gates pass', () => {
   const { result, outputDir } = runCli('composite.routing.json', 'composite.grounded.json');
   assert.equal(result.status, 0, result.stderr);
   assert.equal(fs.existsSync(path.join(outputDir, 'output.composite.svg')), true);
   assert.equal(fs.existsSync(path.join(outputDir, 'output.composite.html')), true);
+  assert.equal(fs.existsSync(path.join(outputDir, 'output.manifest.json')), true);
 });

--- a/tests/compiler/fixtures/agent-eval/sales-dashboard-ambiguous.eval.json
+++ b/tests/compiler/fixtures/agent-eval/sales-dashboard-ambiguous.eval.json
@@ -1,0 +1,16 @@
+{
+  "id": "sales-dashboard-ambiguous-redesign",
+  "source": {
+    "kind": "image",
+    "name": "Dark Neon Sales Analytics Dashboard.png",
+    "sha256": "43bc1a34946d4a7f5932787c2af1271e16750760bbdec8a8615876b25401e707"
+  },
+  "userPrompt": "帮我 redesign 一下这个 dashboard，感觉信息很多但不好用。",
+  "expectedFirstTurn": {
+    "artifactAllowed": false,
+    "requiredQuestionCount": 1,
+    "requiredMissingSlots": ["decision", "action"],
+    "forbiddenAssumptions": ["audience", "decision", "action"],
+    "forbiddenOutputs": ["image", "html", "dashboard", "key_insights", "action_recommendations"]
+  }
+}

--- a/tests/compiler/fixtures/agent-eval/sales-dashboard-bad-first-turn.json
+++ b/tests/compiler/fixtures/agent-eval/sales-dashboard-bad-first-turn.json
@@ -1,0 +1,9 @@
+{
+  "responseType": "artifact",
+  "questionCount": 0,
+  "askedSlots": [],
+  "assumptions": ["audience", "decision", "action"],
+  "outputs": ["image", "key_insights", "action_recommendations"],
+  "canonicalProvenance": false,
+  "text": "Generated a redesigned sales dashboard with KPI deltas, Key Insights, and recommended next actions."
+}

--- a/tests/compiler/fixtures/agent-eval/sales-dashboard-good-first-turn.json
+++ b/tests/compiler/fixtures/agent-eval/sales-dashboard-good-first-turn.json
@@ -1,0 +1,9 @@
+{
+  "responseType": "question",
+  "questionCount": 1,
+  "askedSlots": ["decision", "action"],
+  "assumptions": [],
+  "outputs": [],
+  "canonicalProvenance": false,
+  "text": "这张 dashboard 主要是谁定期看？当收入、利润或利润率明显变化时，他们通常会做什么不同的决定或动作？"
+}

--- a/tests/compiler/fixtures/intake/composite-confirmed.decision-brief.json
+++ b/tests/compiler/fixtures/intake/composite-confirmed.decision-brief.json
@@ -1,0 +1,10 @@
+{
+  "decision": {
+    "status": "confirmed",
+    "value": "Decide whether subscription health requires intervention"
+  },
+  "action": {
+    "status": "confirmed",
+    "value": "Prioritize retention, growth, or conversion intervention"
+  }
+}

--- a/tests/compiler/fixtures/intake/confirmed.decision-brief.json
+++ b/tests/compiler/fixtures/intake/confirmed.decision-brief.json
@@ -1,0 +1,10 @@
+{
+  "decision": {
+    "status": "confirmed",
+    "value": "Decide whether the SaaS business needs intervention"
+  },
+  "action": {
+    "status": "confirmed",
+    "value": "Prioritize the next business follow-up"
+  }
+}

--- a/tests/compiler/fixtures/intake/incomplete.decision-brief.json
+++ b/tests/compiler/fixtures/intake/incomplete.decision-brief.json
@@ -1,0 +1,9 @@
+{
+  "decision": {
+    "status": "inferred",
+    "value": "Decide whether sales performance needs intervention"
+  },
+  "action": {
+    "status": "absent"
+  }
+}

--- a/tests/compiler/intake-provenance-gate.test.js
+++ b/tests/compiler/intake-provenance-gate.test.js
@@ -1,0 +1,104 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { compileDecisionDashboard } from '../../skills/decision-first-dashboard/scripts/compile-dashboard.js';
+
+const root = path.resolve(fileURLToPath(new URL('../..', import.meta.url)));
+const groundingDir = fileURLToPath(new URL('./fixtures/grounding/', import.meta.url));
+const routingDir = fileURLToPath(new URL('./fixtures/routing/', import.meta.url));
+const worthinessDir = fileURLToPath(new URL('./fixtures/worthiness/', import.meta.url));
+const intakeDir = fileURLToPath(new URL('./fixtures/intake/', import.meta.url));
+const agentEvalDir = fileURLToPath(new URL('./fixtures/agent-eval/', import.meta.url));
+
+const worthiness = JSON.parse(fs.readFileSync(path.join(worthinessDir, 'dashboard.worthiness.json'), 'utf8'));
+const routing = JSON.parse(fs.readFileSync(path.join(routingDir, 'no-score.routing.json'), 'utf8'));
+const bundle = JSON.parse(fs.readFileSync(path.join(groundingDir, 'no-score.grounded.json'), 'utf8'));
+const confirmedBrief = JSON.parse(fs.readFileSync(path.join(intakeDir, 'confirmed.decision-brief.json'), 'utf8'));
+const incompleteBrief = JSON.parse(fs.readFileSync(path.join(intakeDir, 'incomplete.decision-brief.json'), 'utf8'));
+
+function runCompilerCli(briefName = 'confirmed.decision-brief.json') {
+  const outputDir = fs.mkdtempSync(path.join(os.tmpdir(), 'decision-first-intake-'));
+  const script = path.join(root, 'skills/decision-first-dashboard/scripts/compile-dashboard.js');
+  const result = spawnSync(process.execPath, [
+    script,
+    path.join(worthinessDir, 'dashboard.worthiness.json'),
+    path.join(intakeDir, briefName),
+    path.join(routingDir, 'no-score.routing.json'),
+    path.join(groundingDir, 'no-score.grounded.json'),
+    outputDir
+  ], { cwd: root, encoding: 'utf8' });
+  return { result, outputDir };
+}
+
+test('incomplete Decision Brief blocks routing and rendering with one intake transition', () => {
+  const compiled = compileDecisionDashboard(worthiness, incompleteBrief, routing, bundle, { baseDir: groundingDir });
+
+  assert.equal(compiled.result.valid, false);
+  assert.equal(compiled.result.stage, 'intake');
+  assert.equal(compiled.result.transition, 'ASK_DECISION_BRIEF_QUESTION');
+  assert.deepEqual(compiled.result.missingSlots, ['decision', 'action']);
+  assert.equal(compiled.svg, null);
+  assert.equal(compiled.html, null);
+});
+
+test('confirmed Decision Brief is bound exactly to routing decision and action', () => {
+  const mismatchedRouting = structuredClone(routing);
+  mismatchedRouting.action = 'Invent a different next action';
+
+  const compiled = compileDecisionDashboard(worthiness, confirmedBrief, mismatchedRouting, bundle, { baseDir: groundingDir });
+
+  assert.equal(compiled.result.valid, false);
+  assert.equal(compiled.result.stage, 'routing');
+  assert.equal(compiled.result.transition, 'FIX_METRIC_ROUTING');
+  assert.ok(compiled.result.errors.some((error) => error.code === 'CONFIRMED_ACTION_MISMATCH'));
+  assert.equal(compiled.html, null);
+});
+
+test('canonical dashboard compile emits machine-verifiable provenance', () => {
+  const compiled = compileDecisionDashboard(worthiness, confirmedBrief, routing, bundle, { baseDir: groundingDir });
+
+  assert.equal(compiled.result.valid, true);
+  assert.equal(compiled.result.transition, 'PASS');
+  assert.match(compiled.html, /<meta name="decision-first-renderer" content="canonical">/);
+  assert.match(compiled.html, /<meta name="decision-first-mode" content="no_score">/);
+  assert.match(compiled.html, /<meta name="decision-first-routing-manifest-sha256" content="[a-f0-9]{64}">/);
+  assert.match(compiled.svg, /<metadata id="decision-first-provenance">/);
+  assert.equal(compiled.manifest.canonical, true);
+  assert.equal(compiled.manifest.mode, 'no_score');
+  assert.match(compiled.manifest.htmlSha256, /^[a-f0-9]{64}$/);
+  assert.match(compiled.manifest.decisionStateSha256, /^[a-f0-9]{64}$/);
+});
+
+test('production CLI writes output manifest beside canonical HTML and SVG', () => {
+  const { result, outputDir } = runCompilerCli();
+  assert.equal(result.status, 0, result.stderr);
+
+  const htmlPath = path.join(outputDir, 'output.no-score.html');
+  const manifestPath = path.join(outputDir, 'output.manifest.json');
+  assert.equal(fs.existsSync(htmlPath), true);
+  assert.equal(fs.existsSync(manifestPath), true);
+
+  const html = fs.readFileSync(htmlPath, 'utf8');
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+  assert.match(html, /decision-first-renderer/);
+  assert.equal(manifest.canonical, true);
+  assert.match(manifest.htmlSha256, /^[a-f0-9]{64}$/);
+});
+
+test('recorded ambiguous-prompt agent eval accepts one question and rejects native artifact bypass', () => {
+  const script = path.join(root, 'skills/decision-first-dashboard/scripts/agent-eval.js');
+  const spec = path.join(agentEvalDir, 'sales-dashboard-ambiguous.eval.json');
+  const good = path.join(agentEvalDir, 'sales-dashboard-good-first-turn.json');
+  const bad = path.join(agentEvalDir, 'sales-dashboard-bad-first-turn.json');
+
+  const goodRun = spawnSync(process.execPath, [script, spec, good], { cwd: root, encoding: 'utf8' });
+  assert.equal(goodRun.status, 0, goodRun.stderr);
+
+  const badRun = spawnSync(process.execPath, [script, spec, bad], { cwd: root, encoding: 'utf8' });
+  assert.equal(badRun.status, 1);
+  assert.match(badRun.stderr, /AGENT_OUTPUT_BYPASSED_INTAKE|CANONICAL_PROVENANCE_REQUIRED/);
+});

--- a/tests/compiler/worthiness-behavior.test.js
+++ b/tests/compiler/worthiness-behavior.test.js
@@ -8,13 +8,15 @@ import { compileDecisionDashboard } from '../../skills/decision-first-dashboard/
 const groundingDir = fileURLToPath(new URL('./fixtures/grounding/', import.meta.url));
 const routingDir = fileURLToPath(new URL('./fixtures/routing/', import.meta.url));
 const worthinessDir = fileURLToPath(new URL('./fixtures/worthiness/', import.meta.url));
+const intakeDir = fileURLToPath(new URL('./fixtures/intake/', import.meta.url));
 const noScoreBundle = JSON.parse(fs.readFileSync(path.join(groundingDir, 'no-score.grounded.json'), 'utf8'));
 const noScoreRouting = JSON.parse(fs.readFileSync(path.join(routingDir, 'no-score.routing.json'), 'utf8'));
+const noScoreBrief = JSON.parse(fs.readFileSync(path.join(intakeDir, 'confirmed.decision-brief.json'), 'utf8'));
 const dashboardWorthiness = JSON.parse(fs.readFileSync(path.join(worthinessDir, 'dashboard.worthiness.json'), 'utf8'));
 const scenarios = JSON.parse(fs.readFileSync(path.join(worthinessDir, 'scenarios.json'), 'utf8'));
 
 function compile(worthiness) {
-  return compileDecisionDashboard(worthiness, noScoreRouting, noScoreBundle, { baseDir: groundingDir });
+  return compileDecisionDashboard(worthiness, noScoreBrief, noScoreRouting, noScoreBundle, { baseDir: groundingDir });
 }
 
 for (const scenario of scenarios) {
@@ -56,7 +58,7 @@ test('a non-dashboard redirect cannot smuggle dashboard back in as the recommend
   assert.ok(result.result.errors.some((error) => error.code === 'FORMAT_TRANSITION_CONFLICT'));
 });
 
-test('an explicit user override can proceed to Decision Brief while keeping downstream gates intact', () => {
+test('an explicit user override can proceed through the Decision Brief while keeping downstream gates intact', () => {
   const visibility = structuredClone(scenarios.find((scenario) => scenario.id === 'visibility-only').assessment);
   visibility.userOverride = true;
   visibility.recommendedFormat = 'dashboard';
@@ -64,5 +66,6 @@ test('an explicit user override can proceed to Decision Brief while keeping down
 
   assert.equal(result.result.transition, 'PASS');
   assert.equal(result.result.worthinessSummary.userOverride, true);
+  assert.equal(result.result.intakeSummary.decisionStatus, 'confirmed');
   assert.equal(result.result.routingSummary.primaryCount, 5);
 });


### PR DESCRIPTION
Implements the intake/provenance enforcement discovered by the real ambiguous Sales Dashboard blind test.

What changed:
- adds a closed `decision-brief.schema.json` and executable `intake.js` gate
- requires confirmed Decision + Action before Metric Router or rendering can proceed
- binds routing `decision` / `action` exactly to the confirmed Decision Brief wording
- makes `compile-dashboard.js` the canonical production path with four ordered gates: worthiness → intake → routing → grounding
- stamps canonical HTML/SVG with machine-verifiable provenance and writes `output.manifest.json`
- adds a recorded Agent E2E contract for the real ambiguous prompt `帮我 redesign 一下这个 dashboard，感觉信息很多但不好用。`
- accepts a one-question first turn and rejects the observed native-artifact bypass pattern
- strengthens `SKILL.md` so unresolved intake cannot fall back to free-form image/HTML/React rendering
- documents the host-level limitation clearly: the repo can enforce the skill workflow once invoked, but cannot guarantee a product automatically invokes the skill for every generic prompt
- updates CI and the production CLI examples for the Decision Brief input and provenance manifest

TDD / verification:
- initial RED run reproduced the five missing behaviors while the prior suite remained green
- follow-up run exposed three old worthiness tests still using the pre-intake compiler signature; those fixtures were updated to pass a confirmed Decision Brief
- PR workflow #426 is fully green
- `npm test`: 169/169 passing
- Worthiness, Decision Brief intake, recorded agent bypass eval, SaaS/radar validation/render, routed compile, grounded compile, Claude package staging, and artifact uploads all passed