### PR TITLE
fix: add path validation in render.js

### DIFF
--- a/skills/decision-first-dashboard/scripts/render.js
+++ b/skills/decision-first-dashboard/scripts/render.js
@@ -148,14 +148,26 @@ export function renderHtml(data) {
   return dimensions?.length ? tuneHtmlRadar(coreMarkup, dimensions) : coreMarkup;
 }
 
-if (process.argv[1] === currentFile) {
-  const inputPath = process.argv[2];
-  const outputDir = process.argv[3] ?? path.dirname(inputPath ?? '.');
+function resolveWithinCwd(candidatePath, label) {
+  const cwd = process.cwd();
+  const resolved = path.resolve(cwd, candidatePath);
+  if (resolved !== cwd && !resolved.startsWith(cwd + path.sep)) {
+    console.error(`Refusing to use ${label} outside the current working directory: ${candidatePath}`);
+    process.exit(2);
+  }
+  return resolved;
+}
 
-  if (!inputPath) {
+if (process.argv[1] === currentFile) {
+  const rawInputPath = process.argv[2];
+
+  if (!rawInputPath) {
     console.error('Usage: node render.js <decision-state.json> [output-dir]');
     process.exit(2);
   }
+
+  const inputPath = resolveWithinCwd(rawInputPath, 'input path');
+  const outputDir = resolveWithinCwd(process.argv[3] ?? path.dirname(rawInputPath), 'output directory');
 
   const data = JSON.parse(fs.readFileSync(inputPath, 'utf8'));
   const svg = renderSvg(data);


### PR DESCRIPTION
## Summary
Fix high severity security issue in `skills/decision-first-dashboard/scripts/render.js`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | HIGH |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `skills/decision-first-dashboard/scripts/render.js:151` |
| **Assessment** | Likely exploitable |
| **CWE** | CWE-22 |

**Description**: The render.js CLI script accepts user-controlled file paths via process.argv[2] (inputPath) and process.argv[3] (outputDir) without any validation or sanitization. An attacker can provide path traversal sequences (e.g., '../../../etc/passwd') to read arbitrary files from the system or write files to arbitrary locations outside the intended directories.

## Evidence

**Exploitation scenario**: An attacker with local system access or ability to influence command-line arguments can exploit this vulnerability by executing 'node render.js /etc/passwd' to read sensitive system files, or 'node.

**Scanner confirmation**: multi_agent_ai rule `V-001` flagged this pattern.

## Threat Model Context

This is a private Node.js application (not published to npm). Vulnerabilities affect this application's own runtime only.

## Changes
- `skills/decision-first-dashboard/scripts/render.js`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path.

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*

<!-- orbis-meta: rule=V-001 scanner=multi_agent_ai -->
