### PR TITLE
Add skill distribution and version integrity gate

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "decision-first-dashboard",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Turn KPI-heavy dashboards into grounded, decision-first views with dashboard-worthiness checks, metric routing, evidence validation, and deterministic rendering.",
   "author": {
     "name": "fourleaf13-hue",

--- a/.github/workflows/compiler-tests.yml
+++ b/.github/workflows/compiler-tests.yml
@@ -59,7 +59,13 @@ jobs:
         run: node skills/decision-first-dashboard/scripts/compile-dashboard.js tests/compiler/fixtures/worthiness/dashboard.worthiness.json tests/compiler/fixtures/intake/confirmed.decision-brief.json tests/compiler/fixtures/routing/no-score.routing.json tests/compiler/fixtures/grounding/no-score.grounded.json tests/compiler/generated/routed-no-score
       - name: Stage Claude Upload Skill package
         run: npm run package:claude-skill
-      - uses: actions/upload-artifact@v4
+      - name: Preflight staged Claude Upload Skill
+        run: node dist/claude-skill/scripts/preflight.js
+      - name: Compile routed no-score fixture from staged skill package
+        run: node dist/claude-skill/scripts/compile-dashboard.js tests/compiler/fixtures/worthiness/dashboard.worthiness.json tests/compiler/fixtures/intake/confirmed.decision-brief.json tests/compiler/fixtures/routing/no-score.routing.json tests/compiler/fixtures/grounding/no-score.grounded.json tests/compiler/generated/staged-routed-no-score
+      - name: Publish Claude Upload Skill artifact from main
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/upload-artifact@v4
         with:
           name: decision-first-dashboard-skill
           path: dist/claude-skill/
@@ -84,3 +90,6 @@ jobs:
             tests/compiler/generated/routed-no-score/output.no-score.svg
             tests/compiler/generated/routed-no-score/output.no-score.html
             tests/compiler/generated/routed-no-score/output.manifest.json
+            tests/compiler/generated/staged-routed-no-score/output.no-score.svg
+            tests/compiler/generated/staged-routed-no-score/output.no-score.html
+            tests/compiler/generated/staged-routed-no-score/output.manifest.json

--- a/package.json
+++ b/package.json
@@ -1,10 +1,12 @@
 {
   "name": "decision-first-dashboard",
+  "version": "1.1.0",
   "private": true,
   "type": "module",
   "scripts": {
     "test": "node --test tests/compiler/*.test.js",
     "package:claude-skill": "node scripts/stage-claude-skill.mjs",
+    "preflight:skill": "node skills/decision-first-dashboard/scripts/preflight.js",
     "validate:saas": "node skills/decision-first-dashboard/scripts/validate.js examples/saas/input.no-score.json",
     "render:saas": "node skills/decision-first-dashboard/scripts/render.js examples/saas/input.no-score.json examples/saas",
     "validate:radar-showcase": "node skills/decision-first-dashboard/scripts/validate.js examples/radar-profile/input.no-score.json",

--- a/scripts/stage-claude-skill.mjs
+++ b/scripts/stage-claude-skill.mjs
@@ -1,5 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
+import { execFileSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 
 const currentFile = fileURLToPath(import.meta.url);
@@ -7,7 +8,56 @@ const repoRoot = path.resolve(path.dirname(currentFile), '..');
 const skillRoot = path.join(repoRoot, 'skills', 'decision-first-dashboard');
 const defaultOutDir = path.join(repoRoot, 'dist', 'claude-skill');
 const outDir = path.resolve(process.argv[2] ?? defaultOutDir);
+const packageJsonPath = path.join(repoRoot, 'package.json');
+const pluginManifestPath = path.join(repoRoot, '.claude-plugin', 'plugin.json');
 const packageEntries = ['SKILL.md', 'scripts', 'schemas', 'templates', 'references'];
+const requiredRuntimeFiles = [
+  'SKILL.md',
+  'scripts/preflight.js',
+  'scripts/worthiness.js',
+  'scripts/intake.js',
+  'scripts/routing.js',
+  'scripts/grounding.js',
+  'scripts/compile-dashboard.js',
+  'scripts/render.js',
+  'schemas/worthiness-assessment.schema.json',
+  'schemas/decision-brief.schema.json',
+  'schemas/metric-routing.schema.json',
+  'schemas/grounded-bundle.schema.json',
+  'schemas/decision-state.schema.json'
+];
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function runGit(args) {
+  try {
+    return execFileSync('git', args, { cwd: repoRoot, encoding: 'utf8' }).trim();
+  } catch {
+    return '';
+  }
+}
+
+function resolveSourceCommit() {
+  return runGit(['rev-parse', 'HEAD']) || process.env.GITHUB_SHA?.trim() || '';
+}
+
+function resolveSourceBranch() {
+  const branch = process.env.GITHUB_HEAD_REF?.trim()
+    || process.env.GITHUB_REF_NAME?.trim()
+    || runGit(['rev-parse', '--abbrev-ref', 'HEAD']);
+  return branch === 'HEAD' ? 'detached' : (branch || 'unknown');
+}
+
+function assertSourcePackageComplete() {
+  for (const relativePath of requiredRuntimeFiles) {
+    const absolutePath = path.join(skillRoot, relativePath);
+    if (!fs.existsSync(absolutePath)) {
+      throw new Error(`Required production skill file is missing: ${relativePath}`);
+    }
+  }
+}
 
 function copyEntry(entry) {
   const source = path.join(skillRoot, entry);
@@ -16,6 +66,40 @@ function copyEntry(entry) {
     throw new Error(`Required skill package entry is missing: ${entry}`);
   }
   fs.cpSync(source, destination, { recursive: true });
+}
+
+function buildInfo() {
+  const packageJson = readJson(packageJsonPath);
+  const pluginManifest = readJson(pluginManifestPath);
+  if (!/^\d+\.\d+\.\d+$/.test(packageJson.version ?? '')) {
+    throw new Error('package.json must contain a semantic skill version');
+  }
+  if (pluginManifest.version !== packageJson.version) {
+    throw new Error('package.json version and .claude-plugin/plugin.json version must match');
+  }
+
+  const sourceCommit = resolveSourceCommit();
+  if (!/^[0-9a-f]{40}$/i.test(sourceCommit)) {
+    throw new Error('Unable to resolve the source Git commit for the skill package');
+  }
+
+  return {
+    schemaVersion: 1,
+    skillName: 'decision-first-dashboard',
+    skillVersion: packageJson.version,
+    sourceCommit,
+    sourceBranch: resolveSourceBranch(),
+    builtAt: new Date().toISOString(),
+    requiredEntrypoint: 'scripts/compile-dashboard.js',
+    requiredRuntimeFiles
+  };
+}
+
+function writeBuildInfo() {
+  fs.writeFileSync(
+    path.join(outDir, 'BUILD_INFO.json'),
+    `${JSON.stringify(buildInfo(), null, 2)}\n`
+  );
 }
 
 function assertClaudeUploadShape() {
@@ -32,11 +116,23 @@ function assertClaudeUploadShape() {
   if (fs.existsSync(path.join(outDir, '.claude-plugin'))) {
     throw new Error('Claude skill upload package must not contain .claude-plugin');
   }
+
+  if (!fs.existsSync(path.join(outDir, 'BUILD_INFO.json'))) {
+    throw new Error('Claude upload package must contain BUILD_INFO.json');
+  }
+
+  for (const relativePath of requiredRuntimeFiles) {
+    if (!fs.existsSync(path.join(outDir, relativePath))) {
+      throw new Error(`Claude upload package is missing required production file: ${relativePath}`);
+    }
+  }
 }
 
+assertSourcePackageComplete();
 fs.rmSync(outDir, { recursive: true, force: true });
 fs.mkdirSync(outDir, { recursive: true });
 for (const entry of packageEntries) copyEntry(entry);
+writeBuildInfo();
 assertClaudeUploadShape();
 
 console.log(`Claude skill staged at ${outDir}`);

--- a/skills/decision-first-dashboard/scripts/preflight.js
+++ b/skills/decision-first-dashboard/scripts/preflight.js
@@ -1,0 +1,119 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const currentFile = fileURLToPath(import.meta.url);
+const skillRoot = path.resolve(path.dirname(currentFile), '..');
+const repoRoot = path.resolve(skillRoot, '../..');
+const buildInfoPath = path.join(skillRoot, 'BUILD_INFO.json');
+const requiredRuntimeFiles = [
+  'SKILL.md',
+  'scripts/preflight.js',
+  'scripts/worthiness.js',
+  'scripts/intake.js',
+  'scripts/routing.js',
+  'scripts/grounding.js',
+  'scripts/compile-dashboard.js',
+  'scripts/render.js',
+  'schemas/worthiness-assessment.schema.json',
+  'schemas/decision-brief.schema.json',
+  'schemas/metric-routing.schema.json',
+  'schemas/grounded-bundle.schema.json',
+  'schemas/decision-state.schema.json'
+];
+
+function runGit(args) {
+  try {
+    return execFileSync('git', args, { cwd: repoRoot, encoding: 'utf8' }).trim();
+  } catch {
+    return '';
+  }
+}
+
+function sourceCheckoutBuildInfo() {
+  const expectedSkillRoot = path.resolve(repoRoot, 'skills', 'decision-first-dashboard');
+  const packageJsonPath = path.join(repoRoot, 'package.json');
+  if (expectedSkillRoot !== skillRoot || !fs.existsSync(packageJsonPath)) return null;
+
+  const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+  const sourceCommit = runGit(['rev-parse', 'HEAD']);
+  const sourceBranchRaw = runGit(['rev-parse', '--abbrev-ref', 'HEAD']);
+  return {
+    schemaVersion: 1,
+    skillName: 'decision-first-dashboard',
+    skillVersion: packageJson.version,
+    sourceCommit,
+    sourceBranch: sourceBranchRaw === 'HEAD' ? 'detached' : (sourceBranchRaw || 'unknown'),
+    builtAt: null,
+    requiredEntrypoint: 'scripts/compile-dashboard.js',
+    requiredRuntimeFiles,
+    mode: 'source_checkout'
+  };
+}
+
+function loadBuildInfo() {
+  if (fs.existsSync(buildInfoPath)) {
+    return {
+      ...JSON.parse(fs.readFileSync(buildInfoPath, 'utf8')),
+      mode: 'packaged_skill'
+    };
+  }
+  return sourceCheckoutBuildInfo();
+}
+
+function validateBuildInfo(info) {
+  const errors = [];
+  if (!info) {
+    errors.push('BUILD_INFO.json is missing and this is not a recognized source checkout');
+    return errors;
+  }
+  if (info.schemaVersion !== 1) errors.push('Unsupported or missing BUILD_INFO schemaVersion');
+  if (info.skillName !== 'decision-first-dashboard') errors.push('Unexpected skillName in BUILD_INFO');
+  if (!/^\d+\.\d+\.\d+$/.test(info.skillVersion ?? '')) errors.push('Invalid or missing semantic skillVersion');
+  if (!/^[0-9a-f]{40}$/i.test(info.sourceCommit ?? '')) errors.push('Invalid or missing sourceCommit');
+  if (typeof info.sourceBranch !== 'string' || info.sourceBranch.trim() === '') errors.push('Invalid or missing sourceBranch');
+  if (info.mode === 'packaged_skill' && Number.isNaN(Date.parse(info.builtAt ?? ''))) errors.push('Invalid or missing builtAt');
+  if (info.requiredEntrypoint !== 'scripts/compile-dashboard.js') errors.push('Unexpected requiredEntrypoint');
+
+  const declared = new Set(Array.isArray(info.requiredRuntimeFiles) ? info.requiredRuntimeFiles : []);
+  for (const relativePath of requiredRuntimeFiles) {
+    if (!declared.has(relativePath)) {
+      errors.push(`BUILD_INFO does not declare required runtime file: ${relativePath}`);
+    }
+  }
+  return errors;
+}
+
+function validateRuntimeFiles() {
+  const errors = [];
+  for (const relativePath of requiredRuntimeFiles) {
+    if (!fs.existsSync(path.join(skillRoot, relativePath))) {
+      errors.push(`Missing required runtime file: ${relativePath}`);
+    }
+  }
+  return errors;
+}
+
+const buildInfo = loadBuildInfo();
+const errors = [...validateRuntimeFiles(), ...validateBuildInfo(buildInfo)];
+
+if (errors.length > 0) {
+  process.stderr.write(`${JSON.stringify({
+    valid: false,
+    code: 'SKILL_PACKAGE_INCOMPLETE_OR_OUTDATED',
+    message: 'The installed decision-first-dashboard skill package is incomplete or outdated. Reinstall the latest main artifact before generating a dashboard.',
+    errors
+  })}\n`);
+  process.exit(1);
+}
+
+process.stdout.write(`${JSON.stringify({
+  valid: true,
+  code: 'SKILL_PACKAGE_READY',
+  mode: buildInfo.mode,
+  skillVersion: buildInfo.skillVersion,
+  sourceCommit: buildInfo.sourceCommit,
+  sourceBranch: buildInfo.sourceBranch,
+  requiredEntrypoint: buildInfo.requiredEntrypoint
+})}\n`);

--- a/tests/compiler/claude-skill-package.test.js
+++ b/tests/compiler/claude-skill-package.test.js
@@ -138,7 +138,7 @@ test('staged skill preflight passes and the staged package executes the canonica
   assert.equal(fs.existsSync(htmlPath), true, 'staged compiler must emit canonical HTML');
   assert.equal(fs.existsSync(svgPath), true, 'staged compiler must emit canonical SVG');
   assert.equal(fs.existsSync(manifestPath), true, 'staged compiler must emit output.manifest.json');
-  assert.match(fs.readFileSync(htmlPath, 'utf8'), /decision-first-renderer=canonical/);
+  assert.match(fs.readFileSync(htmlPath, 'utf8'), /name="decision-first-renderer" content="canonical"/);
 });
 
 test('CI publishes a Claude-ready artifact from main instead of the whole repository ZIP', () => {

--- a/tests/compiler/claude-skill-package.test.js
+++ b/tests/compiler/claude-skill-package.test.js
@@ -11,6 +11,21 @@ const repoRoot = path.resolve(testDir, '../..');
 const packScript = path.join(repoRoot, 'scripts', 'stage-claude-skill.mjs');
 const workflowPath = path.join(repoRoot, '.github', 'workflows', 'compiler-tests.yml');
 const readmePath = path.join(repoRoot, 'README.md');
+const packageJson = JSON.parse(fs.readFileSync(path.join(repoRoot, 'package.json'), 'utf8'));
+const requiredRuntimeFiles = [
+  'scripts/preflight.js',
+  'scripts/worthiness.js',
+  'scripts/intake.js',
+  'scripts/routing.js',
+  'scripts/grounding.js',
+  'scripts/compile-dashboard.js',
+  'scripts/render.js',
+  'schemas/worthiness-assessment.schema.json',
+  'schemas/decision-brief.schema.json',
+  'schemas/metric-routing.schema.json',
+  'schemas/grounded-bundle.schema.json',
+  'schemas/decision-state.schema.json'
+];
 
 function listRelativeFiles(root) {
   const files = [];
@@ -25,17 +40,21 @@ function listRelativeFiles(root) {
   return files.sort();
 }
 
-test('Claude upload package stages the skill with SKILL.md at ZIP root and no plugin manifest', () => {
-  assert.equal(fs.existsSync(packScript), true, 'expected scripts/stage-claude-skill.mjs to exist');
-
+function stageSkill() {
   const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'decision-first-claude-skill-'));
   const outDir = path.join(tempRoot, 'skill');
   const run = spawnSync(process.execPath, [packScript, outDir], {
     cwd: repoRoot,
     encoding: 'utf8'
   });
-
   assert.equal(run.status, 0, run.stderr || run.stdout);
+  return { tempRoot, outDir };
+}
+
+test('Claude upload package stages the complete production skill with build provenance', () => {
+  assert.equal(fs.existsSync(packScript), true, 'expected scripts/stage-claude-skill.mjs to exist');
+
+  const { outDir } = stageSkill();
   assert.equal(fs.existsSync(path.join(outDir, 'SKILL.md')), true, 'SKILL.md must be at package root');
   assert.equal(fs.existsSync(path.join(outDir, '.claude-plugin', 'plugin.json')), false);
 
@@ -48,13 +67,86 @@ test('Claude upload package stages the skill with SKILL.md at ZIP root and no pl
   assert.ok(files.some((file) => file.startsWith('templates/')), 'templates must be packaged');
   assert.ok(files.some((file) => file.startsWith('references/')), 'references must be packaged');
   assert.equal(files.some((file) => file.includes('.claude-plugin/')), false, 'plugin manifest must never enter skill upload package');
+
+  for (const relativePath of requiredRuntimeFiles) {
+    assert.equal(fs.existsSync(path.join(outDir, relativePath)), true, `${relativePath} must be packaged`);
+  }
+
+  const buildInfoPath = path.join(outDir, 'BUILD_INFO.json');
+  assert.equal(fs.existsSync(buildInfoPath), true, 'BUILD_INFO.json must be packaged');
+  const buildInfo = JSON.parse(fs.readFileSync(buildInfoPath, 'utf8'));
+  assert.equal(buildInfo.schemaVersion, 1);
+  assert.equal(buildInfo.skillName, 'decision-first-dashboard');
+  assert.equal(buildInfo.skillVersion, packageJson.version);
+  assert.match(buildInfo.sourceCommit, /^[0-9a-f]{40}$/i);
+  assert.equal(typeof buildInfo.sourceBranch, 'string');
+  assert.ok(buildInfo.sourceBranch.length > 0);
+  assert.equal(Number.isNaN(Date.parse(buildInfo.builtAt)), false);
+  assert.equal(buildInfo.requiredEntrypoint, 'scripts/compile-dashboard.js');
+  for (const relativePath of requiredRuntimeFiles) {
+    assert.ok(buildInfo.requiredRuntimeFiles.includes(relativePath));
+  }
 });
 
-test('CI publishes a Claude-ready artifact instead of the whole repository ZIP', () => {
+test('staged skill preflight rejects an incomplete or stale package', () => {
+  const { outDir } = stageSkill();
+  fs.rmSync(path.join(outDir, 'scripts', 'compile-dashboard.js'));
+
+  const run = spawnSync(process.execPath, [path.join(outDir, 'scripts', 'preflight.js')], {
+    cwd: outDir,
+    encoding: 'utf8'
+  });
+
+  assert.notEqual(run.status, 0, 'preflight must fail when the production compiler is missing');
+  const result = JSON.parse(run.stderr.trim());
+  assert.equal(result.valid, false);
+  assert.equal(result.code, 'SKILL_PACKAGE_INCOMPLETE_OR_OUTDATED');
+  assert.match(result.message, /incomplete or outdated/i);
+  assert.ok(result.errors.some((error) => error.includes('scripts/compile-dashboard.js')));
+});
+
+test('staged skill preflight passes and the staged package executes the canonical compiler', () => {
+  const { tempRoot, outDir } = stageSkill();
+  const preflight = spawnSync(process.execPath, [path.join(outDir, 'scripts', 'preflight.js')], {
+    cwd: outDir,
+    encoding: 'utf8'
+  });
+  assert.equal(preflight.status, 0, preflight.stderr || preflight.stdout);
+  const preflightResult = JSON.parse(preflight.stdout.trim());
+  assert.equal(preflightResult.valid, true);
+  assert.equal(preflightResult.code, 'SKILL_PACKAGE_READY');
+  assert.equal(preflightResult.mode, 'packaged_skill');
+
+  const outputDir = path.join(tempRoot, 'compiled');
+  const fixture = (relativePath) => path.join(repoRoot, 'tests', 'compiler', 'fixtures', relativePath);
+  const compile = spawnSync(process.execPath, [
+    path.join(outDir, 'scripts', 'compile-dashboard.js'),
+    fixture('worthiness/dashboard.worthiness.json'),
+    fixture('intake/confirmed.decision-brief.json'),
+    fixture('routing/no-score.routing.json'),
+    fixture('grounding/no-score.grounded.json'),
+    outputDir
+  ], {
+    cwd: outDir,
+    encoding: 'utf8'
+  });
+
+  assert.equal(compile.status, 0, compile.stderr || compile.stdout);
+  const htmlPath = path.join(outputDir, 'output.no-score.html');
+  const svgPath = path.join(outputDir, 'output.no-score.svg');
+  const manifestPath = path.join(outputDir, 'output.manifest.json');
+  assert.equal(fs.existsSync(htmlPath), true, 'staged compiler must emit canonical HTML');
+  assert.equal(fs.existsSync(svgPath), true, 'staged compiler must emit canonical SVG');
+  assert.equal(fs.existsSync(manifestPath), true, 'staged compiler must emit output.manifest.json');
+  assert.match(fs.readFileSync(htmlPath, 'utf8'), /decision-first-renderer=canonical/);
+});
+
+test('CI publishes a Claude-ready artifact from main instead of the whole repository ZIP', () => {
   const workflow = fs.readFileSync(workflowPath, 'utf8');
   assert.match(workflow, /npm run package:claude-skill/);
   assert.match(workflow, /name:\s*decision-first-dashboard-skill/);
   assert.match(workflow, /path:\s*dist\/claude-skill\//);
+  assert.match(workflow, /github\.ref == 'refs\/heads\/main'/);
 });
 
 test('README tells Claude users to use the dedicated skill artifact, not GitHub Download ZIP', () => {

--- a/tests/compiler/plugin-manifest.test.js
+++ b/tests/compiler/plugin-manifest.test.js
@@ -4,15 +4,19 @@ import test from 'node:test';
 
 const manifestPath = '.claude-plugin/plugin.json';
 const skillPath = 'skills/decision-first-dashboard/SKILL.md';
+const packageJsonPath = 'package.json';
 
 test('Anthropic plugin manifest exposes the dashboard skill with stable metadata', () => {
   assert.equal(existsSync(manifestPath), true, `${manifestPath} must exist`);
   assert.equal(existsSync(skillPath), true, `${skillPath} must remain at plugin root`);
+  assert.equal(existsSync(packageJsonPath), true, `${packageJsonPath} must exist`);
 
   const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+  const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
 
   assert.equal(manifest.name, 'decision-first-dashboard');
   assert.match(manifest.version, /^\d+\.\d+\.\d+$/);
+  assert.equal(manifest.version, packageJson.version, 'plugin and packaged skill versions must stay in sync');
   assert.match(manifest.description, /dashboard/i);
   assert.equal(manifest.author?.name, 'fourleaf13-hue');
   assert.equal(manifest.author?.url, 'https://github.com/fourleaf13-hue');


### PR DESCRIPTION
## What changed

- version the standalone skill package and keep it synchronized with the Claude plugin manifest
- stamp staged Claude skill packages with `BUILD_INFO.json` containing source commit, branch, build time, version, canonical entrypoint, and required runtime files
- add `scripts/preflight.js` so incomplete/outdated packages fail with `SKILL_PACKAGE_INCOMPLETE_OR_OUTDATED`
- make packaging fail if production compiler/gate files are missing
- test the actual staged package, including a missing-compiler regression and a canonical `compile-dashboard.js` happy path
- smoke-test the staged package in GitHub Actions
- publish the user-facing `decision-first-dashboard-skill` artifact only from `main`, so PR/feature runs cannot masquerade as the installable release artifact

This separates package/version failures from agent-compliance failures and directly guards the failure mode where an installed skill did not contain `compile-dashboard.js`.